### PR TITLE
Environment Variable Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ charts:
     set:                                 # values (--set)
       - name: address
         value: https://vault.example.com
+    env:                                 # values (--set) but value will be pulled from environment variables. Will throw an error if the environment variable is not set.
+      - name: db.password
+        value: DB_PASSWORD               # $DB_PASSOWRD needs to be set in the calling environment ex: export DB_PASSWORD='password1'
 
 ```
 
@@ -41,24 +44,24 @@ charts:
 
 ```
 NAME:
-   helmfile
+   helmfile -
 
 USAGE:
-   helmfile [global options] command [command options] [arguments...]
+   main [global options] command [command options] [arguments...]
 
 VERSION:
-   0.0.0
+   0.1.0
 
 COMMANDS:
-     repos    sync repositories from state file (helm repo add && help repo update)
-     charts   sync charts from state file (helm repo upgrade --install)
-     sync     sync all resources from state file (repos && charts)
-     delete   delete charts from state file (helm delete)
-     help, h  Shows a list of commands or help for one command
+     repos   sync repositories from state file (helm repo add && helm repo update)
+     charts  sync charts from state file (helm repo upgrade --install)
+     sync    sync all resources from state file (repos && charts)
+     delete  delete charts from state file (helm delete)
 
 GLOBAL OPTIONS:
    --file FILE, -f FILE  load config from FILE (default: "charts.yaml")
    --quiet, -q           silence output
+   --kube-context value  Set kubectl context. Uses current context by default
    --help, -h            show help
    --version, -v         print the version
 ```

--- a/helmexec/exec.go
+++ b/helmexec/exec.go
@@ -15,11 +15,15 @@ const (
 
 type execer struct {
 	writer io.Writer
+	kubeContext string
 	extra  []string
 }
 
-func NewHelmExec(writer io.Writer) Interface {
-	return &execer{writer: writer}
+func NewHelmExec(writer io.Writer, kubeContext string) Interface {
+	return &execer{
+		writer: writer,
+		kubeContext: kubeContext,
+	}
 }
 
 func (helm *execer) SetExtraArgs(args ...string) {
@@ -69,6 +73,9 @@ func (helm *execer) exec(args ...string) ([]byte, error) {
 	if len(helm.extra) > 0 {
 		cmdargs = append(cmdargs, helm.extra...)
 	}
+	if helm.kubeContext != "" {
+		cmdargs = append(cmdargs, "--kube-context", helm.kubeContext)
+	}	
 	if helm.writer != nil {
 		helm.writer.Write([]byte(fmt.Sprintf("exec: helm %s\n", strings.Join(cmdargs, " "))))
 	}

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "helmfile"
 	app.Usage = ""
+	app.Version = "0.1.0"
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:  "file, f",
@@ -33,7 +34,7 @@ func main() {
 		},
 		cli.StringFlag{
 			Name: "kube-context",
-			Usage: "Set kubectl context",
+			Usage: "Set kubectl context. Uses current context by default",
 		},
 	}
 

--- a/state/state.go
+++ b/state/state.go
@@ -169,7 +169,7 @@ func flagsForChart(chart *ChartSpec) ([]string, error) {
 			if isSet {
 				val = append(val, fmt.Sprintf("%s=%s", set.Name, value))
 			} else {
-				return nil, errors.New(fmt.Sprintf("Unset env var: %s", set.Name))
+				return nil, errors.New(fmt.Sprintf("Could not find environment var: %s. Please make sure it is set and try again.", set.Name))
 			}
 		}
 		flags = append(flags, "--set", strings.Join(val, ","))

--- a/state/state.go
+++ b/state/state.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"errors"
 
 	"github.com/roboll/helmfile/helmexec"
 
@@ -164,7 +165,12 @@ func flagsForChart(chart *ChartSpec) ([]string, error) {
 	if len(chart.EnvValues) > 0 {
 		val := []string{}
 		for _, set := range chart.EnvValues {
-			val = append(val, fmt.Sprintf("%s=%s", set.Name, os.Getenv(set.Value)))
+			value, isSet := os.LookupEnv(set.Value)
+			if isSet {
+				val = append(val, fmt.Sprintf("%s=%s", set.Name, value))
+			} else {
+				return nil, errors.New(fmt.Sprintf("Unset env var: %s", set.Name))
+			}
 		}
 		flags = append(flags, "--set", strings.Join(val, ","))
 	}


### PR DESCRIPTION
Add support for the following flags:

- `--kube-context`: set what kube-context should be passed down to helm
- `charts --values`: add additional value files to the existing list of value files (for use when using overrides for different environments during CI)
- in the Charts.yml file added a new property `env` for environment vars. It's exactly the same as the `set` property but all the value fields are run through `os.Getenv` to resolve their values. Needed this for using secrets in our CI system.

Note: this is my first time working with Go so any and all feedback welcome!