### PR TITLE
Accept chart in a local path

### DIFF
--- a/helmexec/exec.go
+++ b/helmexec/exec.go
@@ -6,6 +6,8 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"regexp"
 	"strings"
 )
 
@@ -42,7 +44,27 @@ func (helm *execer) UpdateRepo() error {
 	return err
 }
 
+func normalizeChart(chart string) (string, error) {
+	regex, err := regexp.Compile("^[.]?[.]?/")
+	if err != nil {
+		return "", err
+	}
+	if !regex.MatchString(chart) {
+		return chart, nil
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(wd, chart)
+	return path, nil
+}
+
 func (helm *execer) SyncChart(name, chart string, flags ...string) error {
+	chart, err := normalizeChart(chart)
+	if err != nil {
+		return err
+	}
 	out, err := helm.exec(append([]string{"upgrade", "--install", name, chart}, flags...)...)
 	if helm.writer != nil {
 		helm.writer.Write(out)

--- a/helmexec/exec.go
+++ b/helmexec/exec.go
@@ -45,7 +45,7 @@ func (helm *execer) UpdateRepo() error {
 }
 
 func normalizeChart(chart string) (string, error) {
-	regex, err := regexp.Compile("^[.]?[.]?/")
+	regex, err := regexp.Compile("^[.]?./")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
If the chart is in directory, for example, `./my/chart` the `helmfile -f my.yaml sync` will fail.

This PR will check if the chart starts with `./` or `../` and will transform it in a full path of the chart directory.