### PR TITLE
Return exit code from helm

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,9 +62,9 @@ func main() {
 					helm.SetExtraArgs(strings.Split(args, " ")...)
 				}
 
-				if errs := state.SyncRepos(helm); err != nil && len(errs) > 0 {
+				if errs := state.SyncRepos(helm); errs != nil && len(errs) > 0 {
 					for _, err := range errs {
-						fmt.Printf("err: %s", err.Error())
+						fmt.Printf("err: %s\n", err.Error())
 					}
 					os.Exit(1)
 				}
@@ -98,9 +98,9 @@ func main() {
 
 				values := c.StringSlice("values")
 
-				if errs := state.SyncCharts(helm, values); err != nil && len(errs) > 0 {
+				if errs := state.SyncCharts(helm, values); errs != nil && len(errs) > 0 {
 					for _, err := range errs {
-						fmt.Printf("err: %s", err.Error())
+						fmt.Printf("err: %s\n", err.Error())
 					}
 					os.Exit(1)
 				}
@@ -122,18 +122,18 @@ func main() {
 					return err
 				}
 
-				if errs := state.SyncRepos(helm); err != nil && len(errs) > 0 {
+				if errs := state.SyncRepos(helm); errs != nil && len(errs) > 0 {
 					for _, err := range errs {
-						fmt.Printf("err: %s", err.Error())
+						fmt.Printf("err: %s\n", err.Error())
 					}
 					os.Exit(1)
 				}
 
 				values := c.StringSlice("values")
 
-				if errs := state.SyncCharts(helm, values); err != nil && len(errs) > 0 {
+				if errs := state.SyncCharts(helm, values); errs != nil && len(errs) > 0 {
 					for _, err := range errs {
-						fmt.Printf("err: %s", err.Error())
+						fmt.Printf("err: %s\n", err.Error())
 					}
 					os.Exit(1)
 				}
@@ -149,9 +149,9 @@ func main() {
 					return err
 				}
 
-				if errs := state.DeleteCharts(helm); err != nil && len(errs) > 0 {
+				if errs := state.DeleteCharts(helm); errs != nil && len(errs) > 0 {
 					for _, err := range errs {
-						fmt.Printf("err: %s", err.Error())
+						fmt.Printf("err: %s\n", err.Error())
 					}
 					os.Exit(1)
 				}


### PR DESCRIPTION
`helmfile` returns exit code `0` even when an executed `helm` command fails.

#### Before patch:
```
$ helmfile --kube-context BAD_CONTEXT --file test.yaml sync
exec: helm repo update --kube-context BAD_CONTEXT
Hang tight while we grab the latest from your chart repositories...
...Skip local chart repository
Writing to ~/.helm/repository/cache/stable-index.yaml
...Successfully got an update from the "stable" chart repository
Update Complete. ⎈ Happy Helming!⎈ 
exec: helm upgrade --install test stable/traefik --namespace kube-system --values values.yaml --kube-context BAD_CONTEXT
Error: could not get kubernetes config for context 'BAD_CONTEXT': context "BAD_CONTEXT" does not exist
$ echo $?
0
```

#### After patch:
```
$ helmfile --kube-context BAD_CONTEXT --file test.yaml sync
exec: helm repo update --kube-context BAD_CONTEXT
Hang tight while we grab the latest from your chart repositories...
...Skip local chart repository
Writing to ~/.helm/repository/cache/stable-index.yaml
...Successfully got an update from the "stable" chart repository
Update Complete. ⎈ Happy Helming!⎈ 
exec: helm upgrade --install test stable/traefik --namespace kube-system --values values.yaml --kube-context BAD_CONTEXT
Error: could not get kubernetes config for context 'BAD_CONTEXT': context "BAD_CONTEXT" does not exist
err: exit status 1
$ echo $?
1
```