### PR TITLE
Add filter mechanism to charts command

### DIFF
--- a/main.go
+++ b/main.go
@@ -84,6 +84,10 @@ func main() {
 					Name:  "values",
 					Usage: "additional value files to be merged into the command",
 				},
+				cli.StringSliceFlag{
+					Name:  "filter",
+					Usage: "only update charts matching the given filter",
+				},
 			},
 			Action: func(c *cli.Context) error {
 				state, helm, err := before(c)
@@ -97,8 +101,9 @@ func main() {
 				}
 
 				values := c.StringSlice("values")
+				filters := c.StringSlice("filter")
 
-				if errs := state.SyncCharts(helm, values); errs != nil && len(errs) > 0 {
+				if errs := state.SyncCharts(helm, values, filters); errs != nil && len(errs) > 0 {
 					for _, err := range errs {
 						fmt.Printf("err: %s\n", err.Error())
 					}
@@ -115,6 +120,10 @@ func main() {
 					Name:  "values",
 					Usage: "additional value files to be merged into the command",
 				},
+				cli.StringSliceFlag{
+					Name:  "filter",
+					Usage: "only update charts matching the given filter",
+				},
 			},
 			Action: func(c *cli.Context) error {
 				state, helm, err := before(c)
@@ -130,8 +139,9 @@ func main() {
 				}
 
 				values := c.StringSlice("values")
+				filters := c.StringSlice("filter")
 
-				if errs := state.SyncCharts(helm, values); errs != nil && len(errs) > 0 {
+				if errs := state.SyncCharts(helm, values, filters); errs != nil && len(errs) > 0 {
 					for _, err := range errs {
 						fmt.Printf("err: %s\n", err.Error())
 					}


### PR DESCRIPTION
As  mentioned in #8 this PR implements the `--filter` parameter for the `charts` command. Purpose is to restrict the concerning charts to be worked on by an glob based expression matching.