### PR TITLE
Adding in diff plugin execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,10 @@ NAME:
 USAGE:
    main [global options] command [command options] [arguments...]
 
-VERSION:
-   0.1.0
-
 COMMANDS:
      repos   sync repositories from state file (helm repo add && helm repo update)
      charts  sync charts from state file (helm repo upgrade --install)
+     diff    diff charts from state file against env (helm diff)
      sync    sync all resources from state file (repos && charts)
      delete  delete charts from state file (helm delete)
 
@@ -65,3 +63,12 @@ GLOBAL OPTIONS:
    --help, -h            show help
    --version, -v         print the version
 ```
+
+### diff
+
+The `helmfile diff` sub-command executes the [helm-diff](https://github.com/databus23/helm-diff) plugin across all of
+the charts/releases defined in the manifest.
+
+Under the covers Helmfile is simply using the `helm diff` plugin, so that needs to be installed prior.  For Helm 2.3+
+you should be able to simply execute `helm plugin install https://github.com/databus23/helm-diff`. For more details
+please look at their [documentation](https://github.com/databus23/helm-diff#helm-diff-plugin).

--- a/helmexec/exec.go
+++ b/helmexec/exec.go
@@ -76,6 +76,18 @@ func (helm *execer) SyncChart(name, chart string, flags ...string) error {
 	return err
 }
 
+func (helm *execer) DiffChart(name, chart string, flags ...string) error {
+	chart, err := normalizeChart(chart)
+	if err != nil {
+		return err
+	}
+	out, err := helm.exec(append([]string{"diff", name, chart}, flags...)...)
+	if helm.writer != nil {
+		helm.writer.Write(out)
+	}
+	return err
+}
+
 func (helm *execer) DeleteChart(name string) error {
 	out, err := helm.exec("delete", name)
 	if helm.writer != nil {

--- a/helmexec/helmexec.go
+++ b/helmexec/helmexec.go
@@ -7,5 +7,6 @@ type Interface interface {
 	UpdateRepo() error
 
 	SyncChart(name, chart string, flags ...string) error
+	DiffChart(name, chart string, flags ...string) error
 	DeleteChart(name string) error
 }

--- a/main.go
+++ b/main.go
@@ -108,6 +108,45 @@ func main() {
 			},
 		},
 		{
+			Name:  "diff",
+			Usage: "diff charts from state file against env (helm diff)",
+			Flags: []cli.Flag{
+				cli.StringSliceFlag{
+					Name:  "values",
+					Usage: "additional value files to be merged into the command",
+				},
+				cli.BoolFlag{
+					Name:  "sync-repos",
+					Usage: "enable a repo sync prior to diffing",
+				},
+			},
+			Action: func(c *cli.Context) error {
+				state, helm, err := before(c)
+				if err != nil {
+					return err
+				}
+
+				if c.Bool("sync-repos") {
+					if errs := state.SyncRepos(helm); errs != nil && len(errs) > 0 {
+						for _, err := range errs {
+							fmt.Printf("err: %s\n", err.Error())
+						}
+						os.Exit(1)
+					}
+				}
+
+				values := c.StringSlice("values")
+
+				if errs := state.DiffCharts(helm, values); errs != nil && len(errs) > 0 {
+					for _, err := range errs {
+						fmt.Printf("err: %s\n", err.Error())
+					}
+					os.Exit(1)
+				}
+				return nil
+			},
+		},
+		{
 			Name:  "sync",
 			Usage: "sync all resources from state file (repos && charts)",
 			Flags: []cli.Flag{

--- a/main.go
+++ b/main.go
@@ -111,6 +111,11 @@ func main() {
 			Name:  "diff",
 			Usage: "diff charts from state file against env (helm diff)",
 			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "args",
+					Value: "",
+					Usage: "pass args to helm exec",
+				},
 				cli.StringSliceFlag{
 					Name:  "values",
 					Usage: "additional value files to be merged into the command",
@@ -124,6 +129,11 @@ func main() {
 				state, helm, err := before(c)
 				if err != nil {
 					return err
+				}
+
+				args := c.String("args")
+				if len(args) > 0 {
+					helm.SetExtraArgs(strings.Split(args, " ")...)
 				}
 
 				if c.Bool("sync-repos") {


### PR DESCRIPTION
This allows the execution of the `helm diff` plugin for the entire state file, which for us makes it very easy to visualize the configuration drift of a given environment for auditing and greater confidence in the deployment similar to a `terraform plan` on an environment. 

NOTE: 
- Simple copy-paste for the most part from sync job.  I had started down
the path of adding in a meta PluginCommand directive and trying to make it
more modular, but in the end there are some small differences between
the execution that were a bit difficult to model and it just got ugly.
Figured keeping it simple would be easier to manage. 

If a more extensible form of this is desired I can work on modeling that a bit to make it easier to add in arbitrary sets of functionality but I wanted to get the conversation started