### PR TITLE
Relative path resolution changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist/
+.idea/

--- a/PATHS.md
+++ b/PATHS.md
@@ -1,0 +1,58 @@
+# Paths Overivew 
+Using manifest files in conjunction with command line argument can be a bit confusing.  
+
+A few rules to clear up this ambiguity: 
+
+- Absolute paths are always resolved as absolute paths
+- Relative paths referenced *in* the helmfile manifest itself are relative to that manifest
+- Relative paths referenced on the command line are relative to the current working directory the user is in
+
+### Examples
+There are several examples that we can go through in the `/examples` folder which demonstrate this.
+
+**Local Execution**
+
+This is an example of a Helmfile manifest referencing a local value directly. 
+
+Indirect:
+```
+helmfile -f examples/deployments/local/charts.yaml sync
+```
+
+Direct: 
+```
+cd examples/deployments/local/
+helmfile sync
+```
+
+**Relative Paths in Helmfile**
+
+This is an example of a Helmfile manifest using relative paths for values. 
+
+Indirect:
+```
+helmfile -f examples/deployments/dev/charts.yaml sync
+```
+
+Direct: 
+```
+cd examples/deployments/dev/
+helmfile sync
+```
+
+**Relative Paths in Helmfile w/ --values overrides**
+
+This is an example of a Helmfile manifest using relative paths for values including an additional `--values` from the command line.  
+
+NOTE: The `--values` is resolved relative to the CWD of the terminal *not* the Helmfile manifest.  You can see this with the `replicas` being adjusted to 3 now for the deployment.
+
+Indirect:
+```
+helmfile -f examples/deployments/dev/charts.yaml sync --values values/replica-values.yaml
+```
+
+Direct: 
+```
+cd examples/deployments/dev/
+helmfile sync --values ../../values/replica-values.yaml
+```

--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ repositories:
     url: http://roboll.io/charts
 
 charts:
+  # Published chart example
   - name: vault                          # helm deployment name
     namespace: vault                     # target namespace
-    chart: roboll/vault-secret-manager   # chart reference
+    chart: roboll/vault-secret-manager   # chart reference (repository)
     values: [ vault.yaml ]               # value files (--values)
     set:                                 # values (--set)
       - name: address
@@ -32,6 +33,13 @@ charts:
     env:                                 # values (--set) but value will be pulled from environment variables. Will throw an error if the environment variable is not set.
       - name: db.password
         value: DB_PASSWORD               # $DB_PASSOWRD needs to be set in the calling environment ex: export DB_PASSWORD='password1'
+
+  # Local chart example
+  - name: grafana                         # helm deployment name
+    namespace: another                    # target namespace
+    chart: ../my-charts/grafana           # chart reference (relative path to manifest)
+    values:
+    - ../../my-values/grafana/values.yaml # Values file (relative path to manifest)
 
 ```
 
@@ -72,3 +80,15 @@ the charts/releases defined in the manifest.
 Under the covers Helmfile is simply using the `helm diff` plugin, so that needs to be installed prior.  For Helm 2.3+
 you should be able to simply execute `helm plugin install https://github.com/databus23/helm-diff`. For more details
 please look at their [documentation](https://github.com/databus23/helm-diff#helm-diff-plugin).
+
+
+## Paths Overview
+Using manifest files in conjunction with command line argument can be a bit confusing.  
+
+A few rules to clear up this ambiguity: 
+
+- Absolute paths are always resolved as absolute paths
+- Relative paths referenced *in* the helmfile manifest itself are relative to that manifest
+- Relative paths referenced on the command line are relative to the current working directory the user is in
+
+For additional context, take a look at [paths examples](PATHS.md)

--- a/examples/charts/paths-example/.helmignore
+++ b/examples/charts/paths-example/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/examples/charts/paths-example/Chart.yaml
+++ b/examples/charts/paths-example/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: demonstration of local file path references in Helmfile
+name: paths-example
+version: 0.1.0

--- a/examples/charts/paths-example/templates/_helpers.tpl
+++ b/examples/charts/paths-example/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/examples/charts/paths-example/templates/deployment.yaml
+++ b/examples/charts/paths-example/templates/deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.internalPort }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.service.internalPort }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.service.internalPort }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}

--- a/examples/charts/paths-example/templates/service.yaml
+++ b/examples/charts/paths-example/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.externalPort }}
+      targetPort: {{ .Values.service.internalPort }}
+      protocol: TCP
+      name: {{ .Values.service.name }}
+  selector:
+    app: {{ template "name" . }}
+    release: {{ .Release.Name }}

--- a/examples/charts/paths-example/values.yaml
+++ b/examples/charts/paths-example/values.yaml
@@ -1,0 +1,13 @@
+# Default values for paths-example.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 1
+image:
+  repository: nginx
+  tag: stable
+  pullPolicy: IfNotPresent
+service:
+  name: nginx
+  type: ClusterIP
+  externalPort: 80
+  internalPort: 80

--- a/examples/deployments/dev/charts.yaml
+++ b/examples/deployments/dev/charts.yaml
@@ -1,0 +1,6 @@
+charts:
+  - name: dev-paths-example
+    namespace: dev
+    chart: ../../charts/paths-example/
+    values:
+    - ../../values/dev/paths-example/values.yaml # Values file (relative path to manifest)

--- a/examples/deployments/local/charts.yaml
+++ b/examples/deployments/local/charts.yaml
@@ -1,0 +1,6 @@
+charts:
+  - name: local-paths-example
+    namespace: local
+    chart: ../../charts/paths-example/
+    values:
+    - values.yaml # Values file (relative path to manifest)

--- a/examples/deployments/local/values.yaml
+++ b/examples/deployments/local/values.yaml
@@ -1,0 +1,2 @@
+# Dev specific overrides
+nameOverride: local-nginx

--- a/examples/deployments/prod/charts.yaml
+++ b/examples/deployments/prod/charts.yaml
@@ -1,0 +1,6 @@
+charts:
+  - name: prod-paths-example
+    namespace: prod
+    chart: ../../charts/paths-example/
+    values:
+    - ../../values/prod/paths-example/values.yaml # Values file (relative path to manifest)

--- a/examples/deployments/published/charts.yaml
+++ b/examples/deployments/published/charts.yaml
@@ -1,0 +1,5 @@
+charts:
+  # Published chart example
+  - name: grafana                         # helm deployment name
+    namespace: grafana                    # target namespace
+    chart: stable/grafana                 # chart reference (repository)

--- a/examples/values/dev/paths-example/values.yaml
+++ b/examples/values/dev/paths-example/values.yaml
@@ -1,0 +1,2 @@
+# Dev specific overrides
+nameOverride: dev-nginx

--- a/examples/values/prod/paths-example/values.yaml
+++ b/examples/values/prod/paths-example/values.yaml
@@ -1,0 +1,2 @@
+# Prod specific overrides
+nameOverride: prod-nginx

--- a/examples/values/replica-values.yaml
+++ b/examples/values/replica-values.yaml
@@ -1,0 +1,2 @@
+# Example used to override value explicitly via CLI
+replicaCount: 3

--- a/helmexec/exec.go
+++ b/helmexec/exec.go
@@ -6,8 +6,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"path/filepath"
-	"regexp"
 	"strings"
 )
 
@@ -48,27 +46,7 @@ func (helm *execer) UpdateRepo() error {
 	return err
 }
 
-func normalizeChart(chart string) (string, error) {
-	regex, err := regexp.Compile("^[.]?./")
-	if err != nil {
-		return "", err
-	}
-	if !regex.MatchString(chart) {
-		return chart, nil
-	}
-	wd, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-	path := filepath.Join(wd, chart)
-	return path, nil
-}
-
 func (helm *execer) SyncChart(name, chart string, flags ...string) error {
-	chart, err := normalizeChart(chart)
-	if err != nil {
-		return err
-	}
 	out, err := helm.exec(append([]string{"upgrade", "--install", name, chart}, flags...)...)
 	if helm.writer != nil {
 		helm.writer.Write(out)
@@ -77,10 +55,6 @@ func (helm *execer) SyncChart(name, chart string, flags ...string) error {
 }
 
 func (helm *execer) DiffChart(name, chart string, flags ...string) error {
-	chart, err := normalizeChart(chart)
-	if err != nil {
-		return err
-	}
 	out, err := helm.exec(append([]string{"diff", name, chart}, flags...)...)
 	if helm.writer != nil {
 		helm.writer.Write(out)

--- a/state/state.go
+++ b/state/state.go
@@ -51,7 +51,8 @@ func ReadFromFile(file string) (*HelmState, error) {
 	}
 
 	var state HelmState
-	state.BaseChartPath = path.Dir(file)
+
+	state.BaseChartPath, _ = filepath.Abs(path.Dir(file))
 	if err := yaml.Unmarshal(content, &state); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #13 (however is dependent on #12 being merged)

This aims to improve on relative, absolute and <repo>/<chart>
resolution for several of Helmfile manifest attributes as well as
command line arguments.

- Users may now utilize the `-f <filepath>` flag to reference
a helmfile manifest outside of their PWD and have relative paths
in the the `charts[*].values` and `charts[*].chart` attribute resolve
relative to the manfiest's location properly

- Values provided in the `--values` argument are no longer automatically
assumed as relative path references from PWD but instead are
conditionally joined with the PWD if it is determined they are relative
file paths

- Users may still signify a chart in the `.charts[*].chart` attribute
as they do now by having an explicit `<repo>/<chart>` value