### PR TITLE
Allow env var interpolation in `set` and `values`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ charts:
       - name: address
         value: https://vault.example.com
       - name: db.password
-        value: {{ env "DB_PASSWORD" }}                   # value taken from environment variable. Will throw an error if the environment variable is not set. $DB_PASSOWRD needs to be set in the calling environment ex: export DB_PASSWORD='password1'
+        value: {{ env "DB_PASSWORD" }}                   # value taken from environment variable. Will throw an error if the environment variable is not set. $DB_PASSWORD needs to be set in the calling environment ex: export DB_PASSWORD='password1'
       - name: proxy.domain
         value: "{{ env \"PLATFORM_ID\" }}.my-domain.com" # Interpolate environment variable with a fixed string
 

--- a/README.md
+++ b/README.md
@@ -23,23 +23,25 @@ repositories:
 
 charts:
   # Published chart example
-  - name: vault                          # helm deployment name
-    namespace: vault                     # target namespace
-    chart: roboll/vault-secret-manager   # chart reference (repository)
-    values: [ vault.yaml ]               # value files (--values)
-    set:                                 # values (--set)
+  - name: vault                               # helm deployment name
+    namespace: vault                          # target namespace
+    chart: roboll/vault-secret-manager        # chart reference (repository)
+    values: [ vault.yaml ]                    # value files (--values)
+    set:                                      # values (--set)
       - name: address
         value: https://vault.example.com
-    env:                                 # values (--set) but value will be pulled from environment variables. Will throw an error if the environment variable is not set.
       - name: db.password
-        value: DB_PASSWORD               # $DB_PASSOWRD needs to be set in the calling environment ex: export DB_PASSWORD='password1'
+        value: ${DB_PASSWORD}                 # value taken from environment variable. Will throw an error if the environment variable is not set. $DB_PASSOWRD needs to be set in the calling environment ex: export DB_PASSWORD='password1'
+      - name: proxy.domain
+        value: "${PLATFORM_ID}.my-domain.com" # Interpolate environment variable with a fixed string
 
   # Local chart example
-  - name: grafana                         # helm deployment name
-    namespace: another                    # target namespace
-    chart: ../my-charts/grafana           # chart reference (relative path to manifest)
+  - name: grafana                            # helm deployment name
+    namespace: another                       # target namespace
+    chart: ../my-charts/grafana              # chart reference (relative path to manifest)
     values:
-    - ../../my-values/grafana/values.yaml # Values file (relative path to manifest)
+    - "../../my-values/grafana/values.yaml"  # Values file (relative path to manifest)
+    - "./values/${PLATFORM_ENV}/config.yaml" # Values file taken from path with environment variable. $PLATFORM_ENV must be set in the calling environment.
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,25 +23,25 @@ repositories:
 
 charts:
   # Published chart example
-  - name: vault                               # helm deployment name
-    namespace: vault                          # target namespace
-    chart: roboll/vault-secret-manager        # chart reference (repository)
-    values: [ vault.yaml ]                    # value files (--values)
-    set:                                      # values (--set)
+  - name: vault                            # helm deployment name
+    namespace: vault                       # target namespace
+    chart: roboll/vault-secret-manager     # chart reference (repository)
+    values: [ vault.yaml ]                 # value files (--values)
+    set:                                   # values (--set)
       - name: address
         value: https://vault.example.com
       - name: db.password
-        value: ${DB_PASSWORD}                 # value taken from environment variable. Will throw an error if the environment variable is not set. $DB_PASSOWRD needs to be set in the calling environment ex: export DB_PASSWORD='password1'
+        value: {{ env "DB_PASSWORD" }}                   # value taken from environment variable. Will throw an error if the environment variable is not set. $DB_PASSOWRD needs to be set in the calling environment ex: export DB_PASSWORD='password1'
       - name: proxy.domain
-        value: "${PLATFORM_ID}.my-domain.com" # Interpolate environment variable with a fixed string
+        value: "{{ env \"PLATFORM_ID\" }}.my-domain.com" # Interpolate environment variable with a fixed string
 
   # Local chart example
   - name: grafana                            # helm deployment name
     namespace: another                       # target namespace
     chart: ../my-charts/grafana              # chart reference (relative path to manifest)
     values:
-    - "../../my-values/grafana/values.yaml"  # Values file (relative path to manifest)
-    - "./values/${PLATFORM_ENV}/config.yaml" # Values file taken from path with environment variable. $PLATFORM_ENV must be set in the calling environment.
+    - "../../my-values/grafana/values.yaml"             # Values file (relative path to manifest)
+    - "./values/{{ env \"PLATFORM_ENV\" }}/config.yaml" # Values file taken from path with environment variable. $PLATFORM_ENV must be set in the calling environment.
 
 ```
 

--- a/state/state.go
+++ b/state/state.go
@@ -39,8 +39,8 @@ type ChartSpec struct {
 	Values    []string   `yaml:"values"`
 	SetValues []SetValue `yaml:"set"`
 
-	// The 'env' section is not really necessary anylonger, as 'set' would now provide the same functionality
-	// EnvValues []SetValue `yaml:"env"`
+	// The 'env' section is not really necessary any longer, as 'set' would now provide the same functionality
+	EnvValues []SetValue `yaml:"env"`
 }
 
 type SetValue struct {
@@ -260,26 +260,32 @@ func flagsForChart(basePath string, chart *ChartSpec) ([]string, error) {
 		flags = append(flags, "--set", strings.Join(val, ","))
 	}
 
-	// The 'env' section is not really necessary anylonger, as 'set' would now provide the same functionality
-	//if len(chart.EnvValues) > 0 {
-	//	val := []string{}
-	//	envValErrs := []string{}
-	//	for _, set := range chart.EnvValues {
-	//		value, isSet := os.LookupEnv(set.Value)
-	//		if isSet {
-	//			val = append(val, fmt.Sprintf("%s=%s", set.Name, value))
-	//		} else {
-	//			errMsg := fmt.Sprintf("\t%s", set.Value)
-	//			envValErrs = append(envValErrs, errMsg)
-	//		}
-	//	}
-	//	if len(envValErrs) != 0 {
-	//		joinedEnvVals := strings.Join(envValErrs, "\n")
-	//		errMsg := fmt.Sprintf("Environment Variables not found. Please make sure they are set and try again:\n%s", joinedEnvVals)
-	//		return nil, errors.New(errMsg)
-	//	}
-	//	flags = append(flags, "--set", strings.Join(val, ","))
-	//}
+	/***********
+	 * START 'env' section for backwards compatibility
+	 ***********/
+	// The 'env' section is not really necessary any longer, as 'set' would now provide the same functionality
+	if len(chart.EnvValues) > 0 {
+		val := []string{}
+		envValErrs := []string{}
+		for _, set := range chart.EnvValues {
+			value, isSet := os.LookupEnv(set.Value)
+			if isSet {
+				val = append(val, fmt.Sprintf("%s=%s", set.Name, value))
+			} else {
+				errMsg := fmt.Sprintf("\t%s", set.Value)
+				envValErrs = append(envValErrs, errMsg)
+			}
+		}
+		if len(envValErrs) != 0 {
+			joinedEnvVals := strings.Join(envValErrs, "\n")
+			errMsg := fmt.Sprintf("Environment Variables not found. Please make sure they are set and try again:\n%s", joinedEnvVals)
+			return nil, errors.New(errMsg)
+		}
+		flags = append(flags, "--set", strings.Join(val, ","))
+	}
+	/**************
+	 * END 'env' section for backwards compatibility
+	 **************/
 
 	return flags, nil
 }


### PR DESCRIPTION
Thanks a lot for sharing this tool - it really helps out in my workflow!

For my use-case I had to make some adjustments though.
I need to use environment variables inside the paths of the `--values` section.
Also I need to interpolate env vars with `--set` strings. Currently we have the `env` section to use env vars, but it cannot be used for interpolation. 
My use-case is like that:

```
---
charts:
  - name: proxy
    namespace: default
    chart: ./helm/charts/PlatformProxy
    values:
    - ./helm/values/${PLATFORM_ENV}/${PLATFORM_ID}/config.yaml
    - ./helm/values/${PLATFORM_ENV}/${PLATFORM_ID}/secrets.yaml
    set:
    - name: proxy.base_url
      value: "${PLATFORM_ID}.my-domain.com"
```

This PR adds the functionality. In order to render the environment variables reliable, they **MUST** be surrounded by `${}`. An error is thrown, if a variable is not set.   
I removed `env`, because `set` would now provide the same functionality, but if you have backwards compatibility concerns I could also easily integrate it again.

It works for me and I thought this might be worth sharing. Whats your take on this?