### PR TITLE
Added ability to set context in charts.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ repositories:
   - name: roboll
     url: http://roboll.io/charts
 
+context: kube-context					 # kube-context (--kube-context)
+
 charts:
   # Published chart example
   - name: vault                          # helm deployment name

--- a/main.go
+++ b/main.go
@@ -225,7 +225,9 @@ func before(c *cli.Context) (*state.HelmState, helmexec.Interface, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-
+	if state.Context != "" {
+		kubeContext = state.Context
+	}
 	var writer io.Writer
 	if !quiet {
 		writer = os.Stdout

--- a/main.go
+++ b/main.go
@@ -226,6 +226,10 @@ func before(c *cli.Context) (*state.HelmState, helmexec.Interface, error) {
 		return nil, nil, err
 	}
 	if state.Context != "" {
+		if kubeContext != "" {
+			log.Printf("err: Cannot use option --kube-context and set attribute context.")
+			os.Exit(1)
+		}
 		kubeContext = state.Context
 	}
 	var writer io.Writer

--- a/state/state.go
+++ b/state/state.go
@@ -18,6 +18,7 @@ import (
 
 type HelmState struct {
 	BaseChartPath string
+	Context       string           `yaml:"context"`
 	Repositories  []RepositorySpec `yaml:"repositories"`
 	Charts        []ChartSpec      `yaml:"charts"`
 }


### PR DESCRIPTION
I would like to have the ability to set the kubernetes cluster context in the charts.yaml.

This means that upgrade pipelines and users can just use "helmfile sync" and will work correctly across multiple cluster contexts.