### PR TITLE
Add option to limit concurrent helm calls

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -18,6 +18,7 @@ dependencies:
 test:
   pre:
     - cd "$WORK" && make check
+    - cd "$WORK" && make pristine
 
   override:
     - cd "$WORK" && make test

--- a/main.go
+++ b/main.go
@@ -84,6 +84,11 @@ func main() {
 					Name:  "values",
 					Usage: "additional value files to be merged into the command",
 				},
+				cli.IntFlag{
+					Name:  "concurrency",
+					Value: 0,
+					Usage: "maximum number of concurrent helm processes to run, 0 is unlimited",
+				},
 			},
 			Action: func(c *cli.Context) error {
 				state, helm, err := before(c)
@@ -97,8 +102,9 @@ func main() {
 				}
 
 				values := c.StringSlice("values")
+				workers := c.Int("concurrency")
 
-				if errs := state.SyncCharts(helm, values); errs != nil && len(errs) > 0 {
+				if errs := state.SyncCharts(helm, values, workers); errs != nil && len(errs) > 0 {
 					for _, err := range errs {
 						fmt.Printf("err: %s\n", err.Error())
 					}
@@ -164,6 +170,11 @@ func main() {
 					Name:  "values",
 					Usage: "additional value files to be merged into the command",
 				},
+				cli.IntFlag{
+					Name:  "concurrency",
+					Value: 0,
+					Usage: "maximum number of concurrent helm processes to run, 0 is unlimited",
+				},
 			},
 			Action: func(c *cli.Context) error {
 				state, helm, err := before(c)
@@ -179,8 +190,9 @@ func main() {
 				}
 
 				values := c.StringSlice("values")
+				workers := c.Int("concurrency")
 
-				if errs := state.SyncCharts(helm, values); errs != nil && len(errs) > 0 {
+				if errs := state.SyncCharts(helm, values, workers); errs != nil && len(errs) > 0 {
 					for _, err := range errs {
 						fmt.Printf("err: %s\n", err.Error())
 					}

--- a/state/state.go
+++ b/state/state.go
@@ -12,10 +12,10 @@ import (
 
 	"github.com/roboll/helmfile/helmexec"
 
+	"bytes"
 	yaml "gopkg.in/yaml.v1"
 	"path"
 	"regexp"
-	"bytes"
 )
 
 type HelmState struct {
@@ -31,9 +31,9 @@ type RepositorySpec struct {
 }
 
 type ChartSpec struct {
-	Chart     string `yaml:"chart"`
-	Version   string `yaml:"version"`
-	Verify    bool   `yaml:"verify"`
+	Chart   string `yaml:"chart"`
+	Version string `yaml:"version"`
+	Verify  bool   `yaml:"verify"`
 
 	Name      string     `yaml:"name"`
 	Namespace string     `yaml:"namespace"`
@@ -64,13 +64,11 @@ func ReadFromFile(file string) (*HelmState, error) {
 	return &state, nil
 }
 
-var /* const */
-	stringTemplateFuncMap = template.FuncMap{
-		"env": getEnvVar,
-	}
+var stringTemplateFuncMap = template.FuncMap{
+	"env": getEnvVar,
+}
 
-var /* const */
-	stringTemplate = template.New("stringTemplate").Funcs(stringTemplateFuncMap)
+var stringTemplate = template.New("stringTemplate").Funcs(stringTemplateFuncMap)
 
 func getEnvVar(envVarName string) (string, error) {
 	envVarValue, isSet := os.LookupEnv(envVarName)


### PR DESCRIPTION
Have added a new argument `--max-connections` that can be used to set a
limit on the number of concurrent calls to helm at one time. To enable
this I have switched `SyncCharts` from using a WaitGroup to using a pool
of workers and a queue of jobs. No changes have been made to the logic
that performs the sync, however that might be something to look at in
the future.

Fixes https://github.com/roboll/helmfile/issues/23