### PR TITLE
Allow running helm against a subsets of charts in a file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist/
 .idea/
+helmfile

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ GLOBAL OPTIONS:
    --file FILE, -f FILE         load config from FILE (default: "helmfile.yaml")
    --quiet, -q                  silence output
    --namespace value, -n value  Set namespace. Uses the namespace set in the context by default
-   --labels value                 Only run using the releases that match labels. Tags can take the form of foo=bar or foo!=bar.
+   --selector,l value           Only run using the releases that match labels. Labels can take the form of foo=bar or foo!=bar.
                                 A release must match all labels in a group in order to be used. Multiple groups can be specified at once.
                                 --labels tier=frontend,tier!=proxy --labels tier=backend. Will match all frontend, non-proxy releases AND all backend releases.
                                 The name of a release can be used as a label. --labels name=myrelease
@@ -115,12 +115,12 @@ A few rules to clear up this ambiguity:
 
 For additional context, take a look at [paths examples](PATHS.md)
 ## Labels Overview
-Labels can be used to only use a subset of releases when running helmfile. This is useful for large helmfiles with releases that are logically grouped together.
+A selector can be used to only target a subset of releases when running helmfile. This is useful for large helmfiles with releases that are logically grouped together.
 
-Labels are simple key value pairs that are an optional field of the release spec. When filtering by label, the search can be inverted. `tier!=backend` would match all releases that do NOT have the `tier: backend` label. `tier=fronted` would only match releases with the `tier: frontend` label.
+Labels are simple key value pairs that are an optional field of the release spec. When selecting by label, the search can be inverted. `tier!=backend` would match all releases that do NOT have the `tier: backend` label. `tier=fronted` would only match releases with the `tier: frontend` label.
 
-Multiple labels can be specified using `,` as a separator. A release must match all labels in order to be selected for the final helm command. 
+Multiple labels can be specified using `,` as a separator. A release must match all selectors in order to be selected for the final helm command. 
 
-The `labels` parameter can be specified multiple times. Each parameter is resolved independently so a release that matches any parameter will be used. 
+The `selector` parameter can be specified multiple times. Each parameter is resolved independently so a release that matches any parameter will be used. 
 
 `--selector tier=frontend --selector tier=backend` will select all the charts

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ releases:
   # Published chart example
   - name: vault                            # name of this release
     namespace: vault                       # target namespace
-    tags:                                  # Arbitrary key value pairs for filtering releases
+    labels:                                  # Arbitrary key value pairs for filtering releases
       foo: bar
     chart: roboll/vault-secret-manager     # the chart being installed to create this release, referenced by `repository/chart` syntax
     values: [ vault.yaml ]                 # value files (--values)
@@ -78,10 +78,10 @@ GLOBAL OPTIONS:
    --file FILE, -f FILE         load config from FILE (default: "helmfile.yaml")
    --quiet, -q                  silence output
    --namespace value, -n value  Set namespace. Uses the namespace set in the context by default
-   --tags value                 Only run using the releases that match tags. Tags can take the form of foo=bar or foo!=bar.
-                                A release must match all tags in a group in order to be used. Multiple groups can be specified at once.
-                                --tags tier=frontend,tier!=proxy --tags tier=backend. Will match all frontend, non-proxy releases AND all backend releases.
-                                The name of a release can be used as a tag. --tags name=myrelease
+   --labels value                 Only run using the releases that match labels. Tags can take the form of foo=bar or foo!=bar.
+                                A release must match all labels in a group in order to be used. Multiple groups can be specified at once.
+                                --labels tier=frontend,tier!=proxy --labels tier=backend. Will match all frontend, non-proxy releases AND all backend releases.
+                                The name of a release can be used as a label. --labels name=myrelease
    --kube-context value         Set kubectl context. Uses current context by default
    --help, -h                   show help
    --version, -v                print the version
@@ -114,11 +114,13 @@ A few rules to clear up this ambiguity:
 - Relative paths referenced on the command line are relative to the current working directory the user is in
 
 For additional context, take a look at [paths examples](PATHS.md)
-## Tags Overview
-Tags can be used to only use a subset of releases when running helmfile. This is useful for large helmfiles with releases that are logically grouped together.
+## Labels Overview
+Labels can be used to only use a subset of releases when running helmfile. This is useful for large helmfiles with releases that are logically grouped together.
 
-Tags are simple key value pairs that are an optional field of the release spec. When filtering by tag, the search can be inverted. `tier!=backend` would match all releases that do NOT have the `tier: backend` tag. `tier=fronted` would only match releases with the `tier: frontend` tag.
+Labels are simple key value pairs that are an optional field of the release spec. When filtering by label, the search can be inverted. `tier!=backend` would match all releases that do NOT have the `tier: backend` label. `tier=fronted` would only match releases with the `tier: frontend` label.
 
-Multiple tags can be specified using `,` as a separator. A release must match all tags in order to be selected for the final helm command. 
+Multiple labels can be specified using `,` as a separator. A release must match all labels in order to be selected for the final helm command. 
 
-The `tags` parameter can be specified multiple times. Each parameter is resolved independently so a release that matches any parameter will be used. 
+The `labels` parameter can be specified multiple times. Each parameter is resolved independently so a release that matches any parameter will be used. 
+
+`--selector tier=frontend --selector tier=backend` will select all the charts

--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ GLOBAL OPTIONS:
    --quiet, -q                  silence output
    --namespace value, -n value  Set namespace. Uses the namespace set in the context by default
    --selector,l value           Only run using the releases that match labels. Labels can take the form of foo=bar or foo!=bar.
-                                A release must match all labels in a group in order to be used. Multiple groups can be specified at once.
-                                --labels tier=frontend,tier!=proxy --labels tier=backend. Will match all frontend, non-proxy releases AND all backend releases.
-                                The name of a release can be used as a label. --labels name=myrelease
+	                              A release must match all labels in a group in order to be used. Multiple groups can be specified at once.
+	                              --selector tier=frontend,tier!=proxy --selector tier=backend. Will match all frontend, non-proxy releases AND all backend releases.
+	                              The name of a release can be used as a label. --selector name=myrelease
    --kube-context value         Set kubectl context. Uses current context by default
    --help, -h                   show help
    --version, -v                print the version

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ releases:
   # Published chart example
   - name: vault                            # name of this release
     namespace: vault                       # target namespace
+    tags:                                  # Arbitrary key value pairs for filtering releases
+      foo: bar
     chart: roboll/vault-secret-manager     # the chart being installed to create this release, referenced by `repository/chart` syntax
     values: [ vault.yaml ]                 # value files (--values)
     secrets:
@@ -73,11 +75,16 @@ COMMANDS:
      delete  delete charts from state file (helm delete)
 
 GLOBAL OPTIONS:
-   --file FILE, -f FILE  load config from FILE (default: "helmfile.yaml")
-   --quiet, -q           silence output
-   --kube-context value  Set kubectl context. Uses current context by default
-   --help, -h            show help
-   --version, -v         print the version
+   --file FILE, -f FILE         load config from FILE (default: "helmfile.yaml")
+   --quiet, -q                  silence output
+   --namespace value, -n value  Set namespace. Uses the namespace set in the context by default
+   --tags value                 Only run using the releases that match tags. Tags can take the form of foo=bar or foo!=bar.
+                                A release must match all tags in a group in order to be used. Multiple groups can be specified at once.
+                                --tags tier=frontend,tier!=proxy --tags tier=backend. Will match all frontend, non-proxy releases AND all backend releases.
+                                The name of a release can be used as a tag. --tags name=myrelease
+   --kube-context value         Set kubectl context. Uses current context by default
+   --help, -h                   show help
+   --version, -v                print the version
 ```
 
 ### diff
@@ -107,3 +114,11 @@ A few rules to clear up this ambiguity:
 - Relative paths referenced on the command line are relative to the current working directory the user is in
 
 For additional context, take a look at [paths examples](PATHS.md)
+## Tags Overview
+Tags can be used to only use a subset of releases when running helmfile. This is useful for large helmfiles with releases that are logically grouped together.
+
+Tags are simple key value pairs that are an optional field of the release spec. When filtering by tag, the search can be inverted. `tier!=backend` would match all releases that do NOT have the `tier: backend` tag. `tier=fronted` would only match releases with the `tier: frontend` tag.
+
+Multiple tags can be specified using `,` as a separator. A release must match all tags in order to be selected for the final helm command. 
+
+The `tags` parameter can be specified multiple times. Each parameter is resolved independently so a release that matches any parameter will be used. 

--- a/main.go
+++ b/main.go
@@ -46,11 +46,11 @@ func main() {
 			Usage: "Set namespace. Uses the namespace set in the context by default",
 		},
 		cli.StringSliceFlag{
-			Name: "tags",
-			Usage: `Only run using the releases that match tags. Tags can take the form of foo=bar or foo!=bar.
-	A release must match all tags in a group in order to be used. Multiple groups can be specified at once.
-	--tags tier=frontend,tier!=proxy --tags tier=backend. Will match all frontend, non-proxy releases AND all backend releases.
-	The name of a release can be used as a tag. --tags name=myrelease`,
+			Name: "selector, l",
+			Usage: `Only run using the releases that match labels. Labels can take the form of foo=bar or foo!=bar.
+	A release must match all labels in a group in order to be used. Multiple groups can be specified at once.
+	--selector tier=frontend,tier!=proxy --selector tier=backend. Will match all frontend, non-proxy releases AND all backend releases.
+	The name of a release can be used as a label. --selector name=myrelease`,
 		},
 	}
 
@@ -222,7 +222,7 @@ func before(c *cli.Context) (*state.HelmState, helmexec.Interface, error) {
 	quiet := c.GlobalBool("quiet")
 	kubeContext := c.GlobalString("kube-context")
 	namespace := c.GlobalString("namespace")
-	tags := c.GlobalStringSlice("tags")
+	labels := c.GlobalStringSlice("selector")
 
 	st, err := state.ReadFromFile(file)
 	if err != nil && strings.Contains(err.Error(), fmt.Sprintf("open %s:", DefaultHelmfile)) {
@@ -247,8 +247,8 @@ func before(c *cli.Context) (*state.HelmState, helmexec.Interface, error) {
 		}
 		st.Namespace = namespace
 	}
-	if len(tags) > 0 {
-		err = st.FilterReleases(tags)
+	if len(labels) > 0 {
+		err = st.FilterReleases(labels)
 		if err != nil {
 			log.Print(err)
 			os.Exit(1)
@@ -264,7 +264,7 @@ func before(c *cli.Context) (*state.HelmState, helmexec.Interface, error) {
 	go func() {
 		sig := <-sigs
 
-		errs := []error{fmt.Errorf("Recived [%s] to shutdown ", sig)}
+		errs := []error{fmt.Errorf("Received [%s] to shutdown ", sig)}
 		clean(st, errs)
 	}()
 

--- a/state/release_filters.go
+++ b/state/release_filters.go
@@ -12,27 +12,27 @@ type ReleaseFilter interface {
 	Match(r ReleaseSpec) bool
 }
 
-// TagFilter matches a release with the given positive tags. Negative tags
+// LabelFilter matches a release with the given positive lables. Negative labels
 // invert the match for cases such as tier!=backend
-type TagFilter struct {
-	positiveTags map[string]string
-	negativeTags map[string]string
+type LabelFilter struct {
+	positiveLabels map[string]string
+	negativeLabels map[string]string
 }
 
-// Match will match a release that has the same tags as the filter
-func (t TagFilter) Match(r ReleaseSpec) bool {
-	if len(t.positiveTags) > 0 {
-		for k, v := range t.positiveTags {
-			if rVal, ok := r.Tags[k]; !ok {
+// Match will match a release that has the same labels as the filter
+func (l LabelFilter) Match(r ReleaseSpec) bool {
+	if len(l.positiveLabels) > 0 {
+		for k, v := range l.positiveLabels {
+			if rVal, ok := r.Labels[k]; !ok {
 				return false
 			} else if rVal != v {
 				return false
 			}
 		}
 	}
-	if len(t.negativeTags) > 0 {
-		for k, v := range t.negativeTags {
-			if rVal, ok := r.Tags[k]; !ok {
+	if len(l.negativeLabels) > 0 {
+		for k, v := range l.negativeLabels {
+			if rVal, ok := r.Labels[k]; !ok {
 				return true
 			} else if rVal == v {
 				return false
@@ -42,23 +42,23 @@ func (t TagFilter) Match(r ReleaseSpec) bool {
 	return true
 }
 
-// ParseTags takes a tag in the form foo=bar,baz!=bat and returns a TagFilter that will match the tags
-func ParseTags(t string) (TagFilter, error) {
-	tf := TagFilter{}
-	tf.positiveTags = map[string]string{}
-	tf.negativeTags = map[string]string{}
+// ParseLabels takes a label in the form foo=bar,baz!=bat and returns a LabelFilter that will match the labels
+func ParseLabels(l string) (LabelFilter, error) {
+	lf := LabelFilter{}
+	lf.positiveLabels = map[string]string{}
+	lf.negativeLabels = map[string]string{}
 	var err error
-	tags := strings.Split(t, ",")
-	for _, tag := range tags {
-		if match, _ := regexp.MatchString("^[a-zA-Z0-9_-]+!=[a-zA-Z0-9_-]+$", tag); match == true { // k!=v case
-			kv := strings.Split(tag, "!=")
-			tf.negativeTags[kv[0]] = kv[1]
-		} else if match, _ := regexp.MatchString("^[a-zA-Z0-9_-]+=[a-zA-Z0-9_-]+$", tag); match == true { // k=v case
-			kv := strings.Split(tag, "=")
-			tf.positiveTags[kv[0]] = kv[1]
+	labels := strings.Split(l, ",")
+	for _, label := range labels {
+		if match, _ := regexp.MatchString("^[a-zA-Z0-9_-]+!=[a-zA-Z0-9_-]+$", label); match == true { // k!=v case
+			kv := strings.Split(label, "!=")
+			lf.negativeLabels[kv[0]] = kv[1]
+		} else if match, _ := regexp.MatchString("^[a-zA-Z0-9_-]+=[a-zA-Z0-9_-]+$", label); match == true { // k=v case
+			kv := strings.Split(label, "=")
+			lf.positiveLabels[kv[0]] = kv[1]
 		} else { // malformed case
-			err = fmt.Errorf("Malformed tag: %s. Expected tag in form k=v or k!=v", tag)
+			err = fmt.Errorf("Malformed label: %s. Expected label in form k=v or k!=v", label)
 		}
 	}
-	return tf, err
+	return lf, err
 }

--- a/state/release_filters.go
+++ b/state/release_filters.go
@@ -1,0 +1,64 @@
+package state
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// ReleaseFilter is used to determine if a given release should be used during helmfile execution
+type ReleaseFilter interface {
+	// Match returns true if the ReleaseSpec matches the Filter
+	Match(r ReleaseSpec) bool
+}
+
+// TagFilter matches a release with the given positive tags. Negative tags
+// invert the match for cases such as tier!=backend
+type TagFilter struct {
+	positiveTags map[string]string
+	negativeTags map[string]string
+}
+
+// Match will match a release that has the same tags as the filter
+func (t TagFilter) Match(r ReleaseSpec) bool {
+	if len(t.positiveTags) > 0 {
+		for k, v := range t.positiveTags {
+			if rVal, ok := r.Tags[k]; !ok {
+				return false
+			} else if rVal != v {
+				return false
+			}
+		}
+	}
+	if len(t.negativeTags) > 0 {
+		for k, v := range t.negativeTags {
+			if rVal, ok := r.Tags[k]; !ok {
+				return true
+			} else if rVal == v {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// ParseTags takes a tag in the form foo=bar,baz!=bat and returns a TagFilter that will match the tags
+func ParseTags(t string) (TagFilter, error) {
+	tf := TagFilter{}
+	tf.positiveTags = map[string]string{}
+	tf.negativeTags = map[string]string{}
+	var err error
+	tags := strings.Split(t, ",")
+	for _, tag := range tags {
+		if match, _ := regexp.MatchString("^[a-zA-Z0-9_-]+!=[a-zA-Z0-9_-]+$", tag); match == true { // k!=v case
+			kv := strings.Split(tag, "!=")
+			tf.negativeTags[kv[0]] = kv[1]
+		} else if match, _ := regexp.MatchString("^[a-zA-Z0-9_-]+=[a-zA-Z0-9_-]+$", tag); match == true { // k=v case
+			kv := strings.Split(tag, "=")
+			tf.positiveTags[kv[0]] = kv[1]
+		} else { // malformed case
+			err = fmt.Errorf("Malformed tag: %s. Expected tag in form k=v or k!=v", tag)
+		}
+	}
+	return tf, err
+}

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -62,34 +62,34 @@ releases:
 	}
 }
 
-func TestReadFromYaml_FilterReleasesOnTags(t *testing.T) {
+func TestReadFromYaml_FilterReleasesOnLabels(t *testing.T) {
 	yamlFile := "example/path/to/yaml/file"
 	yamlContent := []byte(`releases:
 - name: myrelease1
   chart: mychart1
-  tags:
+  labels:
     tier: frontend
     foo: bar
 - name: myrelease2
   chart: mychart2
-  tags:
+  labels:
     tier: frontend
 - name: myrelease3
   chart: mychart3
-  tags:
+  labels:
     tier: backend
 `)
 	cases := []struct {
-		filter  TagFilter
+		filter  LabelFilter
 		results []bool
 	}{
-		{TagFilter{positiveTags: map[string]string{"tier": "frontend"}},
+		{LabelFilter{positiveLabels: map[string]string{"tier": "frontend"}},
 			[]bool{true, true, false}},
-		{TagFilter{positiveTags: map[string]string{"tier": "frontend", "foo": "bar"}},
+		{LabelFilter{positiveLabels: map[string]string{"tier": "frontend", "foo": "bar"}},
 			[]bool{true, false, false}},
-		{TagFilter{negativeTags: map[string]string{"tier": "frontend"}},
+		{LabelFilter{negativeLabels: map[string]string{"tier": "frontend"}},
 			[]bool{false, false, true}},
-		{TagFilter{positiveTags: map[string]string{"tier": "frontend"}, negativeTags: map[string]string{"foo": "bar"}},
+		{LabelFilter{positiveLabels: map[string]string{"tier": "frontend"}, negativeLabels: map[string]string{"foo": "bar"}},
 			[]bool{false, true, false}},
 	}
 	state, err := readFromYaml(yamlContent, yamlFile)
@@ -105,27 +105,27 @@ func TestReadFromYaml_FilterReleasesOnTags(t *testing.T) {
 	}
 }
 
-func TestTagParsing(t *testing.T) {
+func TestLabelParsing(t *testing.T) {
 	cases := []struct {
-		tagString      string
-		expectedFilter TagFilter
+		labelString    string
+		expectedFilter LabelFilter
 		errorExected   bool
 	}{
-		{"foo=bar", TagFilter{positiveTags: map[string]string{"foo": "bar"}, negativeTags: map[string]string{}}, false},
-		{"foo!=bar", TagFilter{positiveTags: map[string]string{}, negativeTags: map[string]string{"foo": "bar"}}, false},
-		{"foo!=bar,baz=bat", TagFilter{positiveTags: map[string]string{"baz": "bat"}, negativeTags: map[string]string{"foo": "bar"}}, false},
-		{"foo", TagFilter{positiveTags: map[string]string{}, negativeTags: map[string]string{}}, true},
-		{"foo!=bar=baz", TagFilter{positiveTags: map[string]string{}, negativeTags: map[string]string{}}, true},
-		{"=bar", TagFilter{positiveTags: map[string]string{}, negativeTags: map[string]string{}}, true},
+		{"foo=bar", LabelFilter{positiveLabels: map[string]string{"foo": "bar"}, negativeLabels: map[string]string{}}, false},
+		{"foo!=bar", LabelFilter{positiveLabels: map[string]string{}, negativeLabels: map[string]string{"foo": "bar"}}, false},
+		{"foo!=bar,baz=bat", LabelFilter{positiveLabels: map[string]string{"baz": "bat"}, negativeLabels: map[string]string{"foo": "bar"}}, false},
+		{"foo", LabelFilter{positiveLabels: map[string]string{}, negativeLabels: map[string]string{}}, true},
+		{"foo!=bar=baz", LabelFilter{positiveLabels: map[string]string{}, negativeLabels: map[string]string{}}, true},
+		{"=bar", LabelFilter{positiveLabels: map[string]string{}, negativeLabels: map[string]string{}}, true},
 	}
 	for idx, c := range cases {
-		filter, err := ParseTags(c.tagString)
+		filter, err := ParseLabels(c.labelString)
 		if err != nil && !c.errorExected {
-			t.Errorf("[%d] Didn't expect an error parsing tags: %s", idx, err)
+			t.Errorf("[%d] Didn't expect an error parsing labels: %s", idx, err)
 		} else if err == nil && c.errorExected {
-			t.Errorf("[%d] Expected %s to result in an error but got none", idx, c.tagString)
+			t.Errorf("[%d] Expected %s to result in an error but got none", idx, c.labelString)
 		} else if !reflect.DeepEqual(filter, c.expectedFilter) {
-			t.Errorf("[%d] parsed tag did not result in expected filter: %v", idx, filter)
+			t.Errorf("[%d] parsed label did not result in expected filter: %v", idx, filter)
 		}
 	}
 }


### PR DESCRIPTION
Similar to what's described in https://github.com/roboll/helmfile/issues/8

Globbing isn't useful for my particular workflow but I do have a large helmfile where its useful to run just one or two charts out of the entire file.