### PR TITLE
Purge releases on deletion

### DIFF
--- a/helmexec/exec.go
+++ b/helmexec/exec.go
@@ -63,7 +63,7 @@ func (helm *execer) DiffChart(name, chart string, flags ...string) error {
 }
 
 func (helm *execer) DeleteChart(name string) error {
-	out, err := helm.exec("delete", name)
+	out, err := helm.exec("delete", "--purge", name)
 	if helm.writer != nil {
 		helm.writer.Write(out)
 	}


### PR DESCRIPTION
So that we can just reuse release names after `helmfile delete`.

This is verified to work by confirming that `helmfile delete` does add `--purge` flag to `helm delete`:

```
$ helmfile delete
exec: helm delete --purge brigade-project
release "brigade-project" deleted
```

And by confirming that I can now re-install releases from the same charts.yaml without any modification of release names:

```
PROJECT=deis/empty-testbed ENV=staging IMAGE=mumoshu/golang-k8s-aws:1.9.1 COMMAND='go' SERVICE_ACCOUNT=default helmfile sync
Release "brigade-project" does not exist. Installing it now.
NAME:   brigade-project
LAST DEPLOYED: Tue Feb 27 15:59:38 2018
NAMESPACE: kube-system
STATUS: DEPLOYED

RESOURCES:
*snip*
```

Fixes #33