### PR TITLE
Allow specifying a default namespace used across all the releases

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,6 +38,10 @@ func main() {
 			Name:  "kube-context",
 			Usage: "Set kubectl context. Uses current context by default",
 		},
+		cli.StringFlag{
+			Name:  "namespace, n",
+			Usage: "Set namespace. Uses the namespace set in the context by default",
+		},
 	}
 
 	app.Commands = []cli.Command{
@@ -220,6 +224,7 @@ func before(c *cli.Context) (*state.HelmState, helmexec.Interface, error) {
 	file := c.GlobalString("file")
 	quiet := c.GlobalBool("quiet")
 	kubeContext := c.GlobalString("kube-context")
+	namespace := c.GlobalString("namespace")
 
 	state, err := state.ReadFromFile(file)
 	if err != nil {
@@ -231,6 +236,13 @@ func before(c *cli.Context) (*state.HelmState, helmexec.Interface, error) {
 			os.Exit(1)
 		}
 		kubeContext = state.Context
+	}
+	if namespace != "" {
+		if state.Namespace != "" {
+			log.Printf("err: Cannot use option --namespace and set attribute namespace.")
+			os.Exit(1)
+		}
+		state.Namespace = namespace
 	}
 	var writer io.Writer
 	if !quiet {

--- a/state/state.go
+++ b/state/state.go
@@ -21,6 +21,7 @@ import (
 type HelmState struct {
 	BaseChartPath string
 	Context       string           `yaml:"context"`
+	Namespace       string           `yaml:"namespace"`
 	Repositories  []RepositorySpec `yaml:"repositories"`
 	Charts        []ChartSpec      `yaml:"charts"`
 }
@@ -99,6 +100,11 @@ func renderTemplateString(s string) (string, error) {
 	return tplString.String(), nil
 }
 
+func (state *HelmState) applyDefaultsTo(spec ChartSpec) ChartSpec {
+	spec.Namespace = state.Namespace
+	return spec
+}
+
 func (state *HelmState) SyncRepos(helm helmexec.Interface) []error {
 	var wg sync.WaitGroup
 	errs := []error{}
@@ -131,7 +137,8 @@ func (state *HelmState) SyncCharts(helm helmexec.Interface, additonalValues []st
 	for _, chart := range state.Charts {
 		wg.Add(1)
 		go func(wg *sync.WaitGroup, chart ChartSpec) {
-			flags, flagsErr := flagsForChart(state.BaseChartPath, &chart)
+			chartWithDefaults := state.applyDefaultsTo(chart)
+			flags, flagsErr := flagsForChart(state.BaseChartPath, &chartWithDefaults)
 			if flagsErr != nil {
 				errs = append(errs, flagsErr)
 			}

--- a/state/state.go
+++ b/state/state.go
@@ -21,7 +21,7 @@ import (
 type HelmState struct {
 	BaseChartPath string
 	Context       string           `yaml:"context"`
-	Namespace       string           `yaml:"namespace"`
+	Namespace     string           `yaml:"namespace"`
 	Repositories  []RepositorySpec `yaml:"repositories"`
 	Charts        []ChartSpec      `yaml:"charts"`
 }
@@ -143,8 +143,8 @@ func (state *HelmState) SyncCharts(helm helmexec.Interface, additonalValues []st
 	for w := 1; w <= workerLimit; w++ {
 		go func() {
 			for chart := range jobQueue {
-        chartWithDefaults := state.applyDefaultsTo(chart)
-			  flags, flagsErr := flagsForChart(state.BaseChartPath, &chartWithDefaults)
+				chartWithDefaults := state.applyDefaultsTo(chart)
+				flags, flagsErr := flagsForChart(state.BaseChartPath, &chartWithDefaults)
 				if flagsErr != nil {
 					errQueue <- flagsErr
 					doneQueue <- true


### PR DESCRIPTION
Omit `namespace` in `charts[].namespace` of charts.yaml and then run `helmfile sync -n yourns` to install your charts into `yourns`.

Resolves #31