### PR TITLE
[state] - Fix issue where spec[].Namespace were ignored

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -117,7 +117,9 @@ func renderTemplateString(s string) (string, error) {
 }
 
 func (state *HelmState) applyDefaultsTo(spec ReleaseSpec) ReleaseSpec {
-	spec.Namespace = state.Namespace
+	if state.Namespace != "" {
+		spec.Namespace = state.Namespace
+	}
 	return spec
 }
 
@@ -155,7 +157,6 @@ func (state *HelmState) SyncReleases(helm helmexec.Interface, additonalValues []
 	if workerLimit < 1 {
 		workerLimit = len(state.Releases)
 	}
-
 	for w := 1; w <= workerLimit; w++ {
 		go func() {
 			for release := range jobQueue {

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -8,6 +9,7 @@ func TestReadFromYaml(t *testing.T) {
 	yamlFile := "example/path/to/yaml/file"
 	yamlContent := []byte(`releases:
 - name: myrelease
+  namespace: mynamespace
   chart: mychart
 `)
 	state, err := readFromYaml(yamlContent, yamlFile)
@@ -17,6 +19,9 @@ func TestReadFromYaml(t *testing.T) {
 
 	if state.Releases[0].Name != "myrelease" {
 		t.Errorf("unexpected release name: expected=myrelease actual=%s", state.Releases[0].Name)
+	}
+	if state.Releases[0].Namespace != "mynamespace" {
+		t.Errorf("unexpected chart namespace: expected=mynamespace actual=%s", state.Releases[0].Chart)
 	}
 	if state.Releases[0].Chart != "mychart" {
 		t.Errorf("unexpected chart name: expected=mychart actual=%s", state.Releases[0].Chart)
@@ -54,5 +59,95 @@ releases:
 	_, err := readFromYaml(yamlContent, yamlFile)
 	if err == nil {
 		t.Error("expected error")
+	}
+}
+
+func TestHelmState_applyDefaultsTo(t *testing.T) {
+	type fields struct {
+		BaseChartPath      string
+		Context            string
+		DeprecatedReleases []ReleaseSpec
+		Namespace          string
+		Repositories       []RepositorySpec
+		Releases           []ReleaseSpec
+	}
+	type args struct {
+		spec ReleaseSpec
+	}
+	specWithNamespace := ReleaseSpec{
+		Chart:     "test/chart",
+		Version:   "0.1",
+		Verify:    false,
+		Name:      "test-charts",
+		Namespace: "test-namespace",
+		Values:    nil,
+		SetValues: nil,
+		EnvValues: nil,
+	}
+
+	specWithoutNamespace := specWithNamespace
+	specWithoutNamespace.Namespace = ""
+	specWithNamespaceFromFields := specWithNamespace
+	specWithNamespaceFromFields.Namespace = "test-namespace-field"
+
+	fieldsWithNamespace := fields{
+		BaseChartPath:      ".",
+		Context:            "test_context",
+		DeprecatedReleases: nil,
+		Namespace:          specWithNamespaceFromFields.Namespace,
+		Repositories:       nil,
+		Releases: []ReleaseSpec{
+			specWithNamespace,
+		},
+	}
+
+	fieldsWithoutNamespace := fieldsWithNamespace
+	fieldsWithoutNamespace.Namespace = ""
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   ReleaseSpec
+	}{
+		{
+			name:   "Has a namespace from spec",
+			fields: fieldsWithoutNamespace,
+			args: args{
+				spec: specWithNamespace,
+			},
+			want: specWithNamespace,
+		},
+		{
+			name:   "Has a namespace from flags",
+			fields: fieldsWithoutNamespace,
+			args: args{
+				spec: specWithNamespace,
+			},
+			want: specWithNamespace,
+		},
+		{
+			name:   "Has a namespace from flags and from spec",
+			fields: fieldsWithNamespace,
+			args: args{
+				spec: specWithNamespace,
+			},
+			want: specWithNamespaceFromFields,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := &HelmState{
+				BaseChartPath:      tt.fields.BaseChartPath,
+				Context:            tt.fields.Context,
+				DeprecatedReleases: tt.fields.DeprecatedReleases,
+				Namespace:          tt.fields.Namespace,
+				Repositories:       tt.fields.Repositories,
+				Releases:           tt.fields.Releases,
+			}
+			if got := state.applyDefaultsTo(tt.args.spec); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("HelmState.applyDefaultsTo() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Since [#39](https://github.com/roboll/helmfile/pull/39) the namespace specified in the spec wasn't working anymore.
Helm used the default namespace if -n wasn't set.