### PR TITLE
Synchronous add repository calls avoid helm add repo race conditions

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -151,7 +151,6 @@ func (state *HelmState) SyncReleases(helm helmexec.Interface, additonalValues []
 	if workerLimit < 1 {
 		workerLimit = len(state.Releases)
 	}
-
 	for w := 1; w <= workerLimit; w++ {
 		go func() {
 			for release := range jobQueue {


### PR DESCRIPTION
Addresses: https://github.com/roboll/helmfile/issues/45

To test:
Create helmfile.yaml
```
repositories:
  - name: monocular
    url: https://kubernetes-helm.github.io/monocular
  - name: incubator
    url: https://kubernetes-charts-incubator.storage.googleapis.com/
  - name: fabric8
    url: https://fabric8.io/helm
```
Steps to test:
```
export HELM_HOME=`pwd`/.helm
helm init --client-only
helm repo list                                        #no extra repositories
helmfile repos
helm repo list                                        #all three repositories haven't been added (usually one, sometimes two)
```

Failing test
```
ubuntu@kub-master:~/test-helmfile-multi-repo$ export HELM_HOME=`pwd`/.helm
ubuntu@kub-master:~/test-helmfile-multi-repo$ helm init --client-only
Creating /home/ubuntu/test-helmfile-multi-repo/.helm 
Creating /home/ubuntu/test-helmfile-multi-repo/.helm/repository 
Creating /home/ubuntu/test-helmfile-multi-repo/.helm/repository/cache 
Creating /home/ubuntu/test-helmfile-multi-repo/.helm/repository/local 
Creating /home/ubuntu/test-helmfile-multi-repo/.helm/plugins 
Creating /home/ubuntu/test-helmfile-multi-repo/.helm/starters 
Creating /home/ubuntu/test-helmfile-multi-repo/.helm/cache/archive 
Creating /home/ubuntu/test-helmfile-multi-repo/.helm/repository/repositories.yaml 
Adding stable repo with URL: https://kubernetes-charts.storage.googleapis.com 
Adding local repo with URL: http://127.0.0.1:8879/charts 
$HELM_HOME has been configured at /home/ubuntu/test-helmfile-multi-repo/.helm.
Not installing Tiller due to 'client-only' flag having been set
Happy Helming!
ubuntu@kub-master:~/test-helmfile-multi-repo$ helm repo list
NAME  	URL                                             
stable	https://kubernetes-charts.storage.googleapis.com
local 	http://127.0.0.1:8879/charts                    
ubuntu@kub-master:~/test-helmfile-multi-repo$ helmfile repos
exec: helm repo add fabric8 https://fabric8.io/helm
exec: helm repo add monocular https://kubernetes-helm.github.io/monocular
exec: helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/
"monocular" has been added to your repositories
"incubator" has been added to your repositories
"fabric8" has been added to your repositories
exec: helm repo update
Hang tight while we grab the latest from your chart repositories...
...Skip local chart repository
...Successfully got an update from the "stable" chart repository
...Successfully got an update from the "fabric8" chart repository
Update Complete. ⎈ Happy Helming!⎈ 
ubuntu@kub-master:~/test-helmfile-multi-repo$ helm repo list
NAME   	URL                                             
stable 	https://kubernetes-charts.storage.googleapis.com
local  	http://127.0.0.1:8879/charts                    
fabric8	https://fabric8.io/helm    #Only 1 repository added!
```

Passing test (with pull request)
```
ubuntu@kub-master:~/test-helmfile-multi-repo$ rm -rf .helm/
ubuntu@kub-master:~/test-helmfile-multi-repo$ helm init --client-only
Creating /home/ubuntu/test-helmfile-multi-repo/.helm 
Creating /home/ubuntu/test-helmfile-multi-repo/.helm/repository 
Creating /home/ubuntu/test-helmfile-multi-repo/.helm/repository/cache 
Creating /home/ubuntu/test-helmfile-multi-repo/.helm/repository/local 
Creating /home/ubuntu/test-helmfile-multi-repo/.helm/plugins 
Creating /home/ubuntu/test-helmfile-multi-repo/.helm/starters 
Creating /home/ubuntu/test-helmfile-multi-repo/.helm/cache/archive 
Creating /home/ubuntu/test-helmfile-multi-repo/.helm/repository/repositories.yaml 
Adding stable repo with URL: https://kubernetes-charts.storage.googleapis.com 
Adding local repo with URL: http://127.0.0.1:8879/charts 
$HELM_HOME has been configured at /home/ubuntu/test-helmfile-multi-repo/.helm.
Not installing Tiller due to 'client-only' flag having been set
Happy Helming!
ubuntu@kub-master:~/test-helmfile-multi-repo$ helm repo list
NAME  	URL                                             
stable	https://kubernetes-charts.storage.googleapis.com
local 	http://127.0.0.1:8879/charts                    
ubuntu@kub-master:~/test-helmfile-multi-repo$ helmfile repos
exec: helm repo add monocular https://kubernetes-helm.github.io/monocular
"monocular" has been added to your repositories
exec: helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/
"incubator" has been added to your repositories
exec: helm repo add fabric8 https://fabric8.io/helm
"fabric8" has been added to your repositories
exec: helm repo update
Hang tight while we grab the latest from your chart repositories...
...Skip local chart repository
...Successfully got an update from the "monocular" chart repository
...Successfully got an update from the "incubator" chart repository
...Successfully got an update from the "stable" chart repository
...Successfully got an update from the "fabric8" chart repository
Update Complete. ⎈ Happy Helming!⎈ 
ubuntu@kub-master:~/test-helmfile-multi-repo$ helm repo list
NAME     	URL                                                        
stable   	https://kubernetes-charts.storage.googleapis.com           
local    	http://127.0.0.1:8879/charts                               
monocular	https://kubernetes-helm.github.io/monocular                
incubator	https://kubernetes-charts-incubator.storage.googleapis.com/
fabric8  	https://fabric8.io/helm   #All 3 repository added!
```