### PR TITLE
Support client certs when accessing remote repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ The default helmfile is `helmfile.yaml`:
 repositories:
   - name: roboll
     url: http://roboll.io/charts
+    cert-file: optional_client_cert
+    key-file: optional_client_key
 
 context: kube-context					 # kube-context (--kube-context)
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ The default helmfile is `helmfile.yaml`:
 repositories:
   - name: roboll
     url: http://roboll.io/charts
-    cert-file: optional_client_cert
-    key-file: optional_client_key
+    certFile: optional_client_cert
+    keyFile: optional_client_key
 
 context: kube-context					 # kube-context (--kube-context)
 

--- a/helmexec/exec.go
+++ b/helmexec/exec.go
@@ -30,8 +30,13 @@ func (helm *execer) SetExtraArgs(args ...string) {
 	helm.extra = args
 }
 
-func (helm *execer) AddRepo(name, repository string) error {
-	out, err := helm.exec("repo", "add", name, repository)
+func (helm *execer) AddRepo(name, repository, certfile, keyfile string) error {
+	var args []string
+	args = append(args, "repo", "add", name, repository)
+	if certfile != "" && keyfile != "" {
+		args = append(args, "--cert-file", certfile, "--key-file", keyfile)
+	}
+	out, err := helm.exec(args...)
 	if helm.writer != nil {
 		helm.writer.Write(out)
 	}

--- a/helmexec/helmexec.go
+++ b/helmexec/helmexec.go
@@ -3,7 +3,7 @@ package helmexec
 type Interface interface {
 	SetExtraArgs(args ...string)
 
-	AddRepo(name, repository string) error
+	AddRepo(name, repository, certfile, keyfile string) error
 	UpdateRepo() error
 
 	SyncRelease(name, chart string, flags ...string) error

--- a/state/state.go
+++ b/state/state.go
@@ -31,8 +31,8 @@ type HelmState struct {
 type RepositorySpec struct {
 	Name     string `yaml:"name"`
 	URL      string `yaml:"url"`
-	CertFile string `yaml:"cert-file"`
-	KeyFile  string `yaml:"key-file"`
+	CertFile string `yaml:"certFile"`
+	KeyFile  string `yaml:"keyFile"`
 }
 
 type ReleaseSpec struct {

--- a/state/state.go
+++ b/state/state.go
@@ -29,8 +29,10 @@ type HelmState struct {
 }
 
 type RepositorySpec struct {
-	Name string `yaml:"name"`
-	URL  string `yaml:"url"`
+	Name     string `yaml:"name"`
+	URL      string `yaml:"url"`
+	CertFile string `yaml:"cert-file"`
+	KeyFile  string `yaml:"key-file"`
 }
 
 type ReleaseSpec struct {
@@ -127,7 +129,7 @@ func (state *HelmState) SyncRepos(helm helmexec.Interface) []error {
 	errs := []error{}
 
 	for _, repo := range state.Repositories {
-		if err := helm.AddRepo(repo.Name, repo.URL); err != nil {
+		if err := helm.AddRepo(repo.Name, repo.URL, repo.CertFile, repo.KeyFile); err != nil {
 			errs = append(errs, err)
 		}
 	}


### PR DESCRIPTION
The "helm repo add" command already supports the cert-file and key-file values, so we just have to pass them through. Everything works the same if you don't provide values for them. This is important for deployments where the chart repo is protected by client cert validation.