### PR TITLE
Fix example to use expected "charts:" key.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ repositories:
 
 context: kube-context					 # kube-context (--kube-context)
 
-releases:
+charts:
   # Published chart example
   - name: vault                            # name of this release
     namespace: vault                       # target namespace


### PR DESCRIPTION
This example uses a "releases:" key for the charts list, but when writing my own charts.yaml, only "charts:" appears to work, while "releases:" results in no charts changes when helmfile is run. All the other example files distributed with helmfile also appear to use "charts:".

Note that there appears to be some unrelated test code that also uses "releases:". You may want to fix that as well. I didn't bite that off as part of this because I don't really know Go.