### PR TITLE
Add --args option to sync command

### DIFF
--- a/main.go
+++ b/main.go
@@ -167,6 +167,11 @@ func main() {
 					Value: 0,
 					Usage: "maximum number of concurrent helm processes to run, 0 is unlimited",
 				},
+				cli.StringFlag{
+					Name:  "args",
+					Value: "",
+					Usage: "pass args to helm exec",
+				},
 			},
 			Action: func(c *cli.Context) error {
 				state, helm, err := before(c)
@@ -183,6 +188,11 @@ func main() {
 
 				values := c.StringSlice("values")
 				workers := c.Int("concurrency")
+
+				args := c.String("args")
+				if len(args) > 0 {
+					helm.SetExtraArgs(strings.Split(args, " ")...)
+				}
 
 				errs := state.SyncReleases(helm, values, workers)
 				return clean(state, errs)


### PR DESCRIPTION
The option exists for some of the other commands, and I'd like to pass options to `helm upgrade` like `--wait` and `--reset-values` 