### PR TITLE
describing current functionality of helmexec as tests

### DIFF
--- a/helmexec/exec.go
+++ b/helmexec/exec.go
@@ -17,11 +17,11 @@ type execer struct {
 	extra       []string
 }
 
-func NewHelmExec(writer io.Writer, kubeContext string) Interface {
+func New(writer io.Writer, kubeContext string) *execer {
 	return &execer{
 		writer:      writer,
 		kubeContext: kubeContext,
-		runner:      new(CliRunner),
+		runner:      &ShellRunner{},
 	}
 }
 
@@ -94,18 +94,4 @@ func (helm *execer) exec(args ...string) ([]byte, error) {
 		helm.writer.Write([]byte(fmt.Sprintf("exec: helm %s\n", strings.Join(cmdargs, " "))))
 	}
 	return helm.runner.Execute(command, cmdargs)
-}
-
-// for unit testing
-func (helm *execer) setRunner(runner Runner) {
-	helm.runner = runner
-}
-func (helm *execer) getExtra() []string {
-	return helm.extra
-}
-func (helm *execer) getKubeContent() string {
-	return helm.kubeContext
-}
-func (helm *execer) getWriter() io.Writer {
-	return helm.writer
 }

--- a/helmexec/exec.go
+++ b/helmexec/exec.go
@@ -21,7 +21,7 @@ func NewHelmExec(writer io.Writer, kubeContext string) Interface {
 	return &execer{
 		writer:      writer,
 		kubeContext: kubeContext,
-		runner:		 new(CliRunner),
+		runner:	     new(CliRunner),
 	}
 }
 

--- a/helmexec/exec.go
+++ b/helmexec/exec.go
@@ -11,7 +11,7 @@ const (
 )
 
 type execer struct {
-	runner		Runner
+	runner      Runner
 	writer      io.Writer
 	kubeContext string
 	extra       []string
@@ -21,7 +21,7 @@ func NewHelmExec(writer io.Writer, kubeContext string) Interface {
 	return &execer{
 		writer:      writer,
 		kubeContext: kubeContext,
-		runner:	     new(CliRunner),
+		runner:      new(CliRunner),
 	}
 }
 

--- a/helmexec/exec_test.go
+++ b/helmexec/exec_test.go
@@ -1,0 +1,178 @@
+package helmexec
+
+import (
+	"bytes"
+	"io"
+	"reflect"
+	"testing"
+)
+
+// Mocking the command-line runner
+
+type MockRunner struct {
+	output []byte
+	err error
+}
+
+func (mock *MockRunner) Execute(cmd string, args []string) ([]byte, error) {
+	return []byte{}, nil
+}
+
+func NewMockExec(writer io.Writer, kubeContext string) Interface {
+	nhe := NewHelmExec(writer, kubeContext)
+	runner := &MockRunner{}
+	nhe.setRunner(runner)
+	return nhe
+}
+
+// Test methods
+
+func TestNewHelmExec(t *testing.T) {
+	buffer := bytes.NewBufferString("something")
+	helm := NewHelmExec(buffer, "dev")
+	if helm.getKubeContent() != "dev" {
+		t.Error("helmexec.NewHelmExec() - kubeContext")
+	}
+	if buffer.String() != "something" {
+		t.Error("helmexec.NewHelmExec() - changed buffer")
+	}
+	if len(helm.getExtra()) != 0 {
+		t.Error("helmexec.NewHelmExec() - extra args not empty")
+	}
+}
+
+func Test_SetExtraArgs(t *testing.T) {
+	helm := NewHelmExec(new(bytes.Buffer), "dev")
+	helm.SetExtraArgs()
+	if len(helm.getExtra()) != 0 {
+		t.Error("helmexec.SetExtraArgs() - passing no arguments should not change extra field")
+	}
+	helm.SetExtraArgs("foo")
+	if !reflect.DeepEqual(helm.getExtra(), []string{"foo"}) {
+		t.Error("helmexec.SetExtraArgs() - one extra argument missing")
+	}
+	helm.SetExtraArgs("alpha", "beta")
+	if !reflect.DeepEqual(helm.getExtra(), []string{"alpha", "beta"}) {
+		t.Error("helmexec.SetExtraArgs() - two extra arguments missing (overwriting the previous value)")
+	}
+}
+
+func Test_AddRepo(t *testing.T) {
+	var buffer bytes.Buffer
+	helm := NewMockExec(&buffer, "dev")
+	helm.AddRepo("myRepo", "https://repo.example.com/", "cert.pem", "key.pem")
+	expected := "exec: helm repo add myRepo https://repo.example.com/ --cert-file cert.pem --key-file key.pem --kube-context dev\n"
+	if buffer.String() != expected {
+		t.Errorf("helmexec.AddRepo()\nactual = %v\nexpect = %v", buffer.String(), expected)
+	}
+
+	buffer.Reset()
+	helm.AddRepo("myRepo", "https://repo.example.com/", "", "")
+	expected = "exec: helm repo add myRepo https://repo.example.com/ --kube-context dev\n"
+	if buffer.String() != expected {
+		t.Errorf("helmexec.AddRepo()\nactual = %v\nexpect = %v", buffer.String(), expected)
+	}
+}
+
+func Test_UpdateRepo(t *testing.T) {
+	var buffer bytes.Buffer
+	helm := NewMockExec(&buffer, "dev")
+	helm.UpdateRepo()
+	expected := "exec: helm repo update --kube-context dev\n"
+	if buffer.String() != expected {
+		t.Errorf("helmexec.UpdateRepo()\nactual = %v\nexpect = %v", buffer.String(), expected)
+	}
+}
+
+func Test_SyncRelease(t *testing.T) {
+	var buffer bytes.Buffer
+	helm := NewMockExec(&buffer, "dev")
+	helm.SyncRelease("release", "chart", "--timeout 10", "--wait")
+	expected := "exec: helm upgrade --install release chart --timeout 10 --wait --kube-context dev\n"
+	if buffer.String() != expected {
+		t.Errorf("helmexec.SyncRelease()\nactual = %v\nexpect = %v", buffer.String(), expected)
+	}
+
+	buffer.Reset()
+	helm.SyncRelease("release", "chart")
+	expected = "exec: helm upgrade --install release chart --kube-context dev\n"
+	if buffer.String() != expected {
+		t.Errorf("helmexec.AddRepo()\nactual = %v\nexpect = %v", buffer.String(), expected)
+	}
+}
+
+func Test_DecryptSecret(t *testing.T) {
+	var buffer bytes.Buffer
+	helm := NewMockExec(&buffer, "dev")
+	helm.DecryptSecret("secretName")
+	expected := "exec: helm secrets dec secretName --kube-context dev\n"
+	if buffer.String() != expected {
+		t.Errorf("helmexec.DecryptSecret()\nactual = %v\nexpect = %v", buffer.String(), expected)
+	}
+}
+
+func Test_DiffRelease(t *testing.T) {
+	var buffer bytes.Buffer
+	helm := NewMockExec(&buffer, "dev")
+	helm.DiffRelease("release", "chart", "--timeout 10", "--wait")
+	expected := "exec: helm diff release chart --timeout 10 --wait --kube-context dev\n"
+	if buffer.String() != expected {
+		t.Errorf("helmexec.DiffRelease()\nactual = %v\nexpect = %v", buffer.String(), expected)
+	}
+
+	buffer.Reset()
+	helm.DiffRelease("release", "chart")
+	expected = "exec: helm diff release chart --kube-context dev\n"
+	if buffer.String() != expected {
+		t.Errorf("helmexec.DiffRelease()\nactual = %v\nexpect = %v", buffer.String(), expected)
+	}
+}
+
+func Test_DeleteRelease(t *testing.T) {
+	var buffer bytes.Buffer
+	helm := NewMockExec(&buffer, "dev")
+	helm.DeleteRelease("release")
+	expected := "exec: helm delete --purge release --kube-context dev\n"
+	if buffer.String() != expected {
+		t.Errorf("helmexec.DeleteRelease()\nactual = %v\nexpect = %v", buffer.String(), expected)
+	}
+}
+
+func Test_exec(t *testing.T) {
+	var buffer bytes.Buffer
+	helm := NewMockExec(&buffer, "")
+	helm.exec("version")
+	expected := "exec: helm version\n"
+	if buffer.String() != expected {
+		t.Errorf("helmexec.exec()\nactual = %v\nexpect = %v", buffer.String(), expected)
+	}
+
+	helm = NewMockExec(nil, "dev")
+	ret, _ := helm.exec("diff")
+	if len(ret) != 0 {
+		t.Error("helmexec.exec() - expected empty return value")
+	}
+
+	buffer.Reset()
+	helm = NewMockExec(&buffer, "dev")
+	helm.exec("diff", "release", "chart", "--timeout 10", "--wait")
+	expected = "exec: helm diff release chart --timeout 10 --wait --kube-context dev\n"
+	if buffer.String() != expected {
+		t.Errorf("helmexec.exec()\nactual = %v\nexpect = %v", buffer.String(), expected)
+	}
+
+	buffer.Reset()
+	helm.exec("version")
+	expected = "exec: helm version --kube-context dev\n"
+	if buffer.String() != expected {
+		t.Errorf("helmexec.exec()\nactual = %v\nexpect = %v", buffer.String(), expected)
+	}
+
+	buffer.Reset()
+	helm.SetExtraArgs("foo")
+	helm.exec("version")
+	expected = "exec: helm version foo --kube-context dev\n"
+	if buffer.String() != expected {
+		t.Errorf("helmexec.exec()\nactual = %v\nexpect = %v", buffer.String(), expected)
+	}
+}

--- a/helmexec/exec_test.go
+++ b/helmexec/exec_test.go
@@ -11,7 +11,7 @@ import (
 
 type MockRunner struct {
 	output []byte
-	err error
+	err    error
 }
 
 func (mock *MockRunner) Execute(cmd string, args []string) ([]byte, error) {

--- a/helmexec/helmexec.go
+++ b/helmexec/helmexec.go
@@ -1,5 +1,7 @@
 package helmexec
 
+import "io"
+
 type Interface interface {
 	SetExtraArgs(args ...string)
 
@@ -11,4 +13,11 @@ type Interface interface {
 	DeleteRelease(name string) error
 
 	DecryptSecret(name string) (string, error)
+
+	// unit testing
+	exec(args ...string) ([]byte, error)
+	setRunner(runner Runner)
+	getExtra() []string
+	getKubeContent() string
+	getWriter() io.Writer
 }

--- a/helmexec/helmexec.go
+++ b/helmexec/helmexec.go
@@ -1,7 +1,5 @@
 package helmexec
 
-import "io"
-
 type Interface interface {
 	SetExtraArgs(args ...string)
 
@@ -13,11 +11,4 @@ type Interface interface {
 	DeleteRelease(name string) error
 
 	DecryptSecret(name string) (string, error)
-
-	// unit testing
-	exec(args ...string) ([]byte, error)
-	setRunner(runner Runner)
-	getExtra() []string
-	getKubeContent() string
-	getWriter() io.Writer
 }

--- a/helmexec/runner.go
+++ b/helmexec/runner.go
@@ -15,10 +15,10 @@ type Runner interface {
 	Execute(cmd string, args []string) ([]byte, error)
 }
 
-type CliRunner struct {}
+type CliRunner struct{}
 
 func (cli CliRunner) Execute(cmd string, args []string) ([]byte, error) {
-	dir, err := ioutil.TempDir("", tmpPrefix + cmd + tmpSuffix)
+	dir, err := ioutil.TempDir("", tmpPrefix+cmd+tmpSuffix)
 	if err != nil {
 		return nil, err
 	}

--- a/helmexec/runner.go
+++ b/helmexec/runner.go
@@ -15,9 +15,9 @@ type Runner interface {
 	Execute(cmd string, args []string) ([]byte, error)
 }
 
-type CliRunner struct{}
+type ShellRunner struct{}
 
-func (cli CliRunner) Execute(cmd string, args []string) ([]byte, error) {
+func (shell ShellRunner) Execute(cmd string, args []string) ([]byte, error) {
 	dir, err := ioutil.TempDir("", tmpPrefix+cmd+tmpSuffix)
 	if err != nil {
 		return nil, err

--- a/helmexec/runner.go
+++ b/helmexec/runner.go
@@ -1,0 +1,30 @@
+package helmexec
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+)
+
+const (
+	tmpPrefix = "helmfile-"
+	tmpSuffix = "-exec"
+)
+
+type Runner interface {
+	Execute(cmd string, args []string) ([]byte, error)
+}
+
+type CliRunner struct {}
+
+func (cli CliRunner) Execute(cmd string, args []string) ([]byte, error) {
+	dir, err := ioutil.TempDir("", tmpPrefix + cmd + tmpSuffix)
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(dir)
+
+	preparedCmd := exec.Command(cmd, args...)
+	preparedCmd.Dir = dir
+	return preparedCmd.CombinedOutput()
+}

--- a/main.go
+++ b/main.go
@@ -278,7 +278,7 @@ func before(c *cli.Context) (*state.HelmState, helmexec.Interface, error) {
 		clean(st, errs)
 	}()
 
-	return st, helmexec.NewHelmExec(writer, kubeContext), nil
+	return st, helmexec.New(writer, kubeContext), nil
 }
 
 func clean(state *state.HelmState, errs []error) error {


### PR DESCRIPTION
I was looking at the code and noticed the lack of unit tests for the `helmexec` package, so I decided to add a basic first version, bringing statement coverage to 83.7%. There's still a lot of test cases missing (like empty or nil arguments), but they would have required actual code changes to support the edge cases. I wanted to just describe existing, happy-path functionality first.

Writing the tests required me to factor out the actual command-line execution bit into the `Runner`.

Beware, I'm a go beginner. I'd appreciate a critical look at this, especially the package-local functions in the interface in `helmexec.go`. Go crazy with critique :P