### PR TITLE
Sync command: change the way we apply args

### DIFF
--- a/main.go
+++ b/main.go
@@ -193,16 +193,16 @@ func main() {
 					os.Exit(1)
 				}
 
-				args := c.String("args")
-				if len(args) > 0 {
-					helm.SetExtraArgs(strings.Split(args, " ")...)
-				}
-
 				if errs := state.UpdateDeps(helm); errs != nil && len(errs) > 0 {
 					for _, err := range errs {
 						fmt.Printf("err: %s\n", err.Error())
 					}
 					os.Exit(1)
+				}
+
+				args := c.String("args")
+				if len(args) > 0 {
+					helm.SetExtraArgs(strings.Split(args, " ")...)
 				}
 
 				values := c.StringSlice("values")


### PR DESCRIPTION
As discussed in #26, the previous PR #77 prevent applying some args like `"--wait"` for the sync command.

The purpose of this PR is to apply args flag only to sync command and not `UpdateDeps`