### PR TITLE
Fix race condition. Add concurrency option similiar to DiffReleases

### DIFF
--- a/main.go
+++ b/main.go
@@ -134,6 +134,11 @@ func main() {
 					Name:  "sync-repos",
 					Usage: "enable a repo sync prior to diffing",
 				},
+				cli.IntFlag{
+					Name:  "concurrency",
+					Value: 0,
+					Usage: "maximum number of concurrent helm processes to run, 0 is unlimited",
+				},
 			},
 			Action: func(c *cli.Context) error {
 				state, helm, err := before(c)
@@ -156,8 +161,9 @@ func main() {
 				}
 
 				values := c.StringSlice("values")
+				workers := c.Int("concurrency")
 
-				errs := state.DiffReleases(helm, values)
+				errs := state.DiffReleases(helm, values, workers)
 				return clean(state, errs)
 			},
 		},


### PR DESCRIPTION
This fixes the race condition mentioned in #94. I tried to implement it similar to DiffReleases, but used wait groups instead of the done channel. Also I added the same concurrency option that DiffReleases uses. Default is as much workers as releases, same as in DiffReleases.