### PR TITLE
Fix resolving relative paths on windows

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -15,7 +15,6 @@ import (
 	"github.com/roboll/helmfile/helmexec"
 
 	"bytes"
-	"path"
 	"regexp"
 
 	yaml "gopkg.in/yaml.v1"
@@ -91,7 +90,7 @@ func ReadFromFile(file string) (*HelmState, error) {
 func readFromYaml(content []byte, file string) (*HelmState, error) {
 	var state HelmState
 
-	state.BaseChartPath, _ = filepath.Abs(path.Dir(file))
+	state.BaseChartPath, _ = filepath.Abs(filepath.Dir(file))
 	if err := yaml.Unmarshal(content, &state); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
`path.Dir()` does not support Windows-style directory separators (backslashes). 
This caused invocations such as `helmfile -f subdir\helmfile.yml` to fail. 

Fixed by using `filepath.Dir()` instead.