### PR TITLE
build consistent statically linked binary for docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     working_directory: /go/src/github.com/roboll/helmfile
     steps:
       - checkout
-      - run: make static-linux
+      - run: make build
       - persist_to_workspace:
           root: /go/src/github.com/roboll/helmfile
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,11 +4,11 @@ jobs:
 
   build:
     docker:
-      - image: circleci/golang:1.10
+      - image: circleci/golang:1.10.1
     working_directory: /go/src/github.com/roboll/helmfile
     steps:
       - checkout
-      - run: make build
+      - run: make static-linux
       - persist_to_workspace:
           root: /go/src/github.com/roboll/helmfile
           paths:
@@ -16,7 +16,7 @@ jobs:
 
   test:
     docker:
-      - image: circleci/golang:1.10
+      - image: circleci/golang:1.10.1
     working_directory: /go/src/github.com/roboll/helmfile
     steps:
       - checkout
@@ -76,7 +76,7 @@ jobs:
 
   release:
     docker:
-      - image: circleci/golang:1.10
+      - image: circleci/golang:1.10.1
     working_directory: /go/src/github.com/roboll/helmfile
     steps:
     - checkout
@@ -84,7 +84,6 @@ jobs:
     - run:
         command: |
           docker login -u="$DOCKER_USER" -p="$DOCKER_PASS" quay.io
-          make tools
           BUILD_URL="$CIRCLE_BUILD_URL" make push release
 
 workflows:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,16 @@
+FROM golang:1.10.1-alpine3.7 as builder
+
+RUN apk add --no-cache make git
+WORKDIR /go/src/github.com/roboll/helmfile/
+
+COPY Makefile /go/src/github.com/roboll/helmfile/Makefile
+RUN make tools
+
+COPY . /go/src/github.com/roboll/helmfile/
+RUN make static-linux
+
+# -----------------------------------------------------------------------------
+
 FROM alpine:3.7
 
 RUN apk add --no-cache ca-certificates
@@ -11,6 +24,6 @@ RUN wget ${HELM_LOCATION}/${HELM_FILENAME} && \
     tar zxf ${HELM_FILENAME} && mv /linux-amd64/helm /usr/local/bin/ && \
     rm ${HELM_FILENAME} && rm -r /linux-amd64
 
-COPY dist/helmfile_linux_amd64 /usr/local/bin/helmfile
+COPY --from=builder /go/src/github.com/roboll/helmfile/dist/helmfile_linux_amd64 /usr/local/bin/helmfile
 
 CMD ["/usr/local/bin/helmfile"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,6 @@ FROM golang:1.10.1-alpine3.7 as builder
 
 RUN apk add --no-cache make git
 WORKDIR /go/src/github.com/roboll/helmfile/
-
-COPY Makefile /go/src/github.com/roboll/helmfile/Makefile
-RUN make tools
-
 COPY . /go/src/github.com/roboll/helmfile/
 RUN make static-linux
 

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ cross:
 .PHONY: cross
 
 static-linux:
-	env CGO_ENABLED=0 gox -osarch="linux/amd64" -output "dist/{{.Dir}}_{{.OS}}_{{.Arch}}" -ldflags '-X main.Version=${TAG}' ${TARGETS}
+	env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o "dist/helmfile_linux_amd64" -ldflags '-X main.Version=${TAG}' ${TARGETS}
 .PHONY: linux
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,10 @@ cross:
 	gox -os '!freebsd !netbsd' -arch '!arm' -output "dist/{{.Dir}}_{{.OS}}_{{.Arch}}" -ldflags '-X main.Version=${TAG}' ${TARGETS}
 .PHONY: cross
 
+static-linux:
+	env CGO_ENABLED=0 gox -osarch="linux/amd64" -output "dist/{{.Dir}}_{{.OS}}_{{.Arch}}" -ldflags '-X main.Version=${TAG}' ${TARGETS}
+.PHONY: linux
+
 clean:
 	rm dist/helmfile_*
 .PHONY: clean
@@ -41,7 +45,7 @@ release: pristine cross
 	@ghr -b ${BODY} -t ${GITHUB_TOKEN} -u ${ORG} -recreate ${TAG} dist
 .PHONY: release
 
-image: cross
+image:
 	docker build -t quay.io/${ORG}/helmfile:${TAG} .
 
 run: image


### PR DESCRIPTION
* use golang 1.10.1 images everywhere
* introduce a `static-linux` target to build a statically linked 64-bit binary only for the docker image
* use a multi-stage dockerfile for a consistent build environment

This resolves #123.