### PR TITLE
retry curl to reduce risk of race condition

### DIFF
--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -20,9 +20,22 @@ kubectl="kubectl --context=minikube --namespace=${test_ns}"
 # FUNCTIONS ----------------------------------------------------------------------------------------------------------
 
 function wait_deploy_ready() {
-    $kubectl rollout status deployment ${1}
-    while [ "$($kubectl get deploy ${1} -o=jsonpath='{.status.readyReplicas}')" == "0" ]; do
+    ${kubectl} rollout status deployment ${1}
+    while [ "$(${kubectl} get deploy ${1} -o=jsonpath='{.status.readyReplicas}')" == "0" ]; do
         info "Waiting for deployment ${1} to be ready"
+        sleep 1
+    done
+}
+function retry() {
+    local -r max=${1}
+    local -r command=${2}
+    n=0
+    retry_result=0
+    until [ ${n} -ge ${max} ]; do
+        info "Executing: ${command} (attempt $((n+1)))"
+        ${command} && break  # substitute your command here
+        retry_result=$?
+        n=$[$n+1]
         sleep 1
     done
 }
@@ -32,9 +45,8 @@ function wait_deploy_ready() {
 set -e
 info "Using namespace: ${test_ns}"
 info "Using Helm version: $(helm version --short --client | grep -o v.*$)"
-$helm init --wait --override spec.template.spec.automountServiceAccountToken=true
-$helmfile -v
-$kubectl get namespace ${test_ns} &> /dev/null && warn "Namespace ${test_ns} exists, from a previous test run?"
+${helm} init --wait --override spec.template.spec.automountServiceAccountToken=true
+${kubectl} get namespace ${test_ns} &> /dev/null && warn "Namespace ${test_ns} exists, from a previous test run?"
 $kubectl create namespace ${test_ns} || fail "Could not create namespace ${test_ns}"
 trap "{ $kubectl delete namespace ${test_ns}; }" EXIT # remove namespace whenever we exit this script
 
@@ -42,13 +54,14 @@ trap "{ $kubectl delete namespace ${test_ns}; }" EXIT # remove namespace wheneve
 # TEST CASES----------------------------------------------------------------------------------------------------------
 
 test_start "happypath - simple rollout of httpbin chart"
-$helmfile -f ${dir}/happypath.yaml sync
+info "Syncing ${dir}/happypath.yaml"
+${helmfile} -f ${dir}/happypath.yaml sync
 wait_deploy_ready httpbin-httpbin
-curl --fail $(minikube service --url --namespace=${test_ns} httpbin-httpbin)/status/200 \
-    || fail "httpbin failed to return 200 OK"
-$helmfile -f ${dir}/happypath.yaml delete
-$helm status --namespace=${test_ns} httpbin &> /dev/null \
-    && fail "release should not exist anymore after a delete"
+retry 3 "curl --fail $(minikube service --url --namespace=${test_ns} httpbin-httpbin)/status/200"
+[ ${retry_result} -eq 0 ] || fail "httpbin failed to return 200 OK"
+info "Deleting release"
+${helmfile} -f ${dir}/happypath.yaml delete
+${helm} status --namespace=${test_ns} httpbin &> /dev/null && fail "release should not exist anymore after a delete"
 test_pass "happypath"
 
 


### PR DESCRIPTION
I am not sure why #103 happens, but I suspect it might be a rare occasion of the pod reporting healthy but the virtual network or service discovery has not fully been initialized. This PR retries the `curl` call to the service to minimize this risk. It's more of a prophylactic measure "into the dark", but it might help.