### PR TITLE
Introduce template function `required_env`

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -107,7 +107,21 @@ func readFromYaml(content []byte, file string) (*HelmState, error) {
 }
 
 func stringTemplate() *template.Template {
-	return template.New("stringTemplate").Funcs(sprig.TxtFuncMap())
+	funcMap := sprig.TxtFuncMap()
+	alterFuncMap(&funcMap)
+	return template.New("stringTemplate").Funcs(funcMap)
+}
+
+func alterFuncMap(funcMap *template.FuncMap) {
+	(*funcMap)["requiredEnv"] = getRequiredEnv
+}
+
+func getRequiredEnv(name string) (string, error) {
+	if val, exists := os.LookupEnv(name); exists && len(val) > 0 {
+		return val, nil
+	}
+
+	return "", fmt.Errorf("required env var `%s` is not set", name)
 }
 
 func renderTemplateString(s string) (string, error) {

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -351,6 +351,25 @@ func Test_renderTemplateString(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "required env var",
+			args: args{
+				s: "{{ requiredEnv \"HF_TEST\" }}",
+				envs: map[string]string{
+					"HF_TEST": "value",
+				},
+			},
+			want:    "value",
+			wantErr: false,
+		},
+		{
+			name: "required env var not set",
+			args: args{
+				s:    "{{ requiredEnv \"HF_TEST_NONE\" }}",
+				envs: map[string]string{},
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
The `required_env` function allows you to declare a particular environment variable as required for template rendering.
If the environment variable is unset or empty, the template rendering will fail with an error message.

Example:

```yaml
releases:
  - name: {{ required_env "NAME" }}-vault
    namespace: {{ required_env "NAME" }}
    chart: roboll/vault-secret-manager
    set:
      - name: proxy.domain
        value: {{ required_env "PLATFORM_ID" }}.my-domain.com
```