### PR TITLE
Make purge optional when running "helmfile delete"

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,12 @@ To supply the diff functionality Helmfile needs the `helm diff` plugin installed
 you should be able to simply execute `helm plugin install https://github.com/databus23/helm-diff`. For more details
 please look at their [documentation](https://github.com/databus23/helm-diff#helm-diff-plugin).
 
+### delete
+
+The `helmfile delete` sub-command deletes all the releases defined in the manfiests
+
+Note that `delete` doesn't purge releases. So `helmfile delete && helmfile sync` results in sync failed due to that releases names are not deleted but preserved for future references. If you really want to remove releases for reuse, add `--purge` flag to run it like `helmfile delete --purge`.
+
 ### secrets
 
 The `secrets` parameter in a `helmfile.yaml` causes the [helm-secrets](https://github.com/futuresimple/helm-secrets) plugin to be executed to decrypt the file.

--- a/helmexec/exec.go
+++ b/helmexec/exec.go
@@ -79,8 +79,8 @@ func (helm *execer) DiffRelease(name, chart string, flags ...string) error {
 	return err
 }
 
-func (helm *execer) DeleteRelease(name string) error {
-	out, err := helm.exec("delete", "--purge", name)
+func (helm *execer) DeleteRelease(name string, flags ...string) error {
+	out, err := helm.exec(append([]string{"delete", name}, flags...)...)
 	helm.write(out)
 	return err
 }

--- a/helmexec/exec_test.go
+++ b/helmexec/exec_test.go
@@ -149,7 +149,16 @@ func Test_DeleteRelease(t *testing.T) {
 	var buffer bytes.Buffer
 	helm := MockExecer(&buffer, "dev")
 	helm.DeleteRelease("release")
-	expected := "exec: helm delete --purge release --kube-context dev\n"
+	expected := "exec: helm delete release --kube-context dev\n"
+	if buffer.String() != expected {
+		t.Errorf("helmexec.DeleteRelease()\nactual = %v\nexpect = %v", buffer.String(), expected)
+	}
+}
+func Test_DeleteRelease_Flags(t *testing.T) {
+	var buffer bytes.Buffer
+	helm := MockExecer(&buffer, "dev")
+	helm.DeleteRelease("release", "--purge")
+	expected := "exec: helm delete release --purge --kube-context dev\n"
 	if buffer.String() != expected {
 		t.Errorf("helmexec.DeleteRelease()\nactual = %v\nexpect = %v", buffer.String(), expected)
 	}

--- a/helmexec/helmexec.go
+++ b/helmexec/helmexec.go
@@ -10,7 +10,7 @@ type Interface interface {
 	SyncRelease(name, chart string, flags ...string) error
 	DiffRelease(name, chart string, flags ...string) error
 	ReleaseStatus(name string) error
-	DeleteRelease(name string) error
+	DeleteRelease(name string, flags ...string) error
 
 	DecryptSecret(name string) (string, error)
 }

--- a/main.go
+++ b/main.go
@@ -252,14 +252,22 @@ func main() {
 		},
 		{
 			Name:  "delete",
-			Usage: "delete charts from state file (helm delete)",
+			Usage: "delete releases from state file (helm delete)",
+			Flags: []cli.Flag{
+				cli.BoolFlag{
+					Name:  "purge",
+					Usage: "purge releases i.e. free release names and histories",
+				},
+			},
 			Action: func(c *cli.Context) error {
 				state, helm, err := before(c)
 				if err != nil {
 					return err
 				}
 
-				errs := state.DeleteReleases(helm)
+				purge := c.Bool("purge")
+
+				errs := state.DeleteReleases(helm, purge)
 				return clean(state, errs)
 			},
 		},

--- a/state/state.go
+++ b/state/state.go
@@ -356,14 +356,18 @@ func (state *HelmState) ReleaseStatuses(helm helmexec.Interface, workerLimit int
 }
 
 // DeleteReleases wrapper for executing helm delete on the releases
-func (state *HelmState) DeleteReleases(helm helmexec.Interface) []error {
+func (state *HelmState) DeleteReleases(helm helmexec.Interface, purge bool) []error {
 	var wg sync.WaitGroup
 	errs := []error{}
 
 	for _, release := range state.Releases {
 		wg.Add(1)
 		go func(wg *sync.WaitGroup, release ReleaseSpec) {
-			if err := helm.DeleteRelease(release.Name); err != nil {
+			flags := []string{}
+			if purge {
+				flags = append(flags, "--purge")
+			}
+			if err := helm.DeleteRelease(release.Name, flags...); err != nil {
 				errs = append(errs, err)
 			}
 			wg.Done()

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -546,7 +546,7 @@ func (helm *mockHelmExec) ReleaseStatus(release string) error {
 	helm.releases = append(helm.releases, mockRelease{name: release, flags: []string{}})
 	return nil
 }
-func (helm *mockHelmExec) DeleteRelease(name string) error {
+func (helm *mockHelmExec) DeleteRelease(name string, flags ...string) error {
 	return nil
 }
 func (helm *mockHelmExec) DecryptSecret(name string) (string, error) {


### PR DESCRIPTION
`helmfile delete` has been implying `--purge` but it is not the case since this change.

The new behavior is:
- `helmfile delete` to delete releases, but without purging them
- `helmfile delete --purge` to actually purge releases.

Resolves #71