### PR TITLE
Don't prefix base path to absolute path

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -481,7 +481,12 @@ func flagsForRelease(helm helmexec.Interface, basePath string, release *ReleaseS
 	for _, value := range release.Values {
 		switch typedValue := value.(type) {
 		case string:
-			path := filepath.Join(basePath, typedValue)
+			var path string
+			if filepath.IsAbs(typedValue) {
+				path = typedValue
+			} else {
+				path = filepath.Join(basePath, typedValue)
+			}
 			if _, err := os.Stat(path); os.IsNotExist(err) {
 				return nil, err
 			}


### PR DESCRIPTION
If an entry in the `values` section of a helmfile is an absolute
path, then it would be erroneously prefixed with the base path.

This would cause `helmfile sync` to fail because the value.yaml file
would not exist at the incorrectly prefixed path.