### PR TITLE
Add helmfile test sub-command

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ COMMANDS:
      sync    sync all resources from state file (repos, charts and local chart deps)
      status  retrieve status of releases in state file
      delete  delete charts from state file (helm delete)
+     test    tets releases from state file (helm test)
 
 GLOBAL OPTIONS:
    --file FILE, -f FILE         load config from FILE (default: "helmfile.yaml")
@@ -199,6 +200,12 @@ The `secrets` parameter in a `helmfile.yaml` causes the [helm-secrets](https://g
 To supply the secret functionality Helmfile needs the `helm secrets` plugin installed. For Helm 2.3+
 you should be able to simply execute `helm plugin install https://github.com/futuresimple/helm-secrets
 `.
+
+### test
+
+The `helmfile test` sub-command runs a `helm test` against specified releases in the manifest, default to all
+
+Use `--cleanup` to delete pods upon completion.
 
 ## Paths Overview
 Using manifest files in conjunction with command line argument can be a bit confusing.

--- a/helmexec/exec.go
+++ b/helmexec/exec.go
@@ -85,6 +85,12 @@ func (helm *execer) DeleteRelease(name string, flags ...string) error {
 	return err
 }
 
+func (helm *execer) TestRelease(name string, flags ...string) error {
+	out, err := helm.exec(append([]string{"test", name}, flags...)...)
+	helm.write(out)
+	return err
+}
+
 func (helm *execer) exec(args ...string) ([]byte, error) {
 	cmdargs := args
 	if len(helm.extra) > 0 {
@@ -102,3 +108,4 @@ func (helm *execer) write(out []byte) {
 		helm.writer.Write(out)
 	}
 }
+

--- a/helmexec/exec.go
+++ b/helmexec/exec.go
@@ -108,4 +108,3 @@ func (helm *execer) write(out []byte) {
 		helm.writer.Write(out)
 	}
 }
-

--- a/helmexec/exec_test.go
+++ b/helmexec/exec_test.go
@@ -164,6 +164,25 @@ func Test_DeleteRelease_Flags(t *testing.T) {
 	}
 }
 
+func Test_TestRelease(t *testing.T) {
+	var buffer bytes.Buffer
+	helm := MockExecer(&buffer, "dev")
+	helm.TestRelease("release")
+	expected := "exec: helm test release --kube-context dev\n"
+	if buffer.String() != expected {
+		t.Errorf("helmexec.TestRelease()\nactual = %v\nexpect = %v", buffer.String(), expected)
+	}
+}
+func Test_TestRelease_Flags(t *testing.T) {
+	var buffer bytes.Buffer
+	helm := MockExecer(&buffer, "dev")
+	helm.TestRelease("release", "--cleanup")
+	expected := "exec: helm test release --cleanup --kube-context dev\n"
+	if buffer.String() != expected {
+		t.Errorf("helmexec.TestRelease()\nactual = %v\nexpect = %v", buffer.String(), expected)
+	}
+}
+
 func Test_ReleaseStatus(t *testing.T) {
 	var buffer bytes.Buffer
 	helm := MockExecer(&buffer, "dev")

--- a/helmexec/exec_test.go
+++ b/helmexec/exec_test.go
@@ -176,8 +176,8 @@ func Test_TestRelease(t *testing.T) {
 func Test_TestRelease_Flags(t *testing.T) {
 	var buffer bytes.Buffer
 	helm := MockExecer(&buffer, "dev")
-	helm.TestRelease("release", "--cleanup")
-	expected := "exec: helm test release --cleanup --kube-context dev\n"
+	helm.TestRelease("release", "--cleanup", "--timeout", "60")
+	expected := "exec: helm test release --cleanup --timeout 60 --kube-context dev\n"
 	if buffer.String() != expected {
 		t.Errorf("helmexec.TestRelease()\nactual = %v\nexpect = %v", buffer.String(), expected)
 	}

--- a/helmexec/helmexec.go
+++ b/helmexec/helmexec.go
@@ -11,6 +11,8 @@ type Interface interface {
 	DiffRelease(name, chart string, flags ...string) error
 	ReleaseStatus(name string) error
 	DeleteRelease(name string, flags ...string) error
+	TestRelease(name string, flags ...string) error
 
 	DecryptSecret(name string) (string, error)
 }
+

--- a/helmexec/helmexec.go
+++ b/helmexec/helmexec.go
@@ -15,4 +15,3 @@ type Interface interface {
 
 	DecryptSecret(name string) (string, error)
 }
-

--- a/main.go
+++ b/main.go
@@ -282,7 +282,12 @@ func main() {
 				cli.StringFlag{
 					Name:  "args",
 					Value: "",
-					Usage: "pass args to helm exec",
+					Usage: "pass additional args to helm exec",
+				},
+				cli.IntFlag{
+					Name:  "timeout",
+					Value: 300,
+					Usage: "maximum time for tests to run before being considered failed",
 				},
 			},
 			Action: func(c *cli.Context) error {
@@ -292,13 +297,14 @@ func main() {
 				}
 
 				cleanup := c.Bool("cleanup")
+				timeout := c.Int("timeout")
 
 				args := c.String("args")
 				if len(args) > 0 {
 					helm.SetExtraArgs(strings.Split(args, " ")...)
 				}
 
-				errs := state.TestReleases(helm, cleanup)
+				errs := state.TestReleases(helm, cleanup, timeout)
 				return clean(state, errs)
 			},
 		},

--- a/main.go
+++ b/main.go
@@ -271,6 +271,21 @@ func main() {
 				return clean(state, errs)
 			},
 		},
+		{
+			Name:  "test",
+			Usage: "test releases from state file (helm test)",
+			Flags: []cli.Flag{
+			},
+			Action: func(c *cli.Context) error {
+				state, helm, err := before(c)
+				if err != nil {
+					return err
+				}
+
+				errs := state.TestReleases(helm)
+				return clean(state, errs)
+			},
+		},
 	}
 
 	err := app.Run(os.Args)
@@ -357,3 +372,4 @@ func clean(state *state.HelmState, errs []error) error {
 	}
 	return nil
 }
+

--- a/main.go
+++ b/main.go
@@ -275,6 +275,10 @@ func main() {
 			Name:  "test",
 			Usage: "test releases from state file (helm test)",
 			Flags: []cli.Flag{
+				cli.BoolFlag{
+					Name:  "cleanup",
+					Usage: "delete test pods upon completion",
+				},
 			},
 			Action: func(c *cli.Context) error {
 				state, helm, err := before(c)
@@ -282,7 +286,9 @@ func main() {
 					return err
 				}
 
-				errs := state.TestReleases(helm)
+				cleanup := c.Bool("cleanup")
+
+				errs := state.TestReleases(helm, cleanup)
 				return clean(state, errs)
 			},
 		},

--- a/main.go
+++ b/main.go
@@ -279,6 +279,11 @@ func main() {
 					Name:  "cleanup",
 					Usage: "delete test pods upon completion",
 				},
+				cli.StringFlag{
+					Name:  "args",
+					Value: "",
+					Usage: "pass args to helm exec",
+				},
 			},
 			Action: func(c *cli.Context) error {
 				state, helm, err := before(c)
@@ -287,6 +292,11 @@ func main() {
 				}
 
 				cleanup := c.Bool("cleanup")
+
+				args := c.String("args")
+				if len(args) > 0 {
+					helm.SetExtraArgs(strings.Split(args, " ")...)
+				}
 
 				errs := state.TestReleases(helm, cleanup)
 				return clean(state, errs)
@@ -378,4 +388,3 @@ func clean(state *state.HelmState, errs []error) error {
 	}
 	return nil
 }
-

--- a/state/state.go
+++ b/state/state.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"text/template"
@@ -382,7 +383,7 @@ func (state *HelmState) DeleteReleases(helm helmexec.Interface, purge bool) []er
 	return nil
 }
 
-func (state *HelmState) TestReleases(helm helmexec.Interface, cleanup bool) []error {
+func (state *HelmState) TestReleases(helm helmexec.Interface, cleanup bool, timeout int) []error {
 	var wg sync.WaitGroup
 	errs := []error{}
 
@@ -393,6 +394,7 @@ func (state *HelmState) TestReleases(helm helmexec.Interface, cleanup bool) []er
 			if cleanup {
 				flags = append(flags, "--cleanup")
 			}
+			flags = append(flags, "--timeout", strconv.Itoa(timeout))
 			if err := helm.TestRelease(release.Name, flags...); err != nil {
 				errs = append(errs, err)
 			}

--- a/state/state.go
+++ b/state/state.go
@@ -382,7 +382,7 @@ func (state *HelmState) DeleteReleases(helm helmexec.Interface, purge bool) []er
 	return nil
 }
 
-func (state *HelmState) TestReleases(helm helmexec.Interface) []error {
+func (state *HelmState) TestReleases(helm helmexec.Interface, cleanup bool) []error {
 	var wg sync.WaitGroup
 	errs := []error{}
 
@@ -390,6 +390,9 @@ func (state *HelmState) TestReleases(helm helmexec.Interface) []error {
 		wg.Add(1)
 		go func(wg *sync.WaitGroup, release ReleaseSpec) {
 			flags := []string{}
+			if cleanup {
+				flags = append(flags, "--cleanup")
+			}
 			if err := helm.TestRelease(release.Name, flags...); err != nil {
 				errs = append(errs, err)
 			}

--- a/state/state.go
+++ b/state/state.go
@@ -383,6 +383,7 @@ func (state *HelmState) DeleteReleases(helm helmexec.Interface, purge bool) []er
 	return nil
 }
 
+// TestReleases wrapper for executing helm test on the releases
 func (state *HelmState) TestReleases(helm helmexec.Interface, cleanup bool, timeout int) []error {
 	var wg sync.WaitGroup
 	errs := []error{}

--- a/state/state.go
+++ b/state/state.go
@@ -594,4 +594,3 @@ func escape(value string) string {
 	intermediate = strings.Replace(intermediate, "}", "\\}", -1)
 	return strings.Replace(intermediate, ",", "\\,", -1)
 }
-

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -552,6 +552,9 @@ func (helm *mockHelmExec) DeleteRelease(name string, flags ...string) error {
 func (helm *mockHelmExec) DecryptSecret(name string) (string, error) {
 	return "", nil
 }
+func (helm *mockHelmExec) TestRelease(name string, flags ...string) error {
+	return nil
+}
 
 func TestHelmState_SyncRepos(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Ref: https://github.com/roboll/helmfile/issues/144

**Feature**
An additional sub-command to the helmfile binary; helmfile test

**Why**
Helm provides helm test (https://github.com/kubernetes/helm/blob/master/docs/chart_tests.md) as a method to run automated tests post chart install to ensure things are working as they should be.

It would be nice to be able to run something like helmfile test against a particular helmfile in order to run helm tests against all charts/releases defined in the file. Either as part of the sync (i.e. helmfile sync --test) to be ran immediately after the corresponding chart is installed, or as a separate command ran after a sync (i.e. helmfile test).

A chart without tests will exit with a 0 status, so it can be safely ran against any charts.

**Notes**

`--cleanup` (bool) & `--timeout` (default: 300) are available as first class arguments. Additional arguments can be passed to the helm binary as with other sub commands using `--args=`