### PR TITLE
Add helmfile lint support

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ COMMANDS:
      repos   sync repositories from state file (helm repo add && helm repo update)
      charts  sync charts from state file (helm upgrade --install)
      diff    diff charts from state file against env (helm diff)
+     lint    lint charts from state file (helm lint)
      sync    sync all resources from state file (repos, charts and local chart deps)
      status  retrieve status of releases in state file
      delete  delete charts from state file (helm delete)
@@ -210,6 +211,10 @@ you should be able to simply execute `helm plugin install https://github.com/fut
 The `helmfile test` sub-command runs a `helm test` against specified releases in the manifest, default to all
 
 Use `--cleanup` to delete pods upon completion.
+
+### lint
+
+The `helmfile lint` sub-command runs a `helm lint` across all of the charts/releases defined in the manifest. Non local charts will be fetched into a temporary folder which will be deleted once the task is completed.
 
 ## Paths Overview
 Using manifest files in conjunction with command line argument can be a bit confusing.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ repositories:
     url: http://roboll.io/charts
     certFile: optional_client_cert
     keyFile: optional_client_key
+    username: optional_username
+    password: optional_password
 
 context: kube-context					 # kube-context (--kube-context)
 
@@ -76,8 +78,8 @@ releases:
 
 Helmfile uses [Go templates](https://godoc.org/text/template) for templating your helmfile.yaml. While go ships several built-in functions, we have added all of the functions in the [Sprig library](https://godoc.org/github.com/Masterminds/sprig).
 
-We also added one special template function: `requiredEnv`.  
-The `required_env` function allows you to declare a particular environment variable as required for template rendering.  
+We also added one special template function: `requiredEnv`.
+The `required_env` function allows you to declare a particular environment variable as required for template rendering.
 If the environment variable is unset or empty, the template rendering will fail with an error message.
 
 ## Using environment variables
@@ -177,6 +179,8 @@ The `helmfile sync` sub-command sync your cluster state as described in your `he
 
 Under the covers, Helmfile executes `helm upgrade --install` for each `release` declared in the manifest, by optionally decrypting [secrets](#secrets) to be consumed as helm chart values. It also updates specified chart repositories and updates the
 dependencies of any referenced local charts.
+
+For Helm 2.9+ you can use a username and password to authenticate to a remote repository. WARNING - repository password will be exposed unmasked in console using literal value or environment variable.
 
 ### diff
 

--- a/helmexec/exec.go
+++ b/helmexec/exec.go
@@ -82,6 +82,18 @@ func (helm *execer) DiffRelease(name, chart string, flags ...string) error {
 	return err
 }
 
+func (helm *execer) Lint(chart string, flags ...string) error {
+	out, err := helm.exec(append([]string{"lint", chart}, flags...)...)
+	helm.write(out)
+	return err
+}
+
+func (helm *execer) Fetch(chart string, flags ...string) error {
+	out, err := helm.exec(append([]string{"fetch", chart}, flags...)...)
+	helm.write(out)
+	return err
+}
+
 func (helm *execer) DeleteRelease(name string, flags ...string) error {
 	out, err := helm.exec(append([]string{"delete", name}, flags...)...)
 	helm.write(out)

--- a/helmexec/exec.go
+++ b/helmexec/exec.go
@@ -30,11 +30,14 @@ func (helm *execer) SetExtraArgs(args ...string) {
 	helm.extra = args
 }
 
-func (helm *execer) AddRepo(name, repository, certfile, keyfile string) error {
+func (helm *execer) AddRepo(name, repository, certfile, keyfile, username, password string) error {
 	var args []string
 	args = append(args, "repo", "add", name, repository)
 	if certfile != "" && keyfile != "" {
 		args = append(args, "--cert-file", certfile, "--key-file", keyfile)
+	}
+	if username != "" && password != "" {
+		args = append(args, "--username", username, "--password", password)
 	}
 	out, err := helm.exec(args...)
 	helm.write(out)

--- a/helmexec/exec_test.go
+++ b/helmexec/exec_test.go
@@ -59,15 +59,22 @@ func Test_SetExtraArgs(t *testing.T) {
 func Test_AddRepo(t *testing.T) {
 	var buffer bytes.Buffer
 	helm := MockExecer(&buffer, "dev")
-	helm.AddRepo("myRepo", "https://repo.example.com/", "cert.pem", "key.pem")
+	helm.AddRepo("myRepo", "https://repo.example.com/", "cert.pem", "key.pem", "", "")
 	expected := "exec: helm repo add myRepo https://repo.example.com/ --cert-file cert.pem --key-file key.pem --kube-context dev\n"
 	if buffer.String() != expected {
 		t.Errorf("helmexec.AddRepo()\nactual = %v\nexpect = %v", buffer.String(), expected)
 	}
 
 	buffer.Reset()
-	helm.AddRepo("myRepo", "https://repo.example.com/", "", "")
+	helm.AddRepo("myRepo", "https://repo.example.com/", "", "", "", "")
 	expected = "exec: helm repo add myRepo https://repo.example.com/ --kube-context dev\n"
+	if buffer.String() != expected {
+		t.Errorf("helmexec.AddRepo()\nactual = %v\nexpect = %v", buffer.String(), expected)
+	}
+
+	buffer.Reset()
+	helm.AddRepo("myRepo", "https://repo.example.com/", "", "", "example_user", "example_password")
+	expected = "exec: helm repo add myRepo https://repo.example.com/ --username example_user --password example_password --kube-context dev\n"
 	if buffer.String() != expected {
 		t.Errorf("helmexec.AddRepo()\nactual = %v\nexpect = %v", buffer.String(), expected)
 	}

--- a/helmexec/exec_test.go
+++ b/helmexec/exec_test.go
@@ -238,3 +238,23 @@ func Test_exec(t *testing.T) {
 		t.Errorf("helmexec.exec()\nactual = %v\nexpect = %v", buffer.String(), expected)
 	}
 }
+
+func Test_Lint(t *testing.T) {
+	var buffer bytes.Buffer
+	helm := MockExecer(&buffer, "dev")
+	helm.Lint("path/to/chart", "--values", "file.yml")
+	expected := "exec: helm lint path/to/chart --values file.yml --kube-context dev\n"
+	if buffer.String() != expected {
+		t.Errorf("helmexec.Lint()\nactual = %v\nexpect = %v", buffer.String(), expected)
+	}
+}
+
+func Test_Fetch(t *testing.T) {
+	var buffer bytes.Buffer
+	helm := MockExecer(&buffer, "dev")
+	helm.Fetch("chart", "--version", "1.2.3", "--untar", "--untardir", "/tmp/dir")
+	expected := "exec: helm fetch chart --version 1.2.3 --untar --untardir /tmp/dir --kube-context dev\n"
+	if buffer.String() != expected {
+		t.Errorf("helmexec.Lint()\nactual = %v\nexpect = %v", buffer.String(), expected)
+	}
+}

--- a/helmexec/helmexec.go
+++ b/helmexec/helmexec.go
@@ -9,6 +9,8 @@ type Interface interface {
 	UpdateDeps(chart string) error
 	SyncRelease(name, chart string, flags ...string) error
 	DiffRelease(name, chart string, flags ...string) error
+	Fetch(chart string, flags ...string) error
+	Lint(chart string, flags ...string) error
 	ReleaseStatus(name string) error
 	DeleteRelease(name string, flags ...string) error
 	TestRelease(name string, flags ...string) error

--- a/helmexec/helmexec.go
+++ b/helmexec/helmexec.go
@@ -4,7 +4,7 @@ package helmexec
 type Interface interface {
 	SetExtraArgs(args ...string)
 
-	AddRepo(name, repository, certfile, keyfile string) error
+	AddRepo(name, repository, certfile, keyfile, username, password string) error
 	UpdateRepo() error
 	UpdateDeps(chart string) error
 	SyncRelease(name, chart string, flags ...string) error

--- a/main.go
+++ b/main.go
@@ -156,6 +156,43 @@ func main() {
 			},
 		},
 		{
+			Name:  "lint",
+			Usage: "lint charts from state file (helm lint)",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "args",
+					Value: "",
+					Usage: "pass args to helm exec",
+				},
+				cli.StringSliceFlag{
+					Name:  "values",
+					Usage: "additional value files to be merged into the command",
+				},
+				cli.IntFlag{
+					Name:  "concurrency",
+					Value: 0,
+					Usage: "maximum number of concurrent helm processes to run, 0 is unlimited",
+				},
+			},
+			Action: func(c *cli.Context) error {
+				state, helm, err := before(c)
+				if err != nil {
+					return err
+				}
+
+				args := c.String("args")
+				if len(args) > 0 {
+					helm.SetExtraArgs(strings.Split(args, " ")...)
+				}
+
+				values := c.StringSlice("values")
+				workers := c.Int("concurrency")
+
+				errs := state.LintReleases(helm, values, workers)
+				return clean(state, errs)
+			},
+		},
+		{
 			Name:  "sync",
 			Usage: "sync all resources from state file (repos, charts and local chart deps)",
 			Flags: []cli.Flag{

--- a/main.go
+++ b/main.go
@@ -12,11 +12,14 @@ import (
 	"github.com/roboll/helmfile/helmexec"
 	"github.com/roboll/helmfile/state"
 	"github.com/urfave/cli"
+	"path/filepath"
+	"sort"
 )
 
 const (
-	DefaultHelmfile    = "helmfile.yaml"
-	DeprecatedHelmfile = "charts.yaml"
+	DefaultHelmfile          = "helmfile.yaml"
+	DeprecatedHelmfile       = "charts.yaml"
+	DefaultHelmfileDirectory = "helmfile.d"
 )
 
 var Version string
@@ -66,18 +69,14 @@ func main() {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				state, helm, err := before(c)
-				if err != nil {
-					return err
-				}
+				return eachDesiredStateDo(c, func(state *state.HelmState, helm helmexec.Interface) []error {
+					args := c.String("args")
+					if len(args) > 0 {
+						helm.SetExtraArgs(strings.Split(args, " ")...)
+					}
 
-				args := c.String("args")
-				if len(args) > 0 {
-					helm.SetExtraArgs(strings.Split(args, " ")...)
-				}
-
-				errs := state.SyncRepos(helm)
-				return clean(state, errs)
+					return state.SyncRepos(helm)
+				})
 			},
 		},
 		{
@@ -100,21 +99,17 @@ func main() {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				state, helm, err := before(c)
-				if err != nil {
-					return err
-				}
+				return eachDesiredStateDo(c, func(state *state.HelmState, helm helmexec.Interface) []error {
+					args := c.String("args")
+					if len(args) > 0 {
+						helm.SetExtraArgs(strings.Split(args, " ")...)
+					}
 
-				args := c.String("args")
-				if len(args) > 0 {
-					helm.SetExtraArgs(strings.Split(args, " ")...)
-				}
+					values := c.StringSlice("values")
+					workers := c.Int("concurrency")
 
-				values := c.StringSlice("values")
-				workers := c.Int("concurrency")
-
-				errs := state.SyncReleases(helm, values, workers)
-				return clean(state, errs)
+					return state.SyncReleases(helm, values, workers)
+				})
 			},
 		},
 		{
@@ -141,30 +136,23 @@ func main() {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				state, helm, err := before(c)
-				if err != nil {
-					return err
-				}
-
-				args := c.String("args")
-				if len(args) > 0 {
-					helm.SetExtraArgs(strings.Split(args, " ")...)
-				}
-
-				if c.Bool("sync-repos") {
-					if errs := state.SyncRepos(helm); errs != nil && len(errs) > 0 {
-						for _, err := range errs {
-							fmt.Printf("err: %s\n", err.Error())
-						}
-						os.Exit(1)
+				return eachDesiredStateDo(c, func(state *state.HelmState, helm helmexec.Interface) []error {
+					args := c.String("args")
+					if len(args) > 0 {
+						helm.SetExtraArgs(strings.Split(args, " ")...)
 					}
-				}
 
-				values := c.StringSlice("values")
-				workers := c.Int("concurrency")
+					if c.Bool("sync-repos") {
+						if errs := state.SyncRepos(helm); errs != nil && len(errs) > 0 {
+							return errs
+						}
+					}
 
-				errs := state.DiffReleases(helm, values, workers)
-				return clean(state, errs)
+					values := c.StringSlice("values")
+					workers := c.Int("concurrency")
+
+					return state.DiffReleases(helm, values, workers)
+				})
 			},
 		},
 		{
@@ -187,35 +175,25 @@ func main() {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				state, helm, err := before(c)
-				if err != nil {
-					return err
-				}
-
-				if errs := state.SyncRepos(helm); errs != nil && len(errs) > 0 {
-					for _, err := range errs {
-						fmt.Printf("err: %s\n", err.Error())
+				return eachDesiredStateDo(c, func(state *state.HelmState, helm helmexec.Interface) []error {
+					if errs := state.SyncRepos(helm); errs != nil && len(errs) > 0 {
+						return errs
 					}
-					os.Exit(1)
-				}
 
-				if errs := state.UpdateDeps(helm); errs != nil && len(errs) > 0 {
-					for _, err := range errs {
-						fmt.Printf("err: %s\n", err.Error())
+					if errs := state.UpdateDeps(helm); errs != nil && len(errs) > 0 {
+						return errs
 					}
-					os.Exit(1)
-				}
 
-				args := c.String("args")
-				if len(args) > 0 {
-					helm.SetExtraArgs(strings.Split(args, " ")...)
-				}
+					args := c.String("args")
+					if len(args) > 0 {
+						helm.SetExtraArgs(strings.Split(args, " ")...)
+					}
 
-				values := c.StringSlice("values")
-				workers := c.Int("concurrency")
+					values := c.StringSlice("values")
+					workers := c.Int("concurrency")
 
-				errs := state.SyncReleases(helm, values, workers)
-				return clean(state, errs)
+					return state.SyncReleases(helm, values, workers)
+				})
 			},
 		},
 		{
@@ -234,20 +212,16 @@ func main() {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				state, helm, err := before(c)
-				if err != nil {
-					return err
-				}
+				return eachDesiredStateDo(c, func(state *state.HelmState, helm helmexec.Interface) []error {
+					workers := c.Int("concurrency")
 
-				workers := c.Int("concurrency")
+					args := c.String("args")
+					if len(args) > 0 {
+						helm.SetExtraArgs(strings.Split(args, " ")...)
+					}
 
-				args := c.String("args")
-				if len(args) > 0 {
-					helm.SetExtraArgs(strings.Split(args, " ")...)
-				}
-
-				errs := state.ReleaseStatuses(helm, workers)
-				return clean(state, errs)
+					return state.ReleaseStatuses(helm, workers)
+				})
 			},
 		},
 		{
@@ -260,15 +234,11 @@ func main() {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				state, helm, err := before(c)
-				if err != nil {
-					return err
-				}
+				return eachDesiredStateDo(c, func(state *state.HelmState, helm helmexec.Interface) []error {
+					purge := c.Bool("purge")
 
-				purge := c.Bool("purge")
-
-				errs := state.DeleteReleases(helm, purge)
-				return clean(state, errs)
+					return state.DeleteReleases(helm, purge)
+				})
 			},
 		},
 		{
@@ -291,21 +261,17 @@ func main() {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				state, helm, err := before(c)
-				if err != nil {
-					return err
-				}
+				return eachDesiredStateDo(c, func(state *state.HelmState, helm helmexec.Interface) []error {
+					cleanup := c.Bool("cleanup")
+					timeout := c.Int("timeout")
 
-				cleanup := c.Bool("cleanup")
-				timeout := c.Int("timeout")
+					args := c.String("args")
+					if len(args) > 0 {
+						helm.SetExtraArgs(strings.Split(args, " ")...)
+					}
 
-				args := c.String("args")
-				if len(args) > 0 {
-					helm.SetExtraArgs(strings.Split(args, " ")...)
-				}
-
-				errs := state.TestReleases(helm, cleanup, timeout)
-				return clean(state, errs)
+					return state.TestReleases(helm, cleanup, timeout)
+				})
 			},
 		},
 	}
@@ -317,8 +283,77 @@ func main() {
 	}
 }
 
-func before(c *cli.Context) (*state.HelmState, helmexec.Interface, error) {
-	file := c.GlobalString("file")
+func eachDesiredStateDo(c *cli.Context, converge func(*state.HelmState, helmexec.Interface) []error) error {
+	fileOrDirPath := c.GlobalString("file")
+	desiredStateFiles, err := findDesiredStateFiles(fileOrDirPath)
+	if err != nil {
+		return err
+	}
+	for _, f := range desiredStateFiles {
+		state, helm, err := loadDesiredStateFromFile(c, f)
+		if err != nil {
+			return err
+		}
+		errs := converge(state, helm)
+		if err := clean(state, errs); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func findDesiredStateFiles(fileOrDirPath string) ([]string, error) {
+	var dir string
+
+	if fileOrDirPath != "" {
+		if !fileExists(fileOrDirPath) {
+			return []string{}, fmt.Errorf("state file named %s is not found", fileOrDirPath)
+		}
+
+		if !directoryExists(fileOrDirPath) {
+			return []string{fileOrDirPath}, nil
+		}
+
+		dir = fileOrDirPath
+	}
+
+	if dir == "" && fileExists(DefaultHelmfileDirectory) && directoryExists(DefaultHelmfileDirectory) {
+		dir = DefaultHelmfileDirectory
+	}
+
+	if dir != "" {
+		files, err := filepath.Glob(filepath.Join(dir, "*.yaml"))
+		if err != nil {
+			return []string{}, err
+		}
+		sort.Slice(files, func(i, j int) bool {
+			return files[i] < files[j]
+		})
+		return files, nil
+	}
+
+	if fileExists(DefaultHelmfile) {
+		return []string{DefaultHelmfile}, nil
+	}
+
+	if fileExists(DeprecatedHelmfile) {
+		return []string{DeprecatedHelmfile}, nil
+	}
+
+	return []string{}, fmt.Errorf("no state file found. It must be named %s or %s, or otherwise specified with the --file flag", DefaultHelmfile, DeprecatedHelmfile)
+}
+
+func fileExists(filename string) bool {
+	_, err := os.Stat(filename)
+	return err == nil
+}
+
+func directoryExists(path string) bool {
+	fileInfo, err := os.Stat(path)
+	return err == nil && fileInfo != nil && fileInfo.IsDir()
+}
+
+func loadDesiredStateFromFile(c *cli.Context, file string) (*state.HelmState, helmexec.Interface, error) {
 	quiet := c.GlobalBool("quiet")
 	kubeContext := c.GlobalString("kube-context")
 	namespace := c.GlobalString("namespace")

--- a/main.go
+++ b/main.go
@@ -175,58 +175,17 @@ func main() {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				state, helm, err := before(c)
-				if err != nil {
-					return err
-				}
+				return eachDesiredStateDo(c, func(state *state.HelmState, helm helmexec.Interface) []error {
+					args := c.String("args")
+					if len(args) > 0 {
+						helm.SetExtraArgs(strings.Split(args, " ")...)
+					}
 
-				args := c.String("args")
-				if len(args) > 0 {
-					helm.SetExtraArgs(strings.Split(args, " ")...)
-				}
+					values := c.StringSlice("values")
+					workers := c.Int("concurrency")
 
-				values := c.StringSlice("values")
-				workers := c.Int("concurrency")
-
-				errs := state.LintReleases(helm, values, workers)
-				return clean(state, errs)
-			},
-		},
-		{
-			Name:  "lint",
-			Usage: "lint charts from state file (helm lint)",
-			Flags: []cli.Flag{
-				cli.StringFlag{
-					Name:  "args",
-					Value: "",
-					Usage: "pass args to helm exec",
-				},
-				cli.StringSliceFlag{
-					Name:  "values",
-					Usage: "additional value files to be merged into the command",
-				},
-				cli.IntFlag{
-					Name:  "concurrency",
-					Value: 0,
-					Usage: "maximum number of concurrent helm processes to run, 0 is unlimited",
-				},
-			},
-			Action: func(c *cli.Context) error {
-				state, helm, err := before(c)
-				if err != nil {
-					return err
-				}
-
-				args := c.String("args")
-				if len(args) > 0 {
-					helm.SetExtraArgs(strings.Split(args, " ")...)
-				}
-
-				values := c.StringSlice("values")
-				workers := c.Int("concurrency")
-
-				errs := state.LintReleases(helm, values, workers)
-				return clean(state, errs)
+					return state.LintReleases(helm, values, workers)
+				})
 			},
 		},
 		{

--- a/state/state.go
+++ b/state/state.go
@@ -37,6 +37,8 @@ type RepositorySpec struct {
 	URL      string `yaml:"url"`
 	CertFile string `yaml:"certFile"`
 	KeyFile  string `yaml:"keyFile"`
+	Username string `yaml:"username"`
+	Password string `yaml:"password"`
 }
 
 // ReleaseSpec defines the structure of a helm release
@@ -152,7 +154,7 @@ func (state *HelmState) SyncRepos(helm helmexec.Interface) []error {
 	errs := []error{}
 
 	for _, repo := range state.Repositories {
-		if err := helm.AddRepo(repo.Name, repo.URL, repo.CertFile, repo.KeyFile); err != nil {
+		if err := helm.AddRepo(repo.Name, repo.URL, repo.CertFile, repo.KeyFile, repo.Username, repo.Password); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/state/state.go
+++ b/state/state.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"path"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -315,6 +316,122 @@ func (state *HelmState) DiffReleases(helm helmexec.Interface, additionalValues [
 	return nil
 }
 
+// LintReleases wrapper for executing helm lint on the releases
+func (state *HelmState) LintReleases(helm helmexec.Interface, additionalValues []string, workerLimit int) []error {
+	var wgRelease sync.WaitGroup
+	var wgError sync.WaitGroup
+	errs := []error{}
+	jobQueue := make(chan *ReleaseSpec, len(state.Releases))
+	errQueue := make(chan error)
+
+	if workerLimit < 1 {
+		workerLimit = len(state.Releases)
+	}
+
+	wgRelease.Add(len(state.Releases))
+
+	// Create tmp directory and bail immediately if it fails
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		errs = append(errs, err)
+		return errs
+	}
+	defer os.RemoveAll(dir)
+
+	for w := 1; w <= workerLimit; w++ {
+		go func() {
+			for release := range jobQueue {
+				errs := []error{}
+				// Plugin command doesn't support explicit namespace
+				release.Namespace = ""
+				flags, err := flagsForRelease(helm, state.BaseChartPath, release)
+				if err != nil {
+					errs = append(errs, err)
+				}
+				for _, value := range additionalValues {
+					valfile, err := filepath.Abs(value)
+					if err != nil {
+						errs = append(errs, err)
+					}
+
+					if _, err := os.Stat(valfile); os.IsNotExist(err) {
+						errs = append(errs, err)
+					}
+					flags = append(flags, "--values", valfile)
+				}
+
+				chartPath := ""
+				if isLocalChart(release.Chart) {
+					chartPath = normalizeChart(state.BaseChartPath, release.Chart)
+				} else {
+					fetchFlags := []string{}
+					if release.Version != "" {
+						chartPath = path.Join(dir, release.Version, release.Chart)
+						fetchFlags = append(fetchFlags, "--version", release.Version)
+					} else {
+						chartPath = path.Join(dir, "latest", release.Chart)
+					}
+
+					// only fetch chart if it is not already fetched
+					if _, err := os.Stat(chartPath); os.IsNotExist(err) {
+						fetchFlags = append(fetchFlags, "--untar", "--untardir", chartPath)
+						if err := helm.Fetch(release.Chart, fetchFlags...); err != nil {
+							errs = append(errs, err)
+						}
+					}
+					chartPath = path.Join(chartPath, chartNameWithoutRepository(release.Chart))
+				}
+
+				// strip version from the slice returned from flagsForRelease
+				realFlags := []string{}
+				isVersion := false
+				for _, v := range flags {
+					if v == "--version" {
+						isVersion = true
+					} else if isVersion {
+						isVersion = false
+					} else {
+						realFlags = append(realFlags, v)
+					}
+				}
+
+				if len(errs) == 0 {
+					if err := helm.Lint(chartPath, realFlags...); err != nil {
+						errs = append(errs, err)
+					}
+				}
+				for _, err := range errs {
+					errQueue <- err
+				}
+				wgRelease.Done()
+			}
+		}()
+	}
+	wgError.Add(1)
+	go func() {
+		for err := range errQueue {
+			errs = append(errs, err)
+		}
+		wgError.Done()
+	}()
+
+	for i := 0; i < len(state.Releases); i++ {
+		jobQueue <- &state.Releases[i]
+	}
+
+	close(jobQueue)
+	wgRelease.Wait()
+
+	close(errQueue)
+	wgError.Wait()
+
+	if len(errs) != 0 {
+		return errs
+	}
+
+	return nil
+}
+
 func (state *HelmState) ReleaseStatuses(helm helmexec.Interface, workerLimit int) []error {
 	var errs []error
 	jobQueue := make(chan ReleaseSpec)
@@ -500,6 +617,11 @@ func normalizeChart(basePath, chart string) string {
 func isLocalChart(chart string) bool {
 	_, err := os.Stat(chart)
 	return err == nil
+}
+
+func chartNameWithoutRepository(chart string) string {
+	chartSplit := strings.Split(chart, "/")
+	return chartSplit[len(chartSplit)-1]
 }
 
 func flagsForRelease(helm helmexec.Interface, basePath string, release *ReleaseSpec) ([]string, error) {

--- a/state/state.go
+++ b/state/state.go
@@ -342,8 +342,6 @@ func (state *HelmState) LintReleases(helm helmexec.Interface, additionalValues [
 		go func() {
 			for release := range jobQueue {
 				errs := []error{}
-				// Plugin command doesn't support explicit namespace
-				release.Namespace = ""
 				flags, err := flagsForRelease(helm, state.BaseChartPath, release)
 				if err != nil {
 					errs = append(errs, err)

--- a/state/state.go
+++ b/state/state.go
@@ -364,10 +364,10 @@ func (state *HelmState) LintReleases(helm helmexec.Interface, additionalValues [
 				} else {
 					fetchFlags := []string{}
 					if release.Version != "" {
-						chartPath = path.Join(dir, release.Version, release.Chart)
+						chartPath = path.Join(dir, release.Name, release.Version, release.Chart)
 						fetchFlags = append(fetchFlags, "--version", release.Version)
 					} else {
-						chartPath = path.Join(dir, "latest", release.Chart)
+						chartPath = path.Join(dir, release.Name, "latest", release.Chart)
 					}
 
 					// only fetch chart if it is not already fetched

--- a/state/state.go
+++ b/state/state.go
@@ -1,11 +1,11 @@
 package state
 
 import (
-	"path"
 	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -521,8 +521,8 @@ func (helm *mockHelmExec) UpdateDeps(chart string) error {
 func (helm *mockHelmExec) SetExtraArgs(args ...string) {
 	return
 }
-func (helm *mockHelmExec) AddRepo(name, repository, certfile, keyfile string) error {
-	helm.repo = []string{name, repository, certfile, keyfile}
+func (helm *mockHelmExec) AddRepo(name, repository, certfile, keyfile, username, password string) error {
+	helm.repo = []string{name, repository, certfile, keyfile, username, password}
 	return nil
 }
 func (helm *mockHelmExec) UpdateRepo() error {
@@ -576,10 +576,12 @@ func TestHelmState_SyncRepos(t *testing.T) {
 					URL:      "http://example.com/",
 					CertFile: "",
 					KeyFile:  "",
+					Username: "",
+					Password: "",
 				},
 			},
 			helm: &mockHelmExec{},
-			want: []string{"name", "http://example.com/", "", ""},
+			want: []string{"name", "http://example.com/", "", "", "", ""},
 		},
 		{
 			name: "repository with cert and key",
@@ -589,10 +591,27 @@ func TestHelmState_SyncRepos(t *testing.T) {
 					URL:      "http://example.com/",
 					CertFile: "certfile",
 					KeyFile:  "keyfile",
+					Username: "",
+					Password: "",
 				},
 			},
 			helm: &mockHelmExec{},
-			want: []string{"name", "http://example.com/", "certfile", "keyfile"},
+			want: []string{"name", "http://example.com/", "certfile", "keyfile", "", ""},
+		},
+		{
+			name: "repository with username and password",
+			repos: []RepositorySpec{
+				{
+					Name:     "name",
+					URL:      "http://example.com/",
+					CertFile: "",
+					KeyFile:  "",
+					Username: "example_user",
+					Password: "example_password",
+				},
+			},
+			helm: &mockHelmExec{},
+			want: []string{"name", "http://example.com/", "", "", "example_user", "example_password"},
 		},
 	}
 	for _, tt := range tests {

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -559,6 +559,12 @@ func (helm *mockHelmExec) TestRelease(name string, flags ...string) error {
 	helm.releases = append(helm.releases, mockRelease{name: name, flags: flags})
 	return nil
 }
+func (helm *mockHelmExec) Fetch(chart string, flags ...string) error {
+	return nil
+}
+func (helm *mockHelmExec) Lint(chart string, flags ...string) error {
+	return nil
+}
 
 func TestHelmState_SyncRepos(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Our use case is to have a list of helmfile releases version controlled together with all settings and have a CI pipeline that will lint all releases with settings before running sync. The new functionality was mostly copy pasted from the Diff implementation with some extra handling for fetching remote charts so open for any feedback. 