### PR TITLE
fail when no releases match selector

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -464,6 +464,9 @@ func (state *HelmState) FilterReleases(labels []string) error {
 	for _, r := range releaseSet {
 		filteredReleases = append(filteredReleases, r)
 	}
+	if len(filteredReleases) == 0 {
+		return errors.New("Specified selector did not match any releases.\n")
+	}
 	state.Releases = filteredReleases
 	return nil
 }

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -825,3 +825,49 @@ func TestHelmState_TestReleasesNoCleanUp(t *testing.T) {
 		t.Run(tt.name, i)
 	}
 }
+
+func TestHelmState_NoReleaseMatched(t *testing.T) {
+	releases := []ReleaseSpec{
+		{
+			Name: "releaseA",
+			Labels: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}
+	tests := []struct {
+		name    string
+		labels  string
+		wantErr bool
+	}{
+		{
+			name: "happy path",
+
+			labels:  "foo=bar",
+			wantErr: false,
+		},
+		{
+			name:    "name does not exist",
+			labels:  "name=releaseB",
+			wantErr: true,
+		},
+		{
+			name:    "label does not match anything",
+			labels:  "foo=notbar",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		i := func(t *testing.T) {
+			state := &HelmState{
+				Releases: releases,
+			}
+			errs := state.FilterReleases([]string{tt.labels})
+			if (errs != nil) != tt.wantErr {
+				t.Errorf("ReleaseStatuses() for %s error = %v, wantErr %v", tt.name, errs, tt.wantErr)
+				return
+			}
+		}
+		t.Run(tt.name, i)
+	}
+}


### PR DESCRIPTION
I just encountered #164 as well. This PR should fix that behaviour and fail with an error when there is no release matching the specified selector:

    helmfile --selector name=httbin diff
    2018/06/12 14:05:48 Specified selector(s) did not match any releases.
