### PR TITLE
adding args to be added in helmfile along with context to be set in helmspec

### DIFF
--- a/main.go
+++ b/main.go
@@ -350,18 +350,7 @@ func before(c *cli.Context) (*state.HelmState, helmexec.Interface, error) {
 			os.Exit(1)
 		}
 
-		if st.Helm.Context != "" {
-			log.Printf("err: Cannot set atrribute context on both helmspec and context.")
-			os.Exit(1)
-		}
-
 		kubeContext = st.Context
-	} else if st.Helm.Context != "" {
-		if kubeContext != "" {
-			log.Printf("err: Cannot use option --kube-context and set attribute context.")
-			os.Exit(1)
-		}
-		kubeContext = st.Helm.Context
 	}
 	if namespace != "" {
 		if st.Namespace != "" {
@@ -417,12 +406,8 @@ func clean(state *state.HelmState, errs []error) error {
 func getArgs(c *cli.Context, state *state.HelmState) []string {
 	args := c.String("args")
 	if len(args) > 0 {
-		if len(state.Helm.Args) > 0 {
-			log.Printf("err: Cannot use option --args and set attribute args.")
-			os.Exit(1)
-		}
-		state.Helm.Args = strings.Split(args, " ")
+		state.HelmDefaults.Args = strings.Split(args, " ")
 	}
 
-	return state.Helm.Args
+	return state.HelmDefaults.Args
 }

--- a/state/state.go
+++ b/state/state.go
@@ -24,7 +24,7 @@ import (
 // HelmState structure for the helmfile
 type HelmState struct {
 	BaseChartPath      string
-	Helm               HelmSpec         `yaml:"helm"`
+	HelmDefaults       HelmSpec         `yaml:"helmDefaults"`
 	Context            string           `yaml:"context"`
 	DeprecatedReleases []ReleaseSpec    `yaml:"charts"`
 	Namespace          string           `yaml:"namespace"`
@@ -32,9 +32,9 @@ type HelmState struct {
 	Releases           []ReleaseSpec    `yaml:"releases"`
 }
 
+// HelmSpec to defines helmDefault values
 type HelmSpec struct {
-	Args    []string `yaml:"args"`
-	Context string   `yaml:"context"`
+	Args []string `yaml:"args"`
 }
 
 // RepositorySpec that defines values for a helm repo

--- a/state/state.go
+++ b/state/state.go
@@ -24,11 +24,17 @@ import (
 // HelmState structure for the helmfile
 type HelmState struct {
 	BaseChartPath      string
+	Helm               HelmSpec         `yaml:"helm"`
 	Context            string           `yaml:"context"`
 	DeprecatedReleases []ReleaseSpec    `yaml:"charts"`
 	Namespace          string           `yaml:"namespace"`
 	Repositories       []RepositorySpec `yaml:"repositories"`
 	Releases           []ReleaseSpec    `yaml:"releases"`
+}
+
+type HelmSpec struct {
+	Args    []string `yaml:"args"`
+	Context string   `yaml:"context"`
 }
 
 // RepositorySpec that defines values for a helm repo


### PR DESCRIPTION
This is regarding issue #114. This PR allows for args to be set in helmfile. Added section helm which 
 args can be set ,as well as context will be set and other contributed key values later on when contributed.