### PR TITLE
Add the option to specify an alternative helm binary

### DIFF
--- a/helmexec/exec.go
+++ b/helmexec/exec.go
@@ -11,7 +11,7 @@ const (
 )
 
 type execer struct {
-	command     string
+	helmBinary  string
 	runner      Runner
 	writer      io.Writer
 	kubeContext string
@@ -21,7 +21,7 @@ type execer struct {
 // New for running helm commands
 func New(writer io.Writer, kubeContext string) *execer {
 	return &execer{
-		command:     command,
+		helmBinary:  command,
 		writer:      writer,
 		kubeContext: kubeContext,
 		runner:      &ShellRunner{},
@@ -33,7 +33,7 @@ func (helm *execer) SetExtraArgs(args ...string) {
 }
 
 func (helm *execer) SetHelmBinary(bin string) {
-	helm.command = bin
+	helm.helmBinary = bin
 }
 
 func (helm *execer) AddRepo(name, repository, certfile, keyfile, username, password string) error {
@@ -120,8 +120,8 @@ func (helm *execer) exec(args ...string) ([]byte, error) {
 	if helm.kubeContext != "" {
 		cmdargs = append(cmdargs, "--kube-context", helm.kubeContext)
 	}
-	helm.write([]byte(fmt.Sprintf("exec: %s %s\n", helm.command, strings.Join(cmdargs, " "))))
-	return helm.runner.Execute(helm.command, cmdargs)
+	helm.write([]byte(fmt.Sprintf("exec: %s %s\n", helm.helmBinary, strings.Join(cmdargs, " "))))
+	return helm.runner.Execute(helm.helmBinary, cmdargs)
 }
 
 func (helm *execer) write(out []byte) {

--- a/helmexec/exec.go
+++ b/helmexec/exec.go
@@ -11,6 +11,7 @@ const (
 )
 
 type execer struct {
+	command     string
 	runner      Runner
 	writer      io.Writer
 	kubeContext string
@@ -20,6 +21,7 @@ type execer struct {
 // New for running helm commands
 func New(writer io.Writer, kubeContext string) *execer {
 	return &execer{
+		command:     command,
 		writer:      writer,
 		kubeContext: kubeContext,
 		runner:      &ShellRunner{},
@@ -28,6 +30,10 @@ func New(writer io.Writer, kubeContext string) *execer {
 
 func (helm *execer) SetExtraArgs(args ...string) {
 	helm.extra = args
+}
+
+func (helm *execer) OverwriteCommand(command string) {
+	helm.command = command
 }
 
 func (helm *execer) AddRepo(name, repository, certfile, keyfile, username, password string) error {
@@ -114,8 +120,8 @@ func (helm *execer) exec(args ...string) ([]byte, error) {
 	if helm.kubeContext != "" {
 		cmdargs = append(cmdargs, "--kube-context", helm.kubeContext)
 	}
-	helm.write([]byte(fmt.Sprintf("exec: helm %s\n", strings.Join(cmdargs, " "))))
-	return helm.runner.Execute(command, cmdargs)
+	helm.write([]byte(fmt.Sprintf("exec: %s %s\n", helm.command, strings.Join(cmdargs, " "))))
+	return helm.runner.Execute(helm.command, cmdargs)
 }
 
 func (helm *execer) write(out []byte) {

--- a/helmexec/exec.go
+++ b/helmexec/exec.go
@@ -32,8 +32,8 @@ func (helm *execer) SetExtraArgs(args ...string) {
 	helm.extra = args
 }
 
-func (helm *execer) OverwriteCommand(command string) {
-	helm.command = command
+func (helm *execer) SetHelmBinary(bin string) {
+	helm.command = bin
 }
 
 func (helm *execer) AddRepo(name, repository, certfile, keyfile, username, password string) error {

--- a/helmexec/exec_test.go
+++ b/helmexec/exec_test.go
@@ -58,12 +58,12 @@ func Test_SetExtraArgs(t *testing.T) {
 
 func Test_SetHelmBinary(t *testing.T) {
 	helm := New(new(bytes.Buffer), "dev")
-	if helm.command != "helm" {
+	if helm.helmBinary != "helm" {
 		t.Error("helmexec.command - default command is not helm")
 	}
 	helm.SetHelmBinary("foo")
-	if helm.command != "foo" {
-		t.Errorf("helmexec.SetHelmBinary() - actual = %s expect = foo", helm.command)
+	if helm.helmBinary != "foo" {
+		t.Errorf("helmexec.SetHelmBinary() - actual = %s expect = foo", helm.helmBinary)
 	}
 }
 

--- a/helmexec/exec_test.go
+++ b/helmexec/exec_test.go
@@ -56,14 +56,14 @@ func Test_SetExtraArgs(t *testing.T) {
 	}
 }
 
-func Test_OverwriteCommand(t *testing.T) {
+func Test_SetHelmBinary(t *testing.T) {
 	helm := New(new(bytes.Buffer), "dev")
 	if helm.command != "helm" {
 		t.Error("helmexec.command - default command is not helm")
 	}
-	helm.OverwriteCommand("foo")
+	helm.SetHelmBinary("foo")
 	if helm.command != "foo" {
-		t.Errorf("helmexec.OverwriteCommand() - actual = %s expect = foo", helm.command)
+		t.Errorf("helmexec.SetHelmBinary() - actual = %s expect = foo", helm.command)
 	}
 }
 
@@ -251,7 +251,7 @@ func Test_exec(t *testing.T) {
 
 	buffer.Reset()
 	helm = MockExecer(&buffer, "")
-	helm.OverwriteCommand("overwritten")
+	helm.SetHelmBinary("overwritten")
 	helm.exec("version")
 	expected = "exec: overwritten version\n"
 	if buffer.String() != expected {

--- a/helmexec/exec_test.go
+++ b/helmexec/exec_test.go
@@ -56,6 +56,17 @@ func Test_SetExtraArgs(t *testing.T) {
 	}
 }
 
+func Test_OverwriteCommand(t *testing.T) {
+	helm := New(new(bytes.Buffer), "dev")
+	if helm.command != "helm" {
+		t.Error("helmexec.command - default command is not helm")
+	}
+	helm.OverwriteCommand("foo")
+	if helm.command != "foo" {
+		t.Errorf("helmexec.OverwriteCommand() - actual = %s expect = foo", helm.command)
+	}
+}
+
 func Test_AddRepo(t *testing.T) {
 	var buffer bytes.Buffer
 	helm := MockExecer(&buffer, "dev")
@@ -234,6 +245,15 @@ func Test_exec(t *testing.T) {
 	helm.SetExtraArgs("foo")
 	helm.exec("version")
 	expected = "exec: helm version foo --kube-context dev\n"
+	if buffer.String() != expected {
+		t.Errorf("helmexec.exec()\nactual = %v\nexpect = %v", buffer.String(), expected)
+	}
+
+	buffer.Reset()
+	helm = MockExecer(&buffer, "")
+	helm.OverwriteCommand("overwritten")
+	helm.exec("version")
+	expected = "exec: overwritten version\n"
 	if buffer.String() != expected {
 		t.Errorf("helmexec.exec()\nactual = %v\nexpect = %v", buffer.String(), expected)
 	}

--- a/helmexec/helmexec.go
+++ b/helmexec/helmexec.go
@@ -3,6 +3,7 @@ package helmexec
 // Interface for executing helm commands
 type Interface interface {
 	SetExtraArgs(args ...string)
+	OverwriteCommand(command string)
 
 	AddRepo(name, repository, certfile, keyfile, username, password string) error
 	UpdateRepo() error

--- a/helmexec/helmexec.go
+++ b/helmexec/helmexec.go
@@ -3,7 +3,7 @@ package helmexec
 // Interface for executing helm commands
 type Interface interface {
 	SetExtraArgs(args ...string)
-	OverwriteCommand(command string)
+	SetHelmBinary(bin string)
 
 	AddRepo(name, repository, certfile, keyfile, username, password string) error
 	UpdateRepo() error

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ func main() {
 	app.Version = Version
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
-			Name:  "helmcommand, c",
+			Name:  "helm-binary, c",
 			Usage: "overwrite helm command. Uses 'helm by default",
 		},
 		cli.StringFlag{
@@ -78,8 +78,8 @@ func main() {
 					if len(args) > 0 {
 						helm.SetExtraArgs(args...)
 					}
-					if c.String("helmcommand") != "" {
-						helm.SetHelmBinary(c.String("helmcommand"))
+					if c.String("helm-binary") != "" {
+						helm.SetHelmBinary(c.String("helm-binary"))
 					}
 
 					return state.SyncRepos(helm)
@@ -111,8 +111,8 @@ func main() {
 					if len(args) > 0 {
 						helm.SetExtraArgs(args...)
 					}
-					if c.String("helmcommand") != "" {
-						helm.SetHelmBinary(c.String("helmcommand"))
+					if c.String("helm-binary") != "" {
+						helm.SetHelmBinary(c.String("helm-binary"))
 					}
 
 					values := c.StringSlice("values")
@@ -151,8 +151,8 @@ func main() {
 					if len(args) > 0 {
 						helm.SetExtraArgs(args...)
 					}
-					if c.String("helmcommand") != "" {
-						helm.SetHelmBinary(c.String("helmcommand"))
+					if c.String("helm-binary") != "" {
+						helm.SetHelmBinary(c.String("helm-binary"))
 					}
 
 					if c.Bool("sync-repos") {
@@ -193,8 +193,8 @@ func main() {
 					if len(args) > 0 {
 						helm.SetExtraArgs(strings.Split(args, " ")...)
 					}
-					if c.String("helmcommand") != "" {
-						helm.SetHelmBinary(c.String("helmcommand"))
+					if c.String("helm-binary") != "" {
+						helm.SetHelmBinary(c.String("helm-binary"))
 					}
 
 					values := c.StringSlice("values")
@@ -237,8 +237,8 @@ func main() {
 					if len(args) > 0 {
 						helm.SetExtraArgs(args...)
 					}
-					if c.String("helmcommand") != "" {
-						helm.SetHelmBinary(c.String("helmcommand"))
+					if c.String("helm-binary") != "" {
+						helm.SetHelmBinary(c.String("helm-binary"))
 					}
 
 					values := c.StringSlice("values")
@@ -271,8 +271,8 @@ func main() {
 					if len(args) > 0 {
 						helm.SetExtraArgs(args...)
 					}
-					if c.String("helmcommand") != "" {
-						helm.SetHelmBinary(c.String("helmcommand"))
+					if c.String("helm-binary") != "" {
+						helm.SetHelmBinary(c.String("helm-binary"))
 					}
 
 					return state.ReleaseStatuses(helm, workers)
@@ -324,8 +324,8 @@ func main() {
 					if len(args) > 0 {
 						helm.SetExtraArgs(args...)
 					}
-					if c.String("helmcommand") != "" {
-						helm.SetHelmBinary(c.String("helmcommand"))
+					if c.String("helm-binary") != "" {
+						helm.SetHelmBinary(c.String("helm-binary"))
 					}
 
 					return state.TestReleases(helm, cleanup, timeout)

--- a/main.go
+++ b/main.go
@@ -32,8 +32,8 @@ func main() {
 	app.Version = Version
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
-			Name:  "helm-binary, c",
-			Usage: "overwrite helm command. Uses 'helm by default",
+			Name:  "helm-binary, b",
+			Usage: "path to helm binary",
 		},
 		cli.StringFlag{
 			Name:  "file, f",

--- a/main.go
+++ b/main.go
@@ -32,6 +32,10 @@ func main() {
 	app.Version = Version
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
+			Name:  "helmcommand, c",
+			Usage: "overwrite helm command. Uses 'helm by default",
+		},
+		cli.StringFlag{
 			Name:  "file, f",
 			Value: DefaultHelmfile,
 			Usage: "load config from `FILE`",
@@ -74,6 +78,9 @@ func main() {
 					if len(args) > 0 {
 						helm.SetExtraArgs(args...)
 					}
+					if c.String("helmcommand") != "" {
+						helm.OverwriteCommand(c.String("helmcommand"))
+					}
 
 					return state.SyncRepos(helm)
 				})
@@ -103,6 +110,9 @@ func main() {
 					args := getArgs(c, state)
 					if len(args) > 0 {
 						helm.SetExtraArgs(args...)
+					}
+					if c.String("helmcommand") != "" {
+						helm.OverwriteCommand(c.String("helmcommand"))
 					}
 
 					values := c.StringSlice("values")
@@ -140,6 +150,9 @@ func main() {
 					args := getArgs(c, state)
 					if len(args) > 0 {
 						helm.SetExtraArgs(args...)
+					}
+					if c.String("helmcommand") != "" {
+						helm.OverwriteCommand(c.String("helmcommand"))
 					}
 
 					if c.Bool("sync-repos") {
@@ -179,6 +192,9 @@ func main() {
 					args := c.String("args")
 					if len(args) > 0 {
 						helm.SetExtraArgs(strings.Split(args, " ")...)
+					}
+					if c.String("helmcommand") != "" {
+						helm.OverwriteCommand(c.String("helmcommand"))
 					}
 
 					values := c.StringSlice("values")
@@ -221,6 +237,9 @@ func main() {
 					if len(args) > 0 {
 						helm.SetExtraArgs(args...)
 					}
+					if c.String("helmcommand") != "" {
+						helm.OverwriteCommand(c.String("helmcommand"))
+					}
 
 					values := c.StringSlice("values")
 					workers := c.Int("concurrency")
@@ -251,6 +270,9 @@ func main() {
 					args := getArgs(c, state)
 					if len(args) > 0 {
 						helm.SetExtraArgs(args...)
+					}
+					if c.String("helmcommand") != "" {
+						helm.OverwriteCommand(c.String("helmcommand"))
 					}
 
 					return state.ReleaseStatuses(helm, workers)
@@ -301,6 +323,9 @@ func main() {
 					args := getArgs(c, state)
 					if len(args) > 0 {
 						helm.SetExtraArgs(args...)
+					}
+					if c.String("helmcommand") != "" {
+						helm.OverwriteCommand(c.String("helmcommand"))
 					}
 
 					return state.TestReleases(helm, cleanup, timeout)

--- a/main.go
+++ b/main.go
@@ -79,7 +79,7 @@ func main() {
 						helm.SetExtraArgs(args...)
 					}
 					if c.String("helmcommand") != "" {
-						helm.OverwriteCommand(c.String("helmcommand"))
+						helm.SetHelmBinary(c.String("helmcommand"))
 					}
 
 					return state.SyncRepos(helm)
@@ -112,7 +112,7 @@ func main() {
 						helm.SetExtraArgs(args...)
 					}
 					if c.String("helmcommand") != "" {
-						helm.OverwriteCommand(c.String("helmcommand"))
+						helm.SetHelmBinary(c.String("helmcommand"))
 					}
 
 					values := c.StringSlice("values")
@@ -152,7 +152,7 @@ func main() {
 						helm.SetExtraArgs(args...)
 					}
 					if c.String("helmcommand") != "" {
-						helm.OverwriteCommand(c.String("helmcommand"))
+						helm.SetHelmBinary(c.String("helmcommand"))
 					}
 
 					if c.Bool("sync-repos") {
@@ -194,7 +194,7 @@ func main() {
 						helm.SetExtraArgs(strings.Split(args, " ")...)
 					}
 					if c.String("helmcommand") != "" {
-						helm.OverwriteCommand(c.String("helmcommand"))
+						helm.SetHelmBinary(c.String("helmcommand"))
 					}
 
 					values := c.StringSlice("values")
@@ -238,7 +238,7 @@ func main() {
 						helm.SetExtraArgs(args...)
 					}
 					if c.String("helmcommand") != "" {
-						helm.OverwriteCommand(c.String("helmcommand"))
+						helm.SetHelmBinary(c.String("helmcommand"))
 					}
 
 					values := c.StringSlice("values")
@@ -272,7 +272,7 @@ func main() {
 						helm.SetExtraArgs(args...)
 					}
 					if c.String("helmcommand") != "" {
-						helm.OverwriteCommand(c.String("helmcommand"))
+						helm.SetHelmBinary(c.String("helmcommand"))
 					}
 
 					return state.ReleaseStatuses(helm, workers)
@@ -325,7 +325,7 @@ func main() {
 						helm.SetExtraArgs(args...)
 					}
 					if c.String("helmcommand") != "" {
-						helm.OverwriteCommand(c.String("helmcommand"))
+						helm.SetHelmBinary(c.String("helmcommand"))
 					}
 
 					return state.TestReleases(helm, cleanup, timeout)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -521,7 +521,7 @@ func (helm *mockHelmExec) UpdateDeps(chart string) error {
 func (helm *mockHelmExec) SetExtraArgs(args ...string) {
 	return
 }
-func (helm *mockHelmExec) OverwriteCommand(command string) {
+func (helm *mockHelmExec) SetHelmBinary(bin string) {
 	return
 }
 func (helm *mockHelmExec) AddRepo(name, repository, certfile, keyfile, username, password string) error {

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -521,6 +521,9 @@ func (helm *mockHelmExec) UpdateDeps(chart string) error {
 func (helm *mockHelmExec) SetExtraArgs(args ...string) {
 	return
 }
+func (helm *mockHelmExec) OverwriteCommand(command string) {
+	return
+}
 func (helm *mockHelmExec) AddRepo(name, repository, certfile, keyfile, username, password string) error {
 	helm.repo = []string{name, repository, certfile, keyfile, username, password}
 	return nil


### PR DESCRIPTION
Helm may not be version compatible, how about option to overwrite command for switching other version client?

incompatible versions error sample is followings
```
Error: UPGRADE FAILED: incompatible versions client[v2.9.1] server[v2.8.2]
```