### PR TITLE
fix: `helmfile sync` doesn't recognize the default `helmfile.d/` directory

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,8 +37,7 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:  "file, f",
-			Value: DefaultHelmfile,
-			Usage: "load config from `FILE`",
+			Usage: "load config from file or directory. defaults to `helmfile.yaml` or `helmfile.d`(means `helmfile.d/*.yaml`) in this preference",
 		},
 		cli.BoolFlag{
 			Name:  "quiet, q",


### PR DESCRIPTION
Fixes #189