### PR TITLE
feat: Optional detailed exitcodes for `helmfile diff`

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -254,7 +254,7 @@ func (state *HelmState) SyncReleases(helm helmexec.Interface, additionalValues [
 }
 
 // DiffReleases wrapper for executing helm diff on the releases
-func (state *HelmState) DiffReleases(helm helmexec.Interface, additionalValues []string, workerLimit int) []error {
+func (state *HelmState) DiffReleases(helm helmexec.Interface, additionalValues []string, workerLimit int, detailedExitCode bool) []error {
 	var wgRelease sync.WaitGroup
 	var wgError sync.WaitGroup
 	errs := []error{}
@@ -287,6 +287,10 @@ func (state *HelmState) DiffReleases(helm helmexec.Interface, additionalValues [
 						errs = append(errs, err)
 					}
 					flags = append(flags, "--values", valfile)
+				}
+
+				if detailedExitCode {
+					flags = append(flags, "--detailed-exitcode")
 				}
 
 				if len(errs) == 0 {


### PR DESCRIPTION
Adds the `--detailed-exitcode` to the `helmfile diff` command to return `1` on failure, and `2` when no error but diff is seen.

This feature requires the latest `helm-diff` containing https://github.com/databus23/helm-diff/pull/78, and `helm` containing https://github.com/helm/helm/pull/4367.

This is verified to work by manually running commands like the followings:

```bash
./helmfile --helm-binary helm211dev -f ./examples/helmfile.d diff --detailed-exitcode; echo $?
./helmfile --helm-binary helm211dev -f ./examples/helmfile.d diff; echo $?
```

Note that, in above example commands, `helm211dev` is a custom `helm` binary that is built from helm's master branch containing [the necessary enhancement to allow propagate non-zero plugin exit code](https://github.com/helm/helm/pull/4367).