### PR TITLE
Add link to more examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,4 +251,4 @@ The `selector` parameter can be specified multiple times. Each parameter is reso
 
 ## Examples
 
-For more examples, see [examples/README.md](https://github.com/roboll/helmfile/blob/master/examples/README.md).
+For more examples, see the [examples/README.md](https://github.com/roboll/helmfile/blob/master/examples/README.md) or the [`helmfile.d`](https://github.com/cloudposse/helmfiles/tree/master/helmfile.d) distribution of helmfiles by [Cloud Posse](https://github.com/cloudposse/).


### PR DESCRIPTION
## what

* Add a link to github repo dedicated to [our](https://github.com/cloudposse) distribution of helmfiles under the `## Examples` section.

Currently, we have implemented helmfiles for the following:
 
* kube2iam
* kiam	
* external-dns
* kube-lego
* cert-manager	
* chartmuseum
* nginx-ingress.yaml
* prometheus-operator
* kube-prometheus
* grafana
* datalog
* fluentd-datadog-logs
* fluentd-elasticsearch-logs
* heapster
* dashboard
* portal
* kibana

## why

When we started out, there weren't many examples of how to write helmfiles. Now we're adding more everyweek. We believe there's an opportunity for helmfiles users to collaborate on writing more/better helmfiles to make it even easier to deploy helm charts. 

Ours aren't perfect, we do accept Pull Requests! =) 

Also, we distribute all helmfiles as a docker image, which is useful for multi-state docker builds.

This is [how we use it](https://github.com/cloudposse/staging.cloudposse.co/blob/master/Dockerfile#L3):

```
FROM cloudposse/helmfiles:0.2.0 as helmfiles
...

# Copy helmfiles
COPY --from=helmfiles /helmfile.d/ /conf/helmfile.d/
```
