### PR TITLE
feat(diff): Pass namespace to helm-diff

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -271,12 +271,14 @@ func (state *HelmState) DiffReleases(helm helmexec.Interface, additionalValues [
 		go func() {
 			for release := range jobQueue {
 				errs := []error{}
-				// Plugin command doesn't support explicit namespace
-				release.Namespace = ""
+
+				state.applyDefaultsTo(release)
+
 				flags, err := flagsForRelease(helm, state.BaseChartPath, release)
 				if err != nil {
 					errs = append(errs, err)
 				}
+
 				for _, value := range additionalValues {
 					valfile, err := filepath.Abs(value)
 					if err != nil {


### PR DESCRIPTION
Tested manually by running `helmfile diff` with debug logging:

```yaml
helmDefaults:
  tillerNamespace: foo

charts:
  - name: grafana
    namespace: grafana
    chart: stable/grafana
```

```console
$ ./helmfile --log-level debug diff
Comparing grafana stable/grafana
exec: helm diff upgrade --allow-unreleased grafana stable/grafana --namespace grafana --tiller-namespace=foo
```

Resolves #179