### PR TITLE
fix: Make logging on unmatched selectors less verbose

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -607,7 +607,8 @@ func (state *HelmState) FilterReleases(labels []string) error {
 		filteredReleases = append(filteredReleases, r)
 	}
 	if len(filteredReleases) == 0 {
-		return fmt.Errorf("specified selector did not match any releases in %s\n", state.file)
+		state.logger.Debugf("specified selector did not match any releases in %s\n", state.file)
+		return nil
 	}
 	state.Releases = filteredReleases
 	return nil

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -861,18 +861,19 @@ func TestHelmState_NoReleaseMatched(t *testing.T) {
 		{
 			name:    "name does not exist",
 			labels:  "name=releaseB",
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name:    "label does not match anything",
 			labels:  "foo=notbar",
-			wantErr: true,
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
 		i := func(t *testing.T) {
 			state := &HelmState{
 				Releases: releases,
+				logger:   logger,
 			}
 			errs := state.FilterReleases([]string{tt.labels})
 			if (errs != nil) != tt.wantErr {


### PR DESCRIPTION
Fixes #200
Depends on #216 because this feature requires zap.SuggeredLogger to be passed to HelmState, which is done as part of #200