### PR TITLE
improve error handling for value rendering

### DIFF
--- a/main.go
+++ b/main.go
@@ -384,8 +384,9 @@ func main() {
 	}
 
 	err := app.Run(os.Args)
-	logger.Errorf("%v",err)
-
+	if err != nil {
+		logger.Errorf("%v",err)
+	}
 }
 
 func eachDesiredStateDo(c *cli.Context, converge func(*state.HelmState, helmexec.Interface) []error) error {

--- a/main.go
+++ b/main.go
@@ -10,12 +10,13 @@ import (
 	"strings"
 	"syscall"
 
+	"os/exec"
+
 	"github.com/roboll/helmfile/helmexec"
 	"github.com/roboll/helmfile/state"
 	"github.com/urfave/cli"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-	"os/exec"
 )
 
 const (
@@ -386,6 +387,7 @@ func main() {
 	err := app.Run(os.Args)
 	if err != nil {
 		logger.Errorf("%v", err)
+		os.Exit(3)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -385,7 +385,7 @@ func main() {
 
 	err := app.Run(os.Args)
 	if err != nil {
-		logger.Errorf("%v",err)
+		logger.Errorf("%v", err)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -384,9 +384,8 @@ func main() {
 	}
 
 	err := app.Run(os.Args)
-	if err != nil {
-		log.Panicf("[bug] this code path shouldn't be arrived: helmfile is expected to exit from within the `cleanup` func in main.go: %v", err)
-	}
+	logger.Errorf("%v",err)
+
 }
 
 func eachDesiredStateDo(c *cli.Context, converge func(*state.HelmState, helmexec.Interface) []error) error {

--- a/state/state.go
+++ b/state/state.go
@@ -703,9 +703,11 @@ func (state *HelmState) namespaceAndValuesFlags(helm helmexec.Interface, basePat
 			if _, err := os.Stat(path); os.IsNotExist(err) {
 				return nil, err
 			}
+
 			yamlBuf, err := RenderTemplateFileToBuffer(path)
 			if err != nil {
-				return nil, err
+
+				return nil, fmt.Errorf("failed to render [%s], because of %v", path, err)
 			}
 			valfile, err := ioutil.TempFile("", "values")
 			if err != nil {


### PR DESCRIPTION
fixes - https://github.com/roboll/helmfile/issues/233

Output on values render error
```
err: failed to render [/Users/sstarcher/xxx/xxx/values.yaml], because of template: stringTemplate:10:18: executing "stringTemplate" at <requiredEnv "HELM_AC...>: error calling requiredEnv: required env var `HELM_ACCOUNT` is not set
```

Also removes panic and sets the output as `apps.Run()` can and will return errors.  Panic makes no sense.