### PR TITLE
fix: panic on flag parsing error

### DIFF
--- a/main.go
+++ b/main.go
@@ -386,7 +386,7 @@ func main() {
 
 	err := app.Run(os.Args)
 	if err != nil {
-		logger.Errorf("%v", err)
+		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(3)
 	}
 }


### PR DESCRIPTION
This is a follow-up for #235.

We setup the default logger only after the flags are parsed successfully.
That's because we init the logger according to the --log-level flag value.