### PR TITLE
feat: All the paths are relative to helmfile.yaml

### DIFF
--- a/helmexec/exec.go
+++ b/helmexec/exec.go
@@ -119,7 +119,7 @@ func (helm *execer) DecryptSecret(name string) (string, error) {
 
 	// os.Rename seems to results in "cross-device link` errors in some cases
 	// Instead of moving, copy it to the destination temp file as a work-around
-	// See https://github.com/roboll/helmfile/issues/251#issuecomment-417166296
+	// See https://github.com/roboll/helmfile/issues/251#issuecomment-417166296f
 	decFile, err := os.Open(name + ".dec")
 	if err != nil {
 		return "", err

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/urfave/cli"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"io/ioutil"
 )
 
 const (
@@ -400,7 +401,7 @@ func eachDesiredStateDo(c *cli.Context, converge func(*state.HelmState, helmexec
 	}
 	allSelectorNotMatched := true
 	for _, f := range desiredStateFiles {
-		yamlBuf, err := tmpl.RenderTemplateFileToBuffer(f)
+		yamlBuf, err := tmpl.NewFileRenderer(ioutil.ReadFile, "").RenderTemplateFileToBuffer(f)
 		if err != nil {
 			return err
 		}

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -560,7 +560,7 @@ func Test_isLocalChart(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := isLocalChart(tt.args.chart); got != tt.want {
-				t.Errorf("isLocalChart() = %v, want %v", got, tt.want)
+				t.Errorf("pathExists() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -879,7 +879,7 @@ func TestHelmState_UpdateDeps(t *testing.T) {
 				Chart: "published/deeper",
 			},
 			{
-				Chart: "./error",
+				Chart: ".error",
 			},
 		},
 	}

--- a/valuesfile/valuesfile.go
+++ b/valuesfile/valuesfile.go
@@ -11,10 +11,10 @@ type renderer struct {
 	tmplFileRenderer tmpl.FileRenderer
 }
 
-func NewRenderer(readFile func(filename string) ([]byte, error)) *renderer {
+func NewRenderer(readFile func(filename string) ([]byte, error), basePath string) *renderer {
 	return &renderer{
 		readFile:         readFile,
-		tmplFileRenderer: tmpl.NewFileRenderer(readFile),
+		tmplFileRenderer: tmpl.NewFileRenderer(readFile, basePath),
 	}
 }
 

--- a/valuesfile/valuesfile_test.go
+++ b/valuesfile/valuesfile_test.go
@@ -24,7 +24,7 @@ func TestRenderToBytes_Gotmpl(t *testing.T) {
 			return []byte(dataFileContent), nil
 		}
 		return nil, fmt.Errorf("unexpected filename: expected=%v or %v, actual=%s", dataFile, valuesTmplFile, filename)
-	})
+	}, "")
 	buf, err := r.RenderToBytes(valuesTmplFile)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -49,7 +49,7 @@ func TestRenderToBytes_Yaml(t *testing.T) {
 			return []byte(valuesYamlContent), nil
 		}
 		return nil, fmt.Errorf("unexpected filename: expected=%v, actual=%s", valuesFile, filename)
-	})
+	}, "")
 	buf, err := r.RenderToBytes(valuesFile)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)


### PR DESCRIPTION
`helmfile lint` works with relative chart reference (#252)
The tempalte function `readFile` accepts the path relative to helmfile.yaml

Resolves #246
Fixes #252