### PR TITLE
fix: follow up for the relative paths improvement

### DIFF
--- a/helmexec/exec.go
+++ b/helmexec/exec.go
@@ -120,7 +120,8 @@ func (helm *execer) DecryptSecret(name string) (string, error) {
 	// os.Rename seems to results in "cross-device link` errors in some cases
 	// Instead of moving, copy it to the destination temp file as a work-around
 	// See https://github.com/roboll/helmfile/issues/251#issuecomment-417166296f
-	decFile, err := os.Open(name + ".dec")
+	decFilename := name + ".dec"
+	decFile, err := os.Open(decFilename)
 	if err != nil {
 		return "", err
 	}
@@ -128,6 +129,14 @@ func (helm *execer) DecryptSecret(name string) (string, error) {
 
 	_, err = io.Copy(tmpFile, decFile)
 	if err != nil {
+		return "", err
+	}
+
+	if err := decFile.Close(); err != nil {
+		return "", err
+	}
+
+	if err := os.Remove(decFilename); err != nil {
 		return "", err
 	}
 

--- a/tmpl/context.go
+++ b/tmpl/context.go
@@ -1,5 +1,6 @@
 package tmpl
 
 type Context struct {
+	basePath string
 	readFile func(string) ([]byte, error)
 }

--- a/tmpl/file.go
+++ b/tmpl/file.go
@@ -2,11 +2,9 @@ package tmpl
 
 import (
 	"bytes"
-	"path/filepath"
 )
 
 type templateFileRenderer struct {
-	basePath string
 	ReadFile func(string) ([]byte, error)
 	Context  *Context
 }
@@ -17,19 +15,16 @@ type FileRenderer interface {
 
 func NewFileRenderer(readFile func(filename string) ([]byte, error), basePath string) *templateFileRenderer {
 	return &templateFileRenderer{
-		basePath: basePath,
 		ReadFile: readFile,
 		Context: &Context{
+			basePath: basePath,
 			readFile: readFile,
 		},
 	}
 }
 
 func (r *templateFileRenderer) RenderTemplateFileToBuffer(file string) (*bytes.Buffer, error) {
-	// path to the file relative to the helmfile.yaml
-	path := filepath.Join(r.basePath, file)
-
-	content, err := r.ReadFile(path)
+	content, err := r.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}

--- a/tmpl/funcs.go
+++ b/tmpl/funcs.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"gopkg.in/yaml.v2"
 	"os"
+	"path/filepath"
 	"strings"
 	"text/template"
 )
@@ -21,7 +22,9 @@ func (c *Context) createFuncMap() template.FuncMap {
 }
 
 func (c *Context) ReadFile(filename string) (string, error) {
-	bytes, err := c.readFile(filename)
+	path := filepath.Join(c.basePath, filename)
+
+	bytes, err := c.readFile(path)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Fixes for the bugs that are introduced by #261, that is values.yaml files specified in `values:` have redundant base path in their prefixes, and remaining .dec files after secrets decryption(https://github.com/roboll/helmfile/issues/251#issuecomment-417285854)