### PR TITLE
Bump Helm 2.9.1 -> 2.10.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,10 @@ FROM alpine:3.7
 
 RUN apk add --no-cache ca-certificates git bash curl
 
-ARG HELM_VERSION=v2.9.1
+ARG HELM_VERSION=v2.10.0
 ARG HELM_LOCATION="https://kubernetes-helm.storage.googleapis.com"
 ARG HELM_FILENAME="helm-${HELM_VERSION}-linux-amd64.tar.gz"
-ARG HELM_SHA256="56ae2d5d08c68d6e7400d462d6ed10c929effac929fedce18d2636a9b4e166ba"
+ARG HELM_SHA256="0fa2ed4983b1e4a3f90f776d08b88b0c73fd83f305b5b634175cb15e61342ffe"
 RUN wget ${HELM_LOCATION}/${HELM_FILENAME} && \
     sha256sum ${HELM_FILENAME} | grep -q "${HELM_SHA256}" && \
     tar zxf ${HELM_FILENAME} && mv /linux-amd64/helm /usr/local/bin/ && \


### PR DESCRIPTION
The Helm client 2.10.0 is incompatible with Tiller 2.9.x, so it may not be desirable to merge this right now. Not sure how eagerly this should be bumped.