### PR TITLE
feat: --suppress-secrets of diff and apply commands

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -215,7 +215,7 @@ func (state *HelmState) SyncReleases(helm helmexec.Interface, additionalValues [
 }
 
 // DiffReleases wrapper for executing helm diff on the releases
-func (state *HelmState) DiffReleases(helm helmexec.Interface, additionalValues []string, workerLimit int, detailedExitCode bool) []error {
+func (state *HelmState) DiffReleases(helm helmexec.Interface, additionalValues []string, workerLimit int, detailedExitCode, suppressSecrets bool) []error {
 	var wgRelease sync.WaitGroup
 	var wgError sync.WaitGroup
 	errs := []error{}
@@ -254,6 +254,10 @@ func (state *HelmState) DiffReleases(helm helmexec.Interface, additionalValues [
 
 				if detailedExitCode {
 					flags = append(flags, "--detailed-exitcode")
+				}
+
+				if suppressSecrets {
+					flags = append(flags, "--suppress-secrets")
 				}
 
 				if len(errs) == 0 {


### PR DESCRIPTION
Adds `--suppress-secrets` to `helmfile apply` and `helmfile diff`, so that the diff command omits the contents of secrets from its output. This is a security feature that should always be turned on for CI/CD use-cases.

With `--suppress-secrets`, the output when there is any change looks like:

```
Comparing bar stable/grafana
default, baz-grafana, Secret (v1) has changed:
+ Changes suppressed on sensitive content of type Secret
```

Resolves #269