### PR TITLE
Fix set in template and lint

### DIFF
--- a/main.go
+++ b/main.go
@@ -220,26 +220,17 @@ func main() {
 					Name:  "values",
 					Usage: "additional value files to be merged into the command",
 				},
-				cli.IntFlag{
-					Name:  "concurrency",
-					Value: 0,
-					Usage: "maximum number of concurrent helm processes to run, 0 is unlimited",
-				},
 			},
 			Action: func(c *cli.Context) error {
 				return findAndIterateOverDesiredStatesUsingFlags(c, func(state *state.HelmState, helm helmexec.Interface) []error {
-					args := args.GetArgs(c.String("args"), state)
-					if len(args) > 0 {
-						helm.SetExtraArgs(args...)
-					}
 					if c.GlobalString("helm-binary") != "" {
 						helm.SetHelmBinary(c.GlobalString("helm-binary"))
 					}
 
 					values := c.StringSlice("values")
-					workers := c.Int("concurrency")
+					args := args.GetArgs(c.String("args"), state)
 
-					return state.LintReleases(helm, values, workers)
+					return state.LintReleases(helm, values, args)
 				})
 			},
 		},

--- a/main.go
+++ b/main.go
@@ -200,11 +200,6 @@ func main() {
 					Name:  "values",
 					Usage: "additional value files to be merged into the command",
 				},
-				cli.IntFlag{
-					Name:  "concurrency",
-					Value: 0,
-					Usage: "maximum number of concurrent helm processes to run, 0 is unlimited",
-				},
 			},
 			Action: func(c *cli.Context) error {
 				return findAndIterateOverDesiredStatesUsingFlags(c, func(state *state.HelmState, helm helmexec.Interface) []error {
@@ -490,9 +485,8 @@ func executeTemplateCommand(c *cli.Context, state *state.HelmState, helm helmexe
 
 	args := args.GetArgs(c.String("args"), state)
 	values := c.StringSlice("values")
-	workers := c.Int("concurrency")
 
-	return state.TemplateReleases(helm, values, workers, args)
+	return state.TemplateReleases(helm, values, args)
 }
 
 func executeDiffCommand(c *cli.Context, state *state.HelmState, helm helmexec.Interface, detailedExitCode, suppressSecrets bool) []error {

--- a/state/state.go
+++ b/state/state.go
@@ -377,7 +377,6 @@ func (state *HelmState) LintReleases(helm helmexec.Interface, additionalValues [
 	}
 
 	for _, release := range state.Releases {
-		errs := []error{}
 		flags, err := state.flagsForLint(helm, &release)
 		if err != nil {
 			errs = append(errs, err)


### PR DESCRIPTION
Hey 
This PR addresses https://github.com/roboll/helmfile/issues/288

NOTE:  There are some breaking changes here, in that both `lint` and `template` no longer accept `--concurrency` as an argument.

As both of these commands are almost instantaneous, and local only run it was adding complexity to the code base with little value.  Now they've converged I was able to share the code to untar the dependencies between those two functions.
