### PR TITLE
docs: update link to documentation for latest released version

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To avoid upgrades for each iteration of `helm`, the `helmfile` executable delega
 
 ## configuration syntax
 
-**CAUTION**: This documentation is for the development version of helmfile. If you are looking for the documentation for any of releases, please switch to the corresponding branch like [v0.12.0](https://github.com/roboll/helmfile/tree/v0.12.0).
+**CAUTION**: This documentation is for the development version of helmfile. If you are looking for the documentation for any of releases, please switch to the corresponding release tag like [v0.31.0](https://github.com/roboll/helmfile/tree/v0.31.0).
 
 The default helmfile is `helmfile.yaml`:
 


### PR DESCRIPTION
Took some time before I realised that I was reading a very old version of the documentation since I followed a link from the README which I thought was to the latest version 🙂 I have updated it.