### PR TITLE
ensure helmfiles are searched relative to base helmfile

### DIFF
--- a/main.go
+++ b/main.go
@@ -583,7 +583,8 @@ func findAndIterateOverDesiredStates(fileOrDir string, converge func(*state.Helm
 			}
 		} else if len(st.Helmfiles) > 0 {
 			for _, globPattern := range st.Helmfiles {
-				matches, err := filepath.Glob(globPattern)
+				helmfileRelativePattern := st.JoinBase(globPattern)
+				matches, err := filepath.Glob(helmfileRelativePattern)
 				if err != nil {
 					return fmt.Errorf("failed processing %s: %v", globPattern, err)
 				}

--- a/state/state.go
+++ b/state/state.go
@@ -761,6 +761,11 @@ func (state *HelmState) UpdateDeps(helm helmexec.Interface) []error {
 	return nil
 }
 
+// JoinBase returns an absolute path in the form basePath/relative
+func (state *HelmState) JoinBase(relPath string) string {
+	return filepath.Join(state.basePath, relPath)
+}
+
 // normalizeChart allows for the distinction between a file path reference and repository references.
 // - Any single (or double character) followed by a `/` will be considered a local file reference and
 // 	 be constructed relative to the `base path`.


### PR DESCRIPTION
This allows calls from an unrelated directory:

```
cd
helmfile -f ~/project/helmfile.yaml
```

Fixes #306