### PR TITLE
double render the helmfile

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,9 +1,14 @@
 package main
 
 import (
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/roboll/helmfile/state"
+	"gopkg.in/yaml.v2"
 )
 
 // See https://github.com/roboll/helmfile/issues/193
@@ -33,5 +38,197 @@ func TestReadFromYaml_DuplicateReleaseName(t *testing.T) {
 	}
 	if err.Error() != "duplicate release \"myrelease1\" found: there were 2 releases named \"myrelease1\" matching specified selector" {
 		t.Errorf("unexpected error happened: %v", err)
+	}
+}
+
+func makeRenderer(readFile func(string) ([]byte, error), env string) *twoPassRenderer {
+	return &twoPassRenderer{
+		reader:   readFile,
+		env:      env,
+		filename: "",
+		logger:   logger,
+		abs:      filepath.Abs,
+	}
+}
+
+func TestReadFromYaml_MakeEnvironmentHasNoSideEffects(t *testing.T) {
+
+	yamlContent := []byte(`
+environments:
+  staging:
+    values:
+    - default/values.yaml
+  production:
+
+releases:
+- name: {{ readFile "other/default/values.yaml" }}
+  chart: mychart1
+`)
+
+	fileReaderCalls := 0
+	// make a reader that returns a simulated context
+	fileReader := func(filename string) ([]byte, error) {
+		expectedFilename := filepath.Clean("default/values.yaml")
+		if !strings.HasSuffix(filename, expectedFilename) {
+			return nil, fmt.Errorf("unexpected filename: expected=%s, actual=%s", expectedFilename, filename)
+		}
+		fileReaderCalls++
+		if fileReaderCalls == 2 {
+			return []byte("SecondPass"), nil
+		}
+		return []byte(""), nil
+	}
+
+	r := makeRenderer(fileReader, "staging")
+	yamlBuf, err := r.renderTemplate(yamlContent)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	var state state.HelmState
+	err = yaml.Unmarshal(yamlBuf.Bytes(), &state)
+
+	if fileReaderCalls > 2 {
+		t.Error("reader should be called only twice")
+	}
+
+	if state.Releases[0].Name != "SecondPass" {
+		t.Errorf("release name should have ben set as SecondPass")
+	}
+}
+
+func TestReadFromYaml_RenderTemplate(t *testing.T) {
+
+	defaultValuesYalm := []byte(`
+releaseName: "hello"
+conditionalReleaseTag: "yes"
+`)
+
+	yamlContent := []byte(`
+environments:
+  staging:
+    values:
+    - default/values.yaml
+  production:
+
+releases:
+- name: {{ .Environment.Values.releaseName }}
+  chart: mychart1
+
+{{ if (eq .Environment.Values.conditionalReleaseTag "yes") }}
+- name: conditionalRelease
+{{ end }}
+
+`)
+
+	// make a reader that returns a simulated context
+	fileReader := func(filename string) ([]byte, error) {
+		expectedFilename := filepath.Clean("default/values.yaml")
+		if !strings.HasSuffix(filename, expectedFilename) {
+			return nil, fmt.Errorf("unexpected filename: expected=%s, actual=%s", expectedFilename, filename)
+		}
+		return defaultValuesYalm, nil
+	}
+
+	r := makeRenderer(fileReader, "staging")
+	// test the double rendering
+	yamlBuf, err := r.renderTemplate(yamlContent)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var state state.HelmState
+	err = yaml.Unmarshal(yamlBuf.Bytes(), &state)
+
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if len(state.Releases) != 2 {
+		t.Fatal("there should be 2 releases")
+	}
+
+	if state.Releases[0].Name != "hello" {
+		t.Errorf("release name should be hello")
+	}
+
+	if state.Releases[1].Name != "conditionalRelease" {
+		t.Error("conditional release should have been present")
+	}
+}
+
+func TestReadFromYaml_RenderTemplateWithValuesReferenceError(t *testing.T) {
+	defaultValuesYalm := []byte("")
+
+	yamlContent := []byte(`
+environments:
+  staging:
+    values:
+    - default/values.yaml
+  production:
+
+{{ if (eq .Environment.Values.releaseName "a") }} # line 8
+releases:
+- name: a
+	chart: mychart1
+{{ end }}
+`)
+
+	// make a reader that returns a simulated context
+	fileReader := func(filename string) ([]byte, error) {
+		return defaultValuesYalm, nil
+	}
+
+	r := makeRenderer(fileReader, "staging")
+	// test the double rendering
+	_, err := r.renderTemplate(yamlContent)
+
+	if !strings.Contains(err.Error(), "stringTemplate:8") {
+		t.Fatalf("error should contain a stringTemplate error (reference to unknow key) %v", err)
+	}
+}
+
+// This test shows that a gotmpl reference will get rendered correctly
+// even if the pre-render disables the readFile and exec functions.
+// This does not apply to .gotmpl files, which is a nice side-effect.
+func TestReadFromYaml_RenderTemplateWithGotmpl(t *testing.T) {
+
+	defaultValuesYalmGotmpl := []byte(`
+releaseName: {{ readFile "nonIgnoredFile" }}
+`)
+
+	yamlContent := []byte(`
+environments:
+  staging:
+    values:
+    - values.yaml.gotmpl
+  production:
+
+{{ if (eq .Environment.Values.releaseName "release-a") }} # line 8
+releases:
+- name: a
+  chart: mychart1
+{{ end }}
+`)
+
+	fileReader := func(filename string) ([]byte, error) {
+		if strings.HasSuffix(filename, "nonIgnoredFile") {
+			return []byte("release-a"), nil
+		}
+		return defaultValuesYalmGotmpl, nil
+	}
+
+	r := makeRenderer(fileReader, "staging")
+	rendered, _ := r.renderTemplate(yamlContent)
+
+	var state state.HelmState
+	yaml.Unmarshal(rendered.Bytes(), &state)
+
+	if len(state.Releases) != 1 {
+		t.Fatal("there should be 1 release")
+	}
+
+	if state.Releases[0].Name != "a" {
+		t.Fatal("release should have been declared")
 	}
 }

--- a/state/create_test.go
+++ b/state/create_test.go
@@ -103,7 +103,7 @@ bar: {{ readFile "bar.txt" }}
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	actual := state.env.Values
+	actual := state.Env.Values
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("unexpected environment values: expected=%v, actual=%v", expected, actual)
 	}

--- a/state/state.go
+++ b/state/state.go
@@ -37,7 +37,7 @@ type HelmState struct {
 	Repositories       []RepositorySpec `yaml:"repositories"`
 	Releases           []ReleaseSpec    `yaml:"releases"`
 
-	env environment.Environment
+	Env environment.Environment
 
 	logger *zap.SugaredLogger
 
@@ -876,7 +876,7 @@ func (state *HelmState) flagsForLint(helm helmexec.Interface, release *ReleaseSp
 }
 
 func (state *HelmState) RenderValuesFileToBytes(path string) ([]byte, error) {
-	r := valuesfile.NewRenderer(state.readFile, state.basePath, state.env)
+	r := valuesfile.NewRenderer(state.readFile, state.basePath, state.Env)
 	return r.RenderToBytes(path)
 }
 

--- a/tmpl/context.go
+++ b/tmpl/context.go
@@ -1,6 +1,7 @@
 package tmpl
 
 type Context struct {
-	basePath string
-	readFile func(string) ([]byte, error)
+	preRender bool
+	basePath  string
+	readFile  func(string) ([]byte, error)
 }

--- a/tmpl/file.go
+++ b/tmpl/file.go
@@ -2,6 +2,8 @@ package tmpl
 
 import (
 	"bytes"
+	"io/ioutil"
+
 	"github.com/roboll/helmfile/environment"
 )
 
@@ -33,11 +35,29 @@ func NewFileRenderer(readFile func(filename string) ([]byte, error), basePath st
 	}
 }
 
+func NewFirstPassRenderer(env environment.Environment) *templateFileRenderer {
+	return &templateFileRenderer{
+		ReadFile: ioutil.ReadFile,
+		Context: &Context{
+			preRender: true,
+			basePath:  "",
+			readFile:  ioutil.ReadFile,
+		},
+		Data: TemplateData{
+			Environment: env,
+		},
+	}
+}
+
 func (r *templateFileRenderer) RenderTemplateFileToBuffer(file string) (*bytes.Buffer, error) {
 	content, err := r.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}
 
+	return r.RenderTemplateContentToBuffer(content)
+}
+
+func (r *templateFileRenderer) RenderTemplateContentToBuffer(content []byte) (*bytes.Buffer, error) {
 	return r.Context.RenderTemplateToBuffer(string(content), r.Data)
 }

--- a/tmpl/funcs.go
+++ b/tmpl/funcs.go
@@ -15,7 +15,7 @@ import (
 type Values = map[string]interface{}
 
 func (c *Context) createFuncMap() template.FuncMap {
-	return template.FuncMap{
+	funcMap := template.FuncMap{
 		"exec":           c.Exec,
 		"readFile":       c.ReadFile,
 		"toYaml":         ToYaml,
@@ -23,6 +23,17 @@ func (c *Context) createFuncMap() template.FuncMap {
 		"setValueAtPath": SetValueAtPath,
 		"requiredEnv":    RequiredEnv,
 	}
+	if c.preRender {
+		// disable potential side-effect template calls
+		funcMap["exec"] = func(string, []interface{}, ...string) (string, error) {
+			return "", nil
+		}
+		funcMap["readFile"] = func(string) (string, error) {
+			return "", nil
+		}
+	}
+
+	return funcMap
 }
 
 func (c *Context) Exec(command string, args []interface{}, inputs ...string) (string, error) {

--- a/tmpl/tmpl.go
+++ b/tmpl/tmpl.go
@@ -11,7 +11,13 @@ func (c *Context) stringTemplate() *template.Template {
 	for name, f := range c.createFuncMap() {
 		funcMap[name] = f
 	}
-	return template.New("stringTemplate").Funcs(funcMap)
+	tmpl := template.New("stringTemplate").Funcs(funcMap)
+	if c.preRender {
+		tmpl.Option("missingkey=zero")
+	} else {
+		tmpl.Option("missingkey=error")
+	}
+	return tmpl
 }
 
 func (c *Context) RenderTemplateToBuffer(s string, data ...interface{}) (*bytes.Buffer, error) {
@@ -28,7 +34,7 @@ func (c *Context) RenderTemplateToBuffer(s string, data ...interface{}) (*bytes.
 	var execErr = t.Execute(&tplString, d)
 
 	if execErr != nil {
-		return nil, execErr
+		return &tplString, execErr
 	}
 
 	return &tplString, nil


### PR DESCRIPTION
This allows using the values defined in the environments: section.

This is done by using a buffer instead of re-reading the file twice.

see #254

@mumoshu can you weigh in on the approach ?