### PR TITLE
fix: {{ .Environment.Name }} being always blank in helmfile.yaml

### DIFF
--- a/main.go
+++ b/main.go
@@ -554,7 +554,7 @@ func findAndIterateOverDesiredStates(fileOrDir string, converge func(*state.Helm
 	noTargetFoundForAllHelmfiles := true
 	for _, f := range desiredStateFiles {
 		logger.Debugf("Processing %s", f)
-		yamlBuf, err := tmpl.NewFileRenderer(ioutil.ReadFile, "", environment.Environment{env, map[string]interface{}(nil)}).RenderTemplateFileToBuffer(f)
+		yamlBuf, err := tmpl.NewFileRenderer(ioutil.ReadFile, "", environment.Environment{Name: env, Values: map[string]interface{}(nil)}).RenderTemplateFileToBuffer(f)
 		if err != nil {
 			return err
 		}

--- a/main.go
+++ b/main.go
@@ -554,7 +554,7 @@ func findAndIterateOverDesiredStates(fileOrDir string, converge func(*state.Helm
 	noTargetFoundForAllHelmfiles := true
 	for _, f := range desiredStateFiles {
 		logger.Debugf("Processing %s", f)
-		yamlBuf, err := tmpl.NewFileRenderer(ioutil.ReadFile, "", environment.EmptyEnvironment).RenderTemplateFileToBuffer(f)
+		yamlBuf, err := tmpl.NewFileRenderer(ioutil.ReadFile, "", environment.Environment{env, map[string]interface{}(nil)}).RenderTemplateFileToBuffer(f)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
I created helmfile.yaml below and executed `helmfile diff` with `--environment` flag. However, it seems that the environment name didn't pass to yamlBuf correctly when reading helmfile.yaml.

```bash
$ cat helmfile.yaml
environments:
  production:
  staging:
releases:
  - name: kiam
    chart: stable/kiam
    version: 1.2.0
    values:
      - values/kiam/{{ .Environment.Name }}/values.yaml
    secrets:
      - secrets/kiam/{{ .Environment.Name }}/secrets.yaml
    wait: true
$ tree ./
./
├── README.md
├── helmfile.yaml
├── secrets
│   └── kiam
│       ├── production
│       │   └── secrets.yaml
│       └── staging
│           └── secrets.yaml
└── values
    └── kiam
        ├── production
        │   └── values.yaml
        └── staging
            └── values.yaml
```

```bash
$ helmfile --environment staging --log-level debug diff
Processing helmfile.yaml
err: release "kiam" in "helmfile.yaml" failed: stat /Users/hashimoto-takuma/go/src/github.com/C-FO/clusterops/manifests/kiam/values/kiam/values.yaml: no such file or directory
```