### PR TITLE
Use --namespace value within Helmfile template

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ releases:
       values:
       - 1
       - 2
+    # set a templated value
+    - name: namespace
+      value: {{ .Namespace }}
     # will attempt to decrypt it using helm-secrets plugin
     secrets:
       - vault_secret.yaml
@@ -200,7 +203,7 @@ GLOBAL OPTIONS:
    --quiet, -q                             Silence output. Equivalent to log-level warn
    --kube-context value                    Set kubectl context. Uses current context by default
    --log-level value                       Set log level, default info
-   --namespace value, -n value             Set namespace. Uses the namespace set in the context by default
+   --namespace value, -n value             Set namespace. Uses the namespace set in the context by default, and is available in templates as {{ .Namespace }}
    --selector value, -l value              Only run using the releases that match labels. Labels can take the form of foo=bar or foo!=bar.
                                            A release must match all labels in a group in order to be used. Multiple groups can be specified at once.
                                            --selector tier=frontend,tier!=proxy --selector tier=backend. Will match all frontend, non-proxy releases AND all backend releases.

--- a/main.go
+++ b/main.go
@@ -667,7 +667,7 @@ func (a *app) FindAndIterateOverDesiredStates(fileOrDir string, converge func(*s
 		r := &twoPassRenderer{
 			reader:    a.readFile,
 			env:       env,
-                        namespace: namespace,
+			namespace: namespace,
 			filename:  f,
 			logger:    a.logger,
 			abs:       a.abs,

--- a/main_test.go
+++ b/main_test.go
@@ -41,11 +41,11 @@ func TestReadFromYaml_DuplicateReleaseName(t *testing.T) {
 	}
 }
 
-func makeRenderer(readFile func(string) ([]byte, error), env string, namespace string) *twoPassRenderer {
+func makeRenderer(readFile func(string) ([]byte, error), env string) *twoPassRenderer {
 	return &twoPassRenderer{
 		reader:    readFile,
 		env:       env,
-		namespace: namespace,
+		namespace: "namespace",
 		filename:  "",
 		logger:    logger,
 		abs:       filepath.Abs,
@@ -80,7 +80,7 @@ releases:
 		return []byte(""), nil
 	}
 
-	r := makeRenderer(fileReader, "staging", "namespace")
+	r := makeRenderer(fileReader, "staging")
 	yamlBuf, err := r.renderTemplate(yamlContent)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -131,7 +131,7 @@ releases:
 		return defaultValuesYaml, nil
 	}
 
-	r := makeRenderer(fileReader, "staging", "namespace")
+	r := makeRenderer(fileReader, "staging")
 	// test the double rendering
 	yamlBuf, err := r.renderTemplate(yamlContent)
 	if err != nil {
@@ -180,7 +180,7 @@ releases:
 		return defaultValuesYaml, nil
 	}
 
-	r := makeRenderer(fileReader, "staging", "namespace")
+	r := makeRenderer(fileReader, "staging")
 	// test the double rendering
 	_, err := r.renderTemplate(yamlContent)
 
@@ -219,7 +219,7 @@ releases:
 		return defaultValuesYamlGotmpl, nil
 	}
 
-	r := makeRenderer(fileReader, "staging", "namespace")
+	r := makeRenderer(fileReader, "staging")
 	rendered, _ := r.renderTemplate(yamlContent)
 
 	var state state.HelmState
@@ -246,7 +246,7 @@ func TestReadFromYaml_RenderTemplateWithNamespace(t *testing.T) {
 		return defaultValuesYaml, nil
 	}
 
-	r := makeRenderer(fileReader, "staging", "namespace")
+	r := makeRenderer(fileReader, "staging")
 	yamlBuf, err := r.renderTemplate(yamlContent)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -61,7 +61,7 @@ wait_deploy_ready httpbin-httpbin
 retry 5 "curl --fail $(minikube service --url --namespace=${test_ns} httpbin-httpbin)/status/200"
 [ ${retry_result} -eq 0 ] || fail "httpbin failed to return 200 OK"
 info "Deleting release"
-${helmfile} -f ${dir}/happypath.yaml delete
+${helmfile} -f ${dir}/happypath.yaml delete --auto-approve
 ${helm} status --namespace=${test_ns} httpbin &> /dev/null && fail "release should not exist anymore after a delete"
 test_pass "happypath"
 

--- a/tmpl/file.go
+++ b/tmpl/file.go
@@ -15,9 +15,9 @@ type templateFileRenderer struct {
 
 type TemplateData struct {
 	// Environment is accessible as `.Environment` from any template executed by the renderer
-	// Namespace is accessible as `.Namespace` from any non-values template executed by the renderer
 	Environment environment.Environment
-	Namespace   string
+	// Namespace is accessible as `.Namespace` from any non-values template executed by the renderer
+	Namespace string
 }
 
 type FileRenderer interface {

--- a/tmpl/file.go
+++ b/tmpl/file.go
@@ -16,13 +16,14 @@ type templateFileRenderer struct {
 type TemplateData struct {
 	// Environment is accessible as `.Environment` from any template executed by the renderer
 	Environment environment.Environment
+        Namespace string
 }
 
 type FileRenderer interface {
 	RenderTemplateFileToBuffer(file string) (*bytes.Buffer, error)
 }
 
-func NewFileRenderer(readFile func(filename string) ([]byte, error), basePath string, env environment.Environment) *templateFileRenderer {
+func NewFileRenderer(readFile func(filename string) ([]byte, error), basePath string, env environment.Environment, namespace string) *templateFileRenderer {
 	return &templateFileRenderer{
 		ReadFile: readFile,
 		Context: &Context{
@@ -31,6 +32,7 @@ func NewFileRenderer(readFile func(filename string) ([]byte, error), basePath st
 		},
 		Data: TemplateData{
 			Environment: env,
+                        Namespace: namespace,
 		},
 	}
 }

--- a/tmpl/file.go
+++ b/tmpl/file.go
@@ -16,7 +16,7 @@ type templateFileRenderer struct {
 type TemplateData struct {
 	// Environment is accessible as `.Environment` from any template executed by the renderer
 	Environment environment.Environment
-	Namespace string
+	Namespace   string
 }
 
 type FileRenderer interface {
@@ -32,7 +32,7 @@ func NewFileRenderer(readFile func(filename string) ([]byte, error), basePath st
 		},
 		Data: TemplateData{
 			Environment: env,
-			Namespace: namespace,
+			Namespace:   namespace,
 		},
 	}
 }

--- a/tmpl/file.go
+++ b/tmpl/file.go
@@ -15,6 +15,7 @@ type templateFileRenderer struct {
 
 type TemplateData struct {
 	// Environment is accessible as `.Environment` from any template executed by the renderer
+	// Namespace is accessible as `.Namespace` from any non-values template executed by the renderer
 	Environment environment.Environment
 	Namespace   string
 }

--- a/tmpl/file.go
+++ b/tmpl/file.go
@@ -16,7 +16,7 @@ type templateFileRenderer struct {
 type TemplateData struct {
 	// Environment is accessible as `.Environment` from any template executed by the renderer
 	Environment environment.Environment
-        Namespace string
+	Namespace string
 }
 
 type FileRenderer interface {
@@ -32,7 +32,7 @@ func NewFileRenderer(readFile func(filename string) ([]byte, error), basePath st
 		},
 		Data: TemplateData{
 			Environment: env,
-                        Namespace: namespace,
+			Namespace: namespace,
 		},
 	}
 }

--- a/valuesfile/valuesfile.go
+++ b/valuesfile/valuesfile.go
@@ -15,7 +15,7 @@ type renderer struct {
 func NewRenderer(readFile func(filename string) ([]byte, error), basePath string, env environment.Environment) *renderer {
 	return &renderer{
 		readFile:         readFile,
-		tmplFileRenderer: tmpl.NewFileRenderer(readFile, basePath, env),
+		tmplFileRenderer: tmpl.NewFileRenderer(readFile, basePath, env, ""),
 	}
 }
 


### PR DESCRIPTION
Resolves #326.

**Comments**

This is my first Go, so let me know if there are any obvious rookie mistakes you'd like fixed. Also, let me know if you'd like to see any additional automated testing.

Note that I did *not* implement plumbing the namespace into *values* file templating, so please let me know if you think that should be part of this.

**Testing done**

Beyond running automated tests, I also put together a test `helmfile.yaml` containing `{{ .Namespace }}` and manually ran `helmfile sync` on it. I confirmed that:

1. When `--namespace` is provided, it gets plumbed through as the value for `{{ .Namespace }}`.
2. When `--namespace` is omitted, `{{ .Namespace }}` is an empty string.
