### PR TITLE
feat: `prepare` and `cleanup` release event hooks

### DIFF
--- a/event/bus.go
+++ b/event/bus.go
@@ -1,0 +1,101 @@
+package event
+
+import (
+	"fmt"
+	"github.com/roboll/helmfile/environment"
+	"github.com/roboll/helmfile/helmexec"
+	"github.com/roboll/helmfile/tmpl"
+	"go.uber.org/zap"
+	"os"
+)
+
+type Hook struct {
+	Name    string   `yaml:"name"`
+	Events  []string `yaml:"events"`
+	Command string   `yaml:"command"`
+	Args    []string `yaml:"args"`
+}
+
+type event struct {
+	Name string
+}
+
+type Bus struct {
+	Runner helmexec.Runner
+	Hooks  []Hook
+
+	BasePath      string
+	StateFilePath string
+	Namespace     string
+
+	Env environment.Environment
+
+	ReadFile func(string) ([]byte, error)
+	Logger   *zap.SugaredLogger
+}
+
+func (bus *Bus) Trigger(evt string, context map[string]interface{}) (bool, error) {
+	if bus.Runner == nil {
+		bus.Runner = helmexec.ShellRunner{
+			Dir: bus.BasePath,
+		}
+	}
+
+	executed := false
+
+	for _, hook := range bus.Hooks {
+		contained := false
+		for _, e := range hook.Events {
+			contained = contained || e == evt
+		}
+		if !contained {
+			continue
+		}
+
+		var err error
+
+		name := hook.Name
+		if name == "" {
+			name = hook.Command
+		}
+
+		fmt.Fprintf(os.Stderr, "%s: basePath=%s\n", bus.StateFilePath, bus.BasePath)
+
+		data := map[string]interface{}{
+			"Environment": bus.Env,
+			"Namespace":   bus.Namespace,
+			"Event": event{
+				Name: evt,
+			},
+		}
+		for k, v := range context {
+			data[k] = v
+		}
+		render := tmpl.NewTextRenderer(bus.ReadFile, bus.BasePath, data)
+
+		bus.Logger.Debugf("hook[%s]: triggered by event \"%s\"\n", name, evt)
+
+		command, err := render.RenderTemplateText(hook.Command)
+		if err != nil {
+			return false, fmt.Errorf("hook[%s]: %v", name, err)
+		}
+
+		args := make([]string, len(hook.Args))
+		for i, raw := range hook.Args {
+			args[i], err = render.RenderTemplateText(raw)
+			if err != nil {
+				return false, fmt.Errorf("hook[%s]: %v", name, err)
+			}
+		}
+
+		bytes, err := bus.Runner.Execute(command, args)
+		bus.Logger.Debugf("hook[%s]: %s\n", name, string(bytes))
+		if err != nil {
+			return false, fmt.Errorf("hook[%s]: command `%s` failed: %v", name, command, err)
+		}
+
+		executed = true
+	}
+
+	return executed, nil
+}

--- a/event/bus_test.go
+++ b/event/bus_test.go
@@ -1,0 +1,113 @@
+package event
+
+import (
+	"fmt"
+	"github.com/roboll/helmfile/environment"
+	"github.com/roboll/helmfile/helmexec"
+	"os"
+	"testing"
+)
+
+var logger = helmexec.NewLogger(os.Stdout, "warn")
+
+type runner struct {
+}
+
+func (r *runner) Execute(cmd string, args []string) ([]byte, error) {
+	if cmd == "ng" {
+		return nil, fmt.Errorf("cmd failed due to invalid cmd: %s", cmd)
+	}
+	for _, a := range args {
+		if a == "ng" {
+			return nil, fmt.Errorf("cmd failed due to invalid arg: %s", a)
+		}
+	}
+	return []byte(""), nil
+}
+
+func TestTrigger(t *testing.T) {
+	cases := []struct {
+		name           string
+		hook           *Hook
+		triggeredEvt   string
+		expectedResult bool
+		expectedErr    string
+	}{
+		{
+			"okhook1",
+			&Hook{"okhook1", []string{"foo"}, "ok", []string{}},
+			"foo",
+			true,
+			"",
+		},
+		{
+			"missinghook1",
+			&Hook{"okhook1", []string{"foo"}, "ok", []string{}},
+			"bar",
+			false,
+			"",
+		},
+		{
+			"nohook1",
+			nil,
+			"bar",
+			false,
+			"",
+		},
+		{
+			"nghook1",
+			&Hook{"nghook1", []string{"foo"}, "ng", []string{}},
+			"foo",
+			false,
+			"hook[nghook1]: command `ng` failed: cmd failed due to invalid cmd: ng",
+		},
+		{
+			"nghook2",
+			&Hook{"nghook2", []string{"foo"}, "ok", []string{"ng"}},
+			"foo",
+			false,
+			"hook[nghook2]: command `ok` failed: cmd failed due to invalid arg: ng",
+		},
+	}
+	readFile := func(filename string) ([]byte, error) {
+		return nil, fmt.Errorf("unexpected call to readFile: %s", filename)
+	}
+	for _, c := range cases {
+		hooks := []Hook{}
+		if c.hook != nil {
+			hooks = append(hooks, *c.hook)
+		}
+		bus := &Bus{
+			Hooks:         hooks,
+			StateFilePath: "path/to/helmfile.yaml",
+			BasePath:      "path/to",
+			Namespace:     "myns",
+			Env:           environment.Environment{Name: "prod"},
+			Logger:        logger,
+			ReadFile:      readFile,
+		}
+
+		bus.Runner = &runner{}
+		data := map[string]interface{}{
+			"Release":         "myrel",
+			"HelmfileCommand": "mycmd",
+		}
+		ok, err := bus.Trigger(c.triggeredEvt, data)
+
+		if ok != c.expectedResult {
+			t.Errorf("unexpected result for case \"%s\": expected=%v, actual=%v", c.name, c.expectedResult, ok)
+		}
+
+		if c.expectedErr != "" {
+			if err == nil {
+				t.Error("error expected, but not occurred")
+			} else if err.Error() != c.expectedErr {
+				t.Errorf("unexpected error for case \"%s\": expected=%s, actual=%v", c.name, c.expectedErr, err)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("unexpected error for case \"%s\": %v", c.name, err)
+			}
+		}
+	}
+}

--- a/helmexec/runner.go
+++ b/helmexec/runner.go
@@ -15,10 +15,13 @@ type Runner interface {
 }
 
 // ShellRunner implemention for shell commands
-type ShellRunner struct{}
+type ShellRunner struct {
+	Dir string
+}
 
 // Execute a shell command
 func (shell ShellRunner) Execute(cmd string, args []string) ([]byte, error) {
 	preparedCmd := exec.Command(cmd, args...)
+	preparedCmd.Dir = shell.Dir
 	return preparedCmd.CombinedOutput()
 }

--- a/main.go
+++ b/main.go
@@ -212,6 +212,10 @@ func main() {
 			},
 			Action: func(c *cli.Context) error {
 				return findAndIterateOverDesiredStatesUsingFlags(c, func(state *state.HelmState, helm helmexec.Interface) []error {
+					if errs := state.PrepareRelease(helm, "template"); errs != nil && len(errs) > 0 {
+						return errs
+					}
+
 					return executeTemplateCommand(c, state, helm)
 				})
 			},
@@ -247,6 +251,9 @@ func main() {
 					if errs := state.SyncRepos(helm); errs != nil && len(errs) > 0 {
 						return errs
 					}
+					if errs := state.PrepareRelease(helm, "lint"); errs != nil && len(errs) > 0 {
+						return errs
+					}
 					return state.LintReleases(helm, values, args, workers)
 				})
 			},
@@ -273,6 +280,9 @@ func main() {
 			Action: func(c *cli.Context) error {
 				return findAndIterateOverDesiredStatesUsingFlags(c, func(state *state.HelmState, helm helmexec.Interface) []error {
 					if errs := state.SyncRepos(helm); errs != nil && len(errs) > 0 {
+						return errs
+					}
+					if errs := state.PrepareRelease(helm, "sync"); errs != nil && len(errs) > 0 {
 						return errs
 					}
 					if errs := state.UpdateDeps(helm); errs != nil && len(errs) > 0 {
@@ -319,6 +329,9 @@ func main() {
 						if errs := st.SyncRepos(helm); errs != nil && len(errs) > 0 {
 							return errs
 						}
+					}
+					if errs := st.PrepareRelease(helm, "apply"); errs != nil && len(errs) > 0 {
+						return errs
 					}
 					if errs := st.UpdateDeps(helm); errs != nil && len(errs) > 0 {
 						return errs

--- a/tmpl/text.go
+++ b/tmpl/text.go
@@ -1,0 +1,30 @@
+package tmpl
+
+type templateTextRenderer struct {
+	ReadText func(string) ([]byte, error)
+	Context  *Context
+	Data     interface{}
+}
+
+type TextRenderer interface {
+	RenderTemplateText(text string) (string, error)
+}
+
+func NewTextRenderer(readFile func(filename string) ([]byte, error), basePath string, data interface{}) *templateTextRenderer {
+	return &templateTextRenderer{
+		ReadText: readFile,
+		Context: &Context{
+			basePath: basePath,
+			readFile: readFile,
+		},
+		Data: data,
+	}
+}
+
+func (r *templateTextRenderer) RenderTemplateText(text string) (string, error) {
+	buf, err := r.Context.RenderTemplateToBuffer(text, r.Data)
+	if err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}


### PR DESCRIPTION
Resolves #295
Resolves #330
Resolves #329 (Supports templating of only `releases[].hooks[].command` and `args` right now
Resolves #324