### PR TITLE
feat: least frequent repository update

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -128,8 +128,13 @@ func (state *HelmState) applyDefaultsTo(spec *ReleaseSpec) {
 	}
 }
 
+type RepoUpdater interface {
+	AddRepo(name, repository, certfile, keyfile, username, password string) error
+	UpdateRepo() error
+}
+
 // SyncRepos will update the given helm releases
-func (state *HelmState) SyncRepos(helm helmexec.Interface) []error {
+func (state *HelmState) SyncRepos(helm RepoUpdater) []error {
 	errs := []error{}
 
 	for _, repo := range state.Repositories {
@@ -828,6 +833,7 @@ func (state *HelmState) PrepareRelease(helm helmexec.Interface, helmfileCommand 
 	for _, release := range state.Releases {
 		if _, err := state.triggerPrepareEvent(&release, helmfileCommand); err != nil {
 			errs = append(errs, &ReleaseError{&release, err})
+			continue
 		}
 	}
 	if len(errs) != 0 {


### PR DESCRIPTION
Prevents helmfile from consuming unnecessarily much time in running `helm
repo update` over and over.

helmfile now marks which repository was updated, and skip second and
further `helm repo update` when all the `repositories` found in a
helmfile.yaml was marked as already updated.

Let's say you had two helmfiles, the first one with repositories `foo` and
`bar`, an the second one with only `bar`. `helmfile repos` will run `helm
update repo` for the first helmfile, marking `foo` and `bar` as already
updated. The second helmfile.yaml contains only `bar`, which is marked as
already updated. So helmfile won't run `helm repo update` for the second.

This applies to all the helmfile command that results in `helm repo
update`, like `repos`, `sync`, `diff` and so on.

Resolves #335

Depends on #353. Please see only the last commit for reviewing this change.