### PR TITLE
relax missing keys when evaluating final value files

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -994,6 +994,7 @@ func (state *HelmState) flagsForLint(helm helmexec.Interface, release *ReleaseSp
 
 func (state *HelmState) RenderValuesFileToBytes(path string) ([]byte, error) {
 	r := valuesfile.NewRenderer(state.readFile, filepath.Dir(path), state.Env)
+	r.SetMissingKeyZero(true)
 	return r.RenderToBytes(path)
 }
 

--- a/tmpl/file.go
+++ b/tmpl/file.go
@@ -22,6 +22,7 @@ type TemplateData struct {
 
 type FileRenderer interface {
 	RenderTemplateFileToBuffer(file string) (*bytes.Buffer, error)
+	SetMissingKeyZero(value bool)
 }
 
 func NewFileRenderer(readFile func(filename string) ([]byte, error), basePath string, env environment.Environment, namespace string) *templateFileRenderer {
@@ -50,6 +51,10 @@ func NewFirstPassRenderer(basePath string, env environment.Environment) *templat
 			Environment: env,
 		},
 	}
+}
+
+func (r *templateFileRenderer) SetMissingKeyZero(value bool) {
+	r.Context.SetMissingKeyZero(value)
 }
 
 func (r *templateFileRenderer) RenderTemplateFileToBuffer(file string) (*bytes.Buffer, error) {

--- a/tmpl/tmpl.go
+++ b/tmpl/tmpl.go
@@ -20,6 +20,10 @@ func (c *Context) stringTemplate() *template.Template {
 	return tmpl
 }
 
+func (c *Context) SetMissingKeyZero(value bool) {
+	c.preRender = value
+}
+
 func (c *Context) RenderTemplateToBuffer(s string, data ...interface{}) (*bytes.Buffer, error) {
 	var t, parseErr = c.stringTemplate().Parse(s)
 	if parseErr != nil {

--- a/valuesfile/valuesfile.go
+++ b/valuesfile/valuesfile.go
@@ -19,6 +19,10 @@ func NewRenderer(readFile func(filename string) ([]byte, error), basePath string
 	}
 }
 
+func (r *renderer) SetMissingKeyZero(value bool) {
+	r.tmplFileRenderer.SetMissingKeyZero(value)
+}
+
 func (r *renderer) RenderToBytes(path string) ([]byte, error) {
 	var yamlBytes []byte
 	splits := strings.Split(path, ".")


### PR DESCRIPTION
This PR reintroduces `missingkey=zero` template rendering option for last render of values (before handing them to helm), to allow piping to default.

This PR can be rejected, depending on what is the outcome of #357 discussion.

Fixes #357 
