### PR TITLE
fix(hook): event hooks should run on remote charts, too

### DIFF
--- a/main.go
+++ b/main.go
@@ -183,6 +183,10 @@ func main() {
 			},
 			Action: func(c *cli.Context) error {
 				return findAndIterateOverDesiredStatesUsingFlags(c, func(state *state.HelmState, helm helmexec.Interface) []error {
+					if errs := state.PrepareRelease(helm, "diff"); errs != nil && len(errs) > 0 {
+						return errs
+					}
+
 					_, errs := executeDiffCommand(c, state, helm, c.Bool("detailed-exitcode"), c.Bool("suppress-secrets"))
 					return errs
 				})

--- a/state/state.go
+++ b/state/state.go
@@ -826,11 +826,8 @@ func (state *HelmState) PrepareRelease(helm helmexec.Interface, helmfileCommand 
 	errs := []error{}
 
 	for _, release := range state.Releases {
-		if isLocalChart(release.Chart) {
-			if _, err := state.triggerPrepareEvent(&release, helmfileCommand); err != nil {
-				errs = append(errs, &ReleaseError{&release, err})
-				continue
-			}
+		if _, err := state.triggerPrepareEvent(&release, helmfileCommand); err != nil {
+			errs = append(errs, &ReleaseError{&release, err})
 		}
 	}
 	if len(errs) != 0 {


### PR DESCRIPTION
And fixed the bug that "diff" was not triggering "prepare" hooks.

Ref #363