### PR TITLE
One Ctrl-C should exit helmfile gracefully

### DIFF
--- a/main.go
+++ b/main.go
@@ -992,7 +992,14 @@ func (a *app) loadDesiredStateFromYaml(yaml []byte, file string, namespace strin
 		sig := <-sigs
 
 		errs := []error{fmt.Errorf("Received [%s] to shutdown ", sig)}
-		clean(st, errs)
+		_ = clean(st, errs)
+		// See http://tldp.org/LDP/abs/html/exitcodes.html
+		switch sig {
+		case syscall.SIGINT:
+			os.Exit(130)
+		case syscall.SIGTERM:
+			os.Exit(143)
+		}
 	}()
 
 	return st, nil


### PR DESCRIPTION
Perhaps in latest commits I unexpectedly changed it to require double Ctrl-C to actually interrupt. This fixes it so that one Ctrl-C exists helmfile.

On the way to the fix, I changed the exit-code to 128 + SIGNAL(2 for SIGINT, 15 for SIGTERM) according to common *nix commands.