### PR TITLE
fix(ci,doc): follow up for default non-interactivity of helmfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,13 +237,15 @@ please look at their [documentation](https://github.com/databus23/helm-diff#helm
 
 ### apply
 
-The `helmfile apply` sub-command begins by executing `diff`. If `diff` finds that there is any changes, `sync` is executed after prompting you for an confirmation. `--auto-approve` skips the confirmation.
+The `helmfile apply` sub-command begins by executing `diff`. If `diff` finds that there is any changes, `sync` is executed. Adding `--interactive` instructs helmfile to request your confirmation before `sync`.
 
 An expected use-case of `apply` is to schedule it to run periodically, so that you can auto-fix skews between the desired and the current state of your apps running on Kubernetes clusters.
 
 ### delete
 
-The `helmfile delete` sub-command deletes all the releases defined in the manfiests
+The `helmfile delete` sub-command deletes all the releases defined in the manfiests.
+
+`helmfile --interactive delete` instructs helmfile to request your confirmation before actually deleting releases.
 
 Note that `delete` doesn't purge releases. So `helmfile delete && helmfile sync` results in sync failed due to that releases names are not deleted but preserved for future references. If you really want to remove releases for reuse, add `--purge` flag to run it like `helmfile delete --purge`.
 

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -61,7 +61,7 @@ wait_deploy_ready httpbin-httpbin
 retry 5 "curl --fail $(minikube service --url --namespace=${test_ns} httpbin-httpbin)/status/200"
 [ ${retry_result} -eq 0 ] || fail "httpbin failed to return 200 OK"
 info "Deleting release"
-${helmfile} -f ${dir}/happypath.yaml delete --auto-approve
+${helmfile} -f ${dir}/happypath.yaml delete
 ${helm} status --namespace=${test_ns} httpbin &> /dev/null && fail "release should not exist anymore after a delete"
 test_pass "happypath"
 


### PR DESCRIPTION
The integration test was failing due to that it was still using `--auto-approve` flag which was removed. The documentation was still refering to `--auto-approve` and had no explanation about the new `--interactive` flag. This fixes all these issues.

This a follow up for #368
See https://github.com/roboll/helmfile/pull/374#issuecomment-425291468 for more context.