### PR TITLE
bump go to 1.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
 
   build:
     docker:
-      - image: circleci/golang:1.10.1
+      - image: circleci/golang:1.11.0
     working_directory: /go/src/github.com/roboll/helmfile
     steps:
       - checkout
@@ -16,7 +16,7 @@ jobs:
 
   test:
     docker:
-      - image: circleci/golang:1.10.1
+      - image: circleci/golang:1.11.0
     working_directory: /go/src/github.com/roboll/helmfile
     steps:
       - checkout
@@ -72,7 +72,7 @@ jobs:
 
   release:
     docker:
-      - image: circleci/golang:1.10.1
+      - image: circleci/golang:1.11.0
     working_directory: /go/src/github.com/roboll/helmfile
     steps:
     - checkout

--- a/app_test.go
+++ b/app_test.go
@@ -14,7 +14,7 @@ import (
 // See https://github.com/roboll/helmfile/issues/193
 func TestVisitDesiredStatesWithReleasesFiltered(t *testing.T) {
 	absPaths := map[string]string{
-		".": "/path/to",
+		".":                   "/path/to",
 		"/path/to/helmfile.d": "/path/to/helmfile.d",
 	}
 	dirs := map[string]bool{
@@ -116,7 +116,7 @@ releases:
 // See https://github.com/roboll/helmfile/issues/320
 func TestVisitDesiredStatesWithReleasesFiltered_UndefinedEnv(t *testing.T) {
 	absPaths := map[string]string{
-		".": "/path/to",
+		".":                   "/path/to",
 		"/path/to/helmfile.d": "/path/to/helmfile.d",
 	}
 	dirs := map[string]bool{
@@ -211,7 +211,7 @@ releases:
 // See https://github.com/roboll/helmfile/issues/322
 func TestVisitDesiredStatesWithReleasesFiltered_Selectors(t *testing.T) {
 	absPaths := map[string]string{
-		".": "/path/to",
+		".":                   "/path/to",
 		"/path/to/helmfile.d": "/path/to/helmfile.d",
 	}
 	dirs := map[string]bool{
@@ -339,7 +339,7 @@ releases:
 // See https://github.com/roboll/helmfile/issues/312
 func TestVisitDesiredStatesWithReleasesFiltered_ReverseOrder(t *testing.T) {
 	absPaths := map[string]string{
-		".": "/path/to",
+		".":                   "/path/to",
 		"/path/to/helmfile.d": "/path/to/helmfile.d",
 	}
 	dirs := map[string]bool{


### PR DESCRIPTION
In go 1.11, the code formatter seems to have changed its formatting rule a bit, that resulted in `make fmt` producing changes introduced in this commit/pr.