### PR TITLE
Deprecated `context` directive

### DIFF
--- a/main.go
+++ b/main.go
@@ -970,11 +970,11 @@ func (a *app) loadDesiredStateFromYaml(yaml []byte, file string, namespace strin
 	}
 
 	if a.kubeContext != "" {
-		if st.Context != "" {
-			log.Printf("err: Cannot use option --kube-context and set attribute context.")
+		if st.HelmDefaults.KubeContext != "" {
+			log.Printf("err: Cannot use option --kube-context and set attribute helmDefaults.kubeContext.")
 			os.Exit(1)
 		}
-		st.Context = a.kubeContext
+		st.HelmDefaults.KubeContext = a.kubeContext
 	}
 	if namespace != "" {
 		if st.Namespace != "" {

--- a/state/create.go
+++ b/state/create.go
@@ -101,6 +101,10 @@ func (c *creator) CreateFromYaml(content []byte, file string, env string) (*Helm
 		state.DeprecatedReleases = []ReleaseSpec{}
 	}
 
+	if state.DeprecatedContext != "" && state.HelmDefaults.KubeContext == "" {
+		state.HelmDefaults.KubeContext = state.DeprecatedContext
+	}
+
 	state.logger = c.logger
 
 	e, err := state.loadEnv(env, c.readFile)

--- a/state/state.go
+++ b/state/state.go
@@ -32,7 +32,7 @@ type HelmState struct {
 	FilePath           string
 	HelmDefaults       HelmSpec         `yaml:"helmDefaults"`
 	Helmfiles          []string         `yaml:"helmfiles"`
-	Context            string           `yaml:"context"`
+	DeprecatedContext  string           `yaml:"context"`
 	DeprecatedReleases []ReleaseSpec    `yaml:"charts"`
 	Namespace          string           `yaml:"namespace"`
 	Repositories       []RepositorySpec `yaml:"repositories"`

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -116,7 +116,7 @@ func TestHelmState_applyDefaultsTo(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			state := &HelmState{
 				basePath:           tt.fields.BaseChartPath,
-				Context:            tt.fields.Context,
+				DeprecatedContext:  tt.fields.Context,
 				DeprecatedReleases: tt.fields.DeprecatedReleases,
 				Namespace:          tt.fields.Namespace,
 				Repositories:       tt.fields.Repositories,
@@ -380,10 +380,10 @@ func TestHelmState_flagsForUpgrade(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			state := &HelmState{
-				basePath:     "./",
-				Context:      "default",
-				Releases:     []ReleaseSpec{*tt.release},
-				HelmDefaults: tt.defaults,
+				basePath:          "./",
+				DeprecatedContext: "default",
+				Releases:          []ReleaseSpec{*tt.release},
+				HelmDefaults:      tt.defaults,
 			}
 			helm := helmexec.New(logger, "default")
 			args, err := state.flagsForUpgrade(helm, tt.release)


### PR DESCRIPTION
Fixes #383. Deprecated `context` directive in favor of `helmDefaults.kubeContext`.

Also fixed `--kube-context` helmfile argument usage