### PR TITLE
Remove extra appending of chartName for lint and template

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -385,7 +385,6 @@ func (state *HelmState) downloadCharts(helm helmexec.Interface, dir string, work
 							errs = append(errs, err)
 						}
 					}
-					chartPath = path.Join(chartPath, chartNameWithoutRepository(release.Chart))
 				}
 				results <- &downloadResults{release.Name, chartPath}
 			}


### PR DESCRIPTION
Suggested fix to remove extra path name after downloading chart from repository.

Closes https://github.com/roboll/helmfile/issues/407