### PR TITLE
add common value path

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -14,7 +14,7 @@ import (
 // See https://github.com/roboll/helmfile/issues/193
 func TestVisitDesiredStatesWithReleasesFiltered(t *testing.T) {
 	absPaths := map[string]string{
-		".": "/path/to",
+		".":                   "/path/to",
 		"/path/to/helmfile.d": "/path/to/helmfile.d",
 	}
 	dirs := map[string]bool{
@@ -116,7 +116,7 @@ releases:
 // See https://github.com/roboll/helmfile/issues/320
 func TestVisitDesiredStatesWithReleasesFiltered_UndefinedEnv(t *testing.T) {
 	absPaths := map[string]string{
-		".": "/path/to",
+		".":                   "/path/to",
 		"/path/to/helmfile.d": "/path/to/helmfile.d",
 	}
 	dirs := map[string]bool{
@@ -211,7 +211,7 @@ releases:
 // See https://github.com/roboll/helmfile/issues/322
 func TestVisitDesiredStatesWithReleasesFiltered_Selectors(t *testing.T) {
 	absPaths := map[string]string{
-		".": "/path/to",
+		".":                   "/path/to",
 		"/path/to/helmfile.d": "/path/to/helmfile.d",
 	}
 	dirs := map[string]bool{
@@ -339,7 +339,7 @@ releases:
 // See https://github.com/roboll/helmfile/issues/312
 func TestVisitDesiredStatesWithReleasesFiltered_ReverseOrder(t *testing.T) {
 	absPaths := map[string]string{
-		".": "/path/to",
+		".":                   "/path/to",
 		"/path/to/helmfile.d": "/path/to/helmfile.d",
 	}
 	dirs := map[string]bool{

--- a/app_test.go
+++ b/app_test.go
@@ -14,7 +14,7 @@ import (
 // See https://github.com/roboll/helmfile/issues/193
 func TestVisitDesiredStatesWithReleasesFiltered(t *testing.T) {
 	absPaths := map[string]string{
-		".":                   "/path/to",
+		".": "/path/to",
 		"/path/to/helmfile.d": "/path/to/helmfile.d",
 	}
 	dirs := map[string]bool{
@@ -116,7 +116,7 @@ releases:
 // See https://github.com/roboll/helmfile/issues/320
 func TestVisitDesiredStatesWithReleasesFiltered_UndefinedEnv(t *testing.T) {
 	absPaths := map[string]string{
-		".":                   "/path/to",
+		".": "/path/to",
 		"/path/to/helmfile.d": "/path/to/helmfile.d",
 	}
 	dirs := map[string]bool{
@@ -211,7 +211,7 @@ releases:
 // See https://github.com/roboll/helmfile/issues/322
 func TestVisitDesiredStatesWithReleasesFiltered_Selectors(t *testing.T) {
 	absPaths := map[string]string{
-		".":                   "/path/to",
+		".": "/path/to",
 		"/path/to/helmfile.d": "/path/to/helmfile.d",
 	}
 	dirs := map[string]bool{
@@ -339,7 +339,7 @@ releases:
 // See https://github.com/roboll/helmfile/issues/312
 func TestVisitDesiredStatesWithReleasesFiltered_ReverseOrder(t *testing.T) {
 	absPaths := map[string]string{
-		".":                   "/path/to",
+		".": "/path/to",
 		"/path/to/helmfile.d": "/path/to/helmfile.d",
 	}
 	dirs := map[string]bool{

--- a/state/state.go
+++ b/state/state.go
@@ -108,7 +108,7 @@ type ReleaseSpec struct {
 	// The 'env' section is not really necessary any longer, as 'set' would now provide the same functionality
 	EnvValues []SetValue `yaml:"env"`
 
-	ValuePath string  	`yaml:"valuePath"`
+	ValuePath string `yaml:"valuePath"`
 
 	// generatedValues are values that need cleaned up on exit
 	generatedValues []string

--- a/state/state.go
+++ b/state/state.go
@@ -108,7 +108,7 @@ type ReleaseSpec struct {
 	// The 'env' section is not really necessary any longer, as 'set' would now provide the same functionality
 	EnvValues []SetValue `yaml:"env"`
 
-	ValuePath string `yaml:"valuePath"`
+	ValuesPathPrefix string `yaml:"valuesPathPrefix"`
 
 	// generatedValues are values that need cleaned up on exit
 	generatedValues []string
@@ -1065,7 +1065,7 @@ func (state *HelmState) namespaceAndValuesFlags(helm helmexec.Interface, release
 	for _, value := range release.Values {
 		switch typedValue := value.(type) {
 		case string:
-			path := state.normalizePath(release.ValuePath + typedValue)
+			path := state.normalizePath(release.ValuesPathPrefix + typedValue)
 
 			if _, err := os.Stat(path); os.IsNotExist(err) {
 				return nil, err
@@ -1104,7 +1104,7 @@ func (state *HelmState) namespaceAndValuesFlags(helm helmexec.Interface, release
 		}
 	}
 	for _, value := range release.Secrets {
-		path := state.normalizePath(release.ValuePath + value)
+		path := state.normalizePath(release.ValuesPathPrefix + value)
 		if _, err := os.Stat(path); os.IsNotExist(err) {
 			return nil, err
 		}

--- a/state/state.go
+++ b/state/state.go
@@ -108,6 +108,8 @@ type ReleaseSpec struct {
 	// The 'env' section is not really necessary any longer, as 'set' would now provide the same functionality
 	EnvValues []SetValue `yaml:"env"`
 
+	ValuePath string  	`yaml:"valuePath"`
+
 	// generatedValues are values that need cleaned up on exit
 	generatedValues []string
 }
@@ -1063,7 +1065,8 @@ func (state *HelmState) namespaceAndValuesFlags(helm helmexec.Interface, release
 	for _, value := range release.Values {
 		switch typedValue := value.(type) {
 		case string:
-			path := state.normalizePath(typedValue)
+			path := state.normalizePath(release.ValuePath + typedValue)
+
 			if _, err := os.Stat(path); os.IsNotExist(err) {
 				return nil, err
 			}
@@ -1101,7 +1104,7 @@ func (state *HelmState) namespaceAndValuesFlags(helm helmexec.Interface, release
 		}
 	}
 	for _, value := range release.Secrets {
-		path := state.normalizePath(value)
+		path := state.normalizePath(release.ValuePath + value)
 		if _, err := os.Stat(path); os.IsNotExist(err) {
 			return nil, err
 		}


### PR DESCRIPTION
Remove duplicated declaration path for cleaner helmfile, for example, this configuration.
```
- chart: projectABC
  name: {{ .Environment.Name }}-projectABC
  namespace: abc
  version: {{ .Environment.Values.projectABC.chart.version }}
  valuePath: ../values/{{ .Environment.Name }}/
  values:
  - common.yaml
  - project-abc.yaml
  - platform.yaml
  - ...
  secrets:
  - secrets.yaml
```