### PR TITLE
docs: Remove `go get` from the recommended installation methods

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# DCO + License
+
+By contributing to `helmfile`, you accept and agree to the following DCO and license terms and
+conditions for your present and future Contributions submitted to the `helmfile` project.
+
+[DCO](https://developercertificate.org/)
+[License](https://github.com/roboll/helmfile/blob/master/LICENSE)
+
+# Developing helmfile
+
+Locate your `GOPATH`, usually `~/go`, and run:
+
+```console
+$ go get github.com/roboll/helmfile
+
+$ cd $GOPATH/src/github.com/roboll/helmfile
+
+$ git checkout -b your-shiny-new-feature origin/master
+
+...
+
+$ git commit -m 'feat: do whatever for whatever purpose
+
+This adds ... by:
+
+- Adding ...
+- Changing ...
+- Removing...
+
+Resolves #ISSUE_NUMBER
+'
+
+$ hub fork
+$ git push YOUR_GITHUB_USER your-shiny-new-feature
+$ hub pull-request
+```
+
+Note that the above tutorial uses [hub](https://github.com/github/hub) just for ease of explanation.
+Please use whatever tool or way to author your pull request!

--- a/README.md
+++ b/README.md
@@ -149,7 +149,6 @@ releases:
 
 ## installation
 
-- `go get github.com/roboll/helmfile` or
 - download one of [releases](https://github.com/roboll/helmfile/releases) or
 - run as a [container](https://quay.io/roboll/helmfile) or
 - install from [AUR](https://aur.archlinux.org/packages/kubernetes-helmfile-bin/) for Archlinux or


### PR DESCRIPTION
Add a contribution guide instead and note about the `go get` way there according to the discussion made in the relevant issue.

Resolves #393