### PR TITLE
fix missingFileHandler

### DIFF
--- a/docs/writing-helmfile.md
+++ b/docs/writing-helmfile.md
@@ -72,6 +72,8 @@ templates:
     chart: stable/{{`{{ .Release.Name }}`}}
     namespace: kube-system
     # This prevents helmfile exiting when it encounters a missing file
+    # Valid values are "Error", "Warn", "Info", "Debug". The default is "Error"
+    # Use "Debug" to make missing files errors invisible at the default log level(--log-level=INFO)
     missingFileHandler: Warn
     values:
     - config/{{`{{ .Release.Name }}`}}/values.yaml

--- a/state/state.go
+++ b/state/state.go
@@ -1104,10 +1104,16 @@ func (st *HelmState) namespaceAndValuesFlags(helm helmexec.Interface, release *R
 			path := st.normalizePath(release.ValuesPathPrefix + typedValue)
 
 			if _, err := os.Stat(path); os.IsNotExist(err) {
-				if release.MissingFileHandler == nil && *release.MissingFileHandler == "Error" {
+				if release.MissingFileHandler == nil || *release.MissingFileHandler == "Error" {
 					return nil, err
-				} else {
+				} else if *release.MissingFileHandler == "Warn" {
 					st.logger.Warnf("skipping missing values file \"%s\"", path)
+					continue
+				} else if *release.MissingFileHandler == "Info" {
+					st.logger.Infof("skipping missing values file \"%s\"", path)
+					continue
+				} else {
+					st.logger.Debugf("skipping missing values file \"%s\"", path)
 					continue
 				}
 			}
@@ -1148,10 +1154,16 @@ func (st *HelmState) namespaceAndValuesFlags(helm helmexec.Interface, release *R
 	for _, value := range release.Secrets {
 		path := st.normalizePath(release.ValuesPathPrefix + value)
 		if _, err := os.Stat(path); os.IsNotExist(err) {
-			if release.MissingFileHandler == nil && *release.MissingFileHandler == "Error" {
+			if release.MissingFileHandler == nil || *release.MissingFileHandler == "Error" {
 				return nil, err
-			} else {
+			} else if *release.MissingFileHandler == "Warn" {
 				st.logger.Warnf("skipping missing secrets file \"%s\"", path)
+				continue
+			} else if *release.MissingFileHandler == "Info" {
+				st.logger.Infof("skipping missing secrets file \"%s\"", path)
+				continue
+			} else {
+				st.logger.Debugf("skipping missing secrets file \"%s\"", path)
 				continue
 			}
 		}


### PR DESCRIPTION
- Fix panics when `missingFileHandler` is not defined
- Fix `missingFileHandler: Error` had been writing errors at the Warn level
- Add `Info` and `Debug` as valid values

Ref https://github.com/roboll/helmfile/pull/439#issuecomment-456155521