### PR TITLE
feat: configurable concurrency for `helmfile test`

### DIFF
--- a/main.go
+++ b/main.go
@@ -496,18 +496,24 @@ Do you really want to delete?
 					Value: 300,
 					Usage: "maximum time for tests to run before being considered failed",
 				},
+				cli.IntFlag{
+					Name:  "concurrency",
+					Value: 0,
+					Usage: "maximum number of concurrent helm processes to run, 0 is unlimited",
+				},
 			},
 			Action: func(c *cli.Context) error {
 				return findAndIterateOverDesiredStatesUsingFlags(c, func(state *state.HelmState, helm helmexec.Interface, _ context) []error {
 					cleanup := c.Bool("cleanup")
 					timeout := c.Int("timeout")
+					concurrency := c.Int("concurrency")
 
 					args := args.GetArgs(c.String("args"), state)
 					if len(args) > 0 {
 						helm.SetExtraArgs(args...)
 					}
 
-					return state.TestReleases(helm, cleanup, timeout)
+					return state.TestReleases(helm, cleanup, timeout, concurrency)
 				})
 			},
 		},

--- a/state/state_run.go
+++ b/state/state_run.go
@@ -1,0 +1,88 @@
+package state
+
+import (
+	"fmt"
+	"github.com/roboll/helmfile/helmexec"
+	"sync"
+)
+
+type result struct {
+	release ReleaseSpec
+	err     error
+}
+
+func (st *HelmState) scatterGather(concurrency int, items int, produceInputs func(), receiveInputsAndProduceIntermediates func(int), aggregateIntermediates func()) {
+	numReleases := len(st.Releases)
+	if concurrency < 1 {
+		concurrency = numReleases
+	} else if concurrency > numReleases {
+		concurrency = numReleases
+	}
+
+	// WaitGroup is required to wait until goroutine per job in job queue cleanly stops.
+	var waitGroup sync.WaitGroup
+	waitGroup.Add(concurrency)
+
+	go produceInputs()
+
+	for w := 1; w <= concurrency; w++ {
+		go func(id int) {
+			st.logger.Debugf("worker %d/%d started", id, concurrency)
+			receiveInputsAndProduceIntermediates(id)
+			st.logger.Debugf("worker %d/%d finished", id, concurrency)
+			waitGroup.Done()
+		}(w)
+	}
+
+	aggregateIntermediates()
+
+	// Wait until all the goroutines to gracefully finish
+	waitGroup.Wait()
+}
+
+func (st *HelmState) scatterGatherReleases(helm helmexec.Interface, concurrency int, do func(ReleaseSpec) error) []error {
+	var errs []error
+
+	inputs := st.Releases
+	inputsSize := len(inputs)
+
+	releases := make(chan ReleaseSpec)
+	results := make(chan result)
+
+	st.scatterGather(
+		concurrency,
+		inputsSize,
+		func() {
+			for _, release := range inputs {
+				releases <- release
+			}
+			close(releases)
+		},
+		func(id int) {
+			for release := range releases {
+				err := do(release)
+				st.logger.Debugf("sending result for release: %s\n", release.Name)
+				results <- result{release: release, err: err}
+				st.logger.Debugf("sent result for release: %s\n", release.Name)
+			}
+		},
+		func() {
+			for i := range inputs {
+				st.logger.Debugf("receiving result %d", i)
+				r := <-results
+				if r.err != nil {
+					errs = append(errs, fmt.Errorf("release \"%s\" failed: %v", r.release.Name, r.err))
+				} else {
+					st.logger.Debugf("received result for release \"%s\"", r.release.Name)
+				}
+				st.logger.Debugf("received result for %d", i)
+			}
+		},
+	)
+
+	if len(errs) != 0 {
+		return errs
+	}
+
+	return nil
+}

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -738,6 +738,7 @@ func TestHelmState_SyncReleases(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			state := &HelmState{
 				Releases: tt.releases,
+				logger:   logger,
 			}
 			if _ = state.SyncReleases(tt.helm, []string{}, 1); !reflect.DeepEqual(tt.helm.releases, tt.wantReleases) {
 				t.Errorf("HelmState.SyncReleases() for [%s] = %v, want %v", tt.name, tt.helm.releases, tt.wantReleases)
@@ -815,6 +816,7 @@ func TestHelmState_ReleaseStatuses(t *testing.T) {
 		i := func(t *testing.T) {
 			state := &HelmState{
 				Releases: tt.releases,
+				logger:   logger,
 			}
 			errs := state.ReleaseStatuses(tt.helm, 1)
 			if (errs != nil) != tt.wantErr {
@@ -874,8 +876,9 @@ func TestHelmState_TestReleasesNoCleanUp(t *testing.T) {
 		i := func(t *testing.T) {
 			state := &HelmState{
 				Releases: tt.releases,
+				logger:   logger,
 			}
-			errs := state.TestReleases(tt.helm, tt.cleanup, 1)
+			errs := state.TestReleases(tt.helm, tt.cleanup, 1, 1)
 			if (errs != nil) != tt.wantErr {
 				t.Errorf("TestReleases() for %s error = %v, wantErr %v", tt.name, errs, tt.wantErr)
 				return


### PR DESCRIPTION
`helmfile test --concurency N` to set a concurrency number.
It is automatically ceiled at the number of releases just to reduce wasting computing resources.

Also, I've refactored the scatter-gather logic scattered across the code-base.

Resolves #433