### PR TITLE
fix: remote file provided to `set.file` should not break helmfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,10 @@ static-linux:
 	env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o "dist/helmfile_linux_amd64" -ldflags '-X main.Version=${TAG}' ${TARGETS}
 .PHONY: linux
 
+install:
+	env CGO_ENABLED=0 go install -ldflags '-X main.Version=${TAG}' ${TARGETS}
+.PHONY: install
+
 clean:
 	rm dist/helmfile_*
 .PHONY: clean

--- a/state/state.go
+++ b/state/state.go
@@ -23,6 +23,7 @@ import (
 	"github.com/roboll/helmfile/tmpl"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v2"
+	"net/url"
 )
 
 // HelmState structure for the helmfile
@@ -857,7 +858,8 @@ func (st *HelmState) JoinBase(relPath string) string {
 
 // normalizes relative path to absolute one
 func (st *HelmState) normalizePath(path string) string {
-	if filepath.IsAbs(path) {
+	u, _ := url.Parse(path)
+	if u.Scheme != "" || filepath.IsAbs(path) {
 		return path
 	} else {
 		return st.JoinBase(path)


### PR DESCRIPTION
Fixes #473