### PR TITLE
fix: read absolute path with readFile

### DIFF
--- a/tmpl/context_funcs.go
+++ b/tmpl/context_funcs.go
@@ -114,7 +114,12 @@ func (c *Context) Exec(command string, args []interface{}, inputs ...string) (st
 }
 
 func (c *Context) ReadFile(filename string) (string, error) {
-	path := filepath.Join(c.basePath, filename)
+	var path string
+	if filepath.IsAbs(filename) {
+		path = filename
+	} else {
+		path = filepath.Join(c.basePath, filename)
+	}
 
 	bytes, err := c.readFile(path)
 	if err != nil {

--- a/tmpl/context_funcs_test.go
+++ b/tmpl/context_funcs_test.go
@@ -2,6 +2,7 @@ package tmpl
 
 import (
 	"fmt"
+	"path/filepath"
 	"reflect"
 	"testing"
 )
@@ -11,7 +12,27 @@ func TestReadFile(t *testing.T) {
   bar: BAR
 `
 	expectedFilename := "values.yaml"
-	ctx := &Context{readFile: func(filename string) ([]byte, error) {
+	ctx := &Context{basePath: ".", readFile: func(filename string) ([]byte, error) {
+		if filename != expectedFilename {
+			return nil, fmt.Errorf("unexpected filename: expected=%v, actual=%s", expectedFilename, filename)
+		}
+		return []byte(expected), nil
+	}}
+	actual, err := ctx.ReadFile(expectedFilename)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("unexpected result: expected=%v, actual=%v", expected, actual)
+	}
+}
+
+func TestReadFile_PassAbsPath(t *testing.T) {
+	expected := `foo:
+  bar: BAR
+`
+	expectedFilename, _ := filepath.Abs("values.yaml")
+	ctx := &Context{basePath: ".", readFile: func(filename string) ([]byte, error) {
 		if filename != expectedFilename {
 			return nil, fmt.Errorf("unexpected filename: expected=%v, actual=%s", expectedFilename, filename)
 		}


### PR DESCRIPTION
When passing absolute path `/path/to/file`, it converts to `path/to/file` of the relative path and the reading failed.