### PR TITLE
fix: `helmfile sync` should NOT continue when secret decryption fails

### DIFF
--- a/helmexec/exec.go
+++ b/helmexec/exec.go
@@ -118,6 +118,9 @@ func (helm *execer) DecryptSecret(name string) (string, error) {
 	helm.logger.Infof("Decrypting secret %v", name)
 	out, err := helm.exec(append([]string{"secrets", "dec", name})...)
 	helm.write(out)
+	if err != nil {
+		return "", err
+	}
 
 	tmpFile, err := ioutil.TempFile("", "secret")
 	if err != nil {


### PR DESCRIPTION
Fixes #336