### PR TITLE
Add option to set to force helm to template value as string

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ releases:
     # set a templated value
     - name: namespace
       value: {{ .Namespace }}
+    # force value to be evaluated as a string, translates to --set-string bigint=123456789012 https://github.com/helm/helm/pull/3599
+    - name: bigint
+      string: "123456789012"
     # will attempt to decrypt it using helm-secrets plugin
     secrets:
       - vault_secret.yaml

--- a/state/state.go
+++ b/state/state.go
@@ -127,6 +127,7 @@ type SetValue struct {
 	Value  string   `yaml:"value"`
 	File   string   `yaml:"file"`
 	Values []string `yaml:"values"`
+	String string   `yaml:"string"`
 }
 
 const DefaultEnv = "default"
@@ -1090,6 +1091,8 @@ func (st *HelmState) namespaceAndValuesFlags(helm helmexec.Interface, release *R
 				flags = append(flags, "--set", fmt.Sprintf("%s=%s", escape(set.Name), escape(set.Value)))
 			} else if set.File != "" {
 				flags = append(flags, "--set-file", fmt.Sprintf("%s=%s", escape(set.Name), st.normalizePath(set.File)))
+			} else if set.String != "" {
+				flags = append(flags, "--set-string", fmt.Sprintf("%s=%s", escape(set.Name), escape(set.String)))
 			} else if len(set.Values) > 0 {
 				items := make([]string, len(set.Values))
 				for i, raw := range set.Values {

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -741,6 +741,27 @@ func TestHelmState_SyncReleases(t *testing.T) {
 			helm:         &mockHelmExec{},
 			wantReleases: []mockRelease{{"releaseName", []string{"--set", "foo.bar[0]={A,B}"}}},
 		},
+		{
+			name: "explicit string value",
+			releases: []ReleaseSpec{
+				{
+					Name:  "releaseName",
+					Chart: "foo",
+					SetValues: []SetValue{
+						{
+							Name:  "someList",
+							Value: "a,b,c",
+						},
+						{
+							Name:   "bigint",
+							String: "123456789012",
+						},
+					},
+				},
+			},
+			helm:         &mockHelmExec{},
+			wantReleases: []mockRelease{{"releaseName", []string{"--set", "someList=a\\,b\\,c", "--set-string", "bigint=123456789012"}}},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Adds additional capabilities to `set` to force a value to be evaluated as a string (Translates to Helms `--set-string`)

Activated by specifying `string` instead of `value`:

```yaml
set:
- name: bigint
  string: 123456789012
```

Fixes https://github.com/roboll/helmfile/issues/476
