### PR TITLE
Fix: Release options should override helm defaults

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -928,11 +928,11 @@ func (st *HelmState) flagsForUpgrade(helm helmexec.Interface, release *ReleaseSp
 		flags = append(flags, "--devel")
 	}
 
-	if release.Verify != nil && *release.Verify || st.HelmDefaults.Verify {
+	if release.Verify != nil && *release.Verify || release.Verify == nil && st.HelmDefaults.Verify {
 		flags = append(flags, "--verify")
 	}
 
-	if release.Wait != nil && *release.Wait || st.HelmDefaults.Wait {
+	if release.Wait != nil && *release.Wait || release.Wait == nil && st.HelmDefaults.Wait {
 		flags = append(flags, "--wait")
 	}
 
@@ -944,15 +944,15 @@ func (st *HelmState) flagsForUpgrade(helm helmexec.Interface, release *ReleaseSp
 		flags = append(flags, "--timeout", fmt.Sprintf("%d", timeout))
 	}
 
-	if release.Force != nil && *release.Force || st.HelmDefaults.Force {
+	if release.Force != nil && *release.Force || release.Force == nil && st.HelmDefaults.Force {
 		flags = append(flags, "--force")
 	}
 
-	if release.RecreatePods != nil && *release.RecreatePods || st.HelmDefaults.RecreatePods {
+	if release.RecreatePods != nil && *release.RecreatePods || release.RecreatePods == nil && st.HelmDefaults.RecreatePods {
 		flags = append(flags, "--recreate-pods")
 	}
 
-	if release.Atomic != nil && *release.Atomic || st.HelmDefaults.Atomic {
+	if release.Atomic != nil && *release.Atomic || release.Atomic == nil && st.HelmDefaults.Atomic {
 		flags = append(flags, "--atomic")
 	}
 

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -192,7 +192,6 @@ func TestHelmState_flagsForUpgrade(t *testing.T) {
 			},
 			want: []string{
 				"--version", "0.1",
-				"--verify",
 				"--namespace", "test-namespace",
 			},
 		},
@@ -228,7 +227,6 @@ func TestHelmState_flagsForUpgrade(t *testing.T) {
 			},
 			want: []string{
 				"--version", "0.1",
-				"--force",
 				"--namespace", "test-namespace",
 			},
 		},
@@ -264,7 +262,6 @@ func TestHelmState_flagsForUpgrade(t *testing.T) {
 			},
 			want: []string{
 				"--version", "0.1",
-				"--recreate-pods",
 				"--namespace", "test-namespace",
 			},
 		},
@@ -336,7 +333,6 @@ func TestHelmState_flagsForUpgrade(t *testing.T) {
 			},
 			want: []string{
 				"--version", "0.1",
-				"--wait",
 				"--namespace", "test-namespace",
 			},
 		},
@@ -395,7 +391,7 @@ func TestHelmState_flagsForUpgrade(t *testing.T) {
 			},
 		},
 		{
-			name: "atomic-from-default",
+			name: "atomic-override-default",
 			defaults: HelmSpec{
 				Atomic: true,
 			},
@@ -403,6 +399,22 @@ func TestHelmState_flagsForUpgrade(t *testing.T) {
 				Chart:     "test/chart",
 				Version:   "0.1",
 				Atomic:    &disable,
+				Name:      "test-charts",
+				Namespace: "test-namespace",
+			},
+			want: []string{
+				"--version", "0.1",
+				"--namespace", "test-namespace",
+			},
+		},
+		{
+			name: "atomic-from-default",
+			defaults: HelmSpec{
+				Atomic: true,
+			},
+			release: &ReleaseSpec{
+				Chart:     "test/chart",
+				Version:   "0.1",
 				Name:      "test-charts",
 				Namespace: "test-namespace",
 			},


### PR DESCRIPTION
Options specified in releases (e.g. `recreatePods`) should override the respective options set in `helmDefaults`. Currently, `helmDefaults` takes precedence.

In the below example, `--force` should not be passed as an additional deployment argument:
```
helmDefaults:
  force: true

releases:
  - name: example
    namespace: example
    chart: some/repo
    version: ~1.24.1
    force: false
```

Fixes https://github.com/roboll/helmfile/issues/492

