### PR TITLE
fix: prevent confusing error messages when `installed: false`

### DIFF
--- a/helmexec/exec.go
+++ b/helmexec/exec.go
@@ -110,6 +110,13 @@ func (helm *execer) ReleaseStatus(name string) error {
 	return err
 }
 
+func (helm *execer) List(filter string) (string, error) {
+	helm.logger.Infof("Listing releases matching %v", filter)
+	out, err := helm.exec(append([]string{"list", filter})...)
+	helm.write(out)
+	return string(out), err
+}
+
 func (helm *execer) DecryptSecret(name string) (string, error) {
 	// Prevents https://github.com/roboll/helmfile/issues/258
 	helm.decryptionMutex.Lock()

--- a/helmexec/helmexec.go
+++ b/helmexec/helmexec.go
@@ -17,6 +17,6 @@ type Interface interface {
 	ReleaseStatus(name string) error
 	DeleteRelease(name string, flags ...string) error
 	TestRelease(name string, flags ...string) error
-
+	List(filter string) (string, error)
 	DecryptSecret(name string) (string, error)
 }

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -614,6 +614,9 @@ func (helm *mockHelmExec) ReleaseStatus(release string) error {
 func (helm *mockHelmExec) DeleteRelease(name string, flags ...string) error {
 	return nil
 }
+func (helm *mockHelmExec) List(filter string) (string, error) {
+	return "", nil
+}
 func (helm *mockHelmExec) DecryptSecret(name string) (string, error) {
 	return "", nil
 }


### PR DESCRIPTION
This removes `release: "your_release_name" not found` errors seen for releases with `installed: false` when running `helmfile sync` and `helmfile apply`.

The problem was that helmfile had been running `helm status` to detect releases to be deleted. helmfile now use `helm list ^YOUR_RELEASE_NAME$` to detect if the release is currently installed or not, which emits no error-like logs on against uninstalled releases.

Fixes #507 