### PR TITLE
fix: `helmfile delete` should not stop on uninstalled release(s)

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -708,7 +708,14 @@ func (st *HelmState) DeleteReleases(helm helmexec.Interface, purge bool) []error
 		if purge {
 			flags = append(flags, "--purge")
 		}
-		return helm.DeleteRelease(release.Name, flags...)
+		installed, err := isReleaseInstalled(helm, release)
+		if err != nil {
+			return err
+		}
+		if installed {
+			return helm.DeleteRelease(release.Name, flags...)
+		}
+		return nil
 	})
 }
 

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -80,6 +80,9 @@ info "Deleting release"
 ${helmfile} -f ${dir}/happypath.yaml delete
 ${helm} status --namespace=${test_ns} httpbin &> /dev/null && fail "release should not exist anymore after a delete"
 
+info "Ensuring \"helmfile delete\" doesn't fail when no releases installed"
+${helmfile} -f ${dir}/happypath.yaml delete || fail "\"helmfile delete\" shouldn't fail when there are no installed releases"
+
 test_pass "happypath"
 
 


### PR DESCRIPTION
Resolves #481