### PR TITLE
feat: Enhanced `get` template function

### DIFF
--- a/tmpl/get_or_nil.go
+++ b/tmpl/get_or_nil.go
@@ -14,36 +14,67 @@ func (e *noValueError) Error() string {
 	return e.msg
 }
 
-func get(path string, obj interface{}) (interface{}, error) {
+func get(path string, varArgs ...interface{}) (interface{}, error) {
+	var defSet bool
+	var def interface{}
+	var obj interface{}
+	switch len(varArgs) {
+	case 1:
+		defSet = false
+		def = nil
+		obj = varArgs[0]
+	case 2:
+		defSet = true
+		def = varArgs[0]
+		obj = varArgs[1]
+	default:
+		return nil, fmt.Errorf("unexpected number of args pased to the template function get(path, [def, ]obj): expected 1 or 2, got %d, args was %v", len(varArgs), varArgs)
+	}
+
 	if path == "" {
 		return obj, nil
 	}
 	keys := strings.Split(path, ".")
+	var v interface{}
+	var ok bool
 	switch typedObj := obj.(type) {
 	case map[string]interface{}:
-		v, ok := typedObj[keys[0]]
+		v, ok = typedObj[keys[0]]
 		if !ok {
+			if defSet {
+				return def, nil
+			}
 			return nil, &noValueError{fmt.Sprintf("no value exist for key \"%s\" in %v", keys[0], typedObj)}
 		}
-		return get(strings.Join(keys[1:], "."), v)
 	case map[interface{}]interface{}:
-		v, ok := typedObj[keys[0]]
+		v, ok = typedObj[keys[0]]
 		if !ok {
+			if defSet {
+				return def, nil
+			}
 			return nil, &noValueError{fmt.Sprintf("no value exist for key \"%s\" in %v", keys[0], typedObj)}
 		}
-		return get(strings.Join(keys[1:], "."), v)
 	default:
 		maybeStruct := reflect.ValueOf(typedObj)
-		if maybeStruct.NumField() < 1 {
+		if maybeStruct.Kind() != reflect.Struct {
 			return nil, &noValueError{fmt.Sprintf("unexpected type(%v) of value for key \"%s\": it must be either map[string]interface{} or any struct", reflect.TypeOf(obj), keys[0])}
+		} else if maybeStruct.NumField() < 1 {
+			return nil, &noValueError{fmt.Sprintf("no accessible struct fields for key \"%s\"", keys[0])}
 		}
 		f := maybeStruct.FieldByName(keys[0])
 		if !f.IsValid() {
+			if defSet {
+				return def, nil
+			}
 			return nil, &noValueError{fmt.Sprintf("no field named \"%s\" exist in %v", keys[0], typedObj)}
 		}
-		v := f.Interface()
-		return get(strings.Join(keys[1:], "."), v)
+		v = f.Interface()
 	}
+
+	if defSet {
+		return get(strings.Join(keys[1:], "."), def, v)
+	}
+	return get(strings.Join(keys[1:], "."), v)
 }
 
 func getOrNil(path string, o interface{}) (interface{}, error) {

--- a/tmpl/get_or_nil_test.go
+++ b/tmpl/get_or_nil_test.go
@@ -4,6 +4,9 @@ import (
 	"testing"
 )
 
+type EmptyStruct struct {
+}
+
 func TestGetStruct(t *testing.T) {
 	type Foo struct{ Bar string }
 
@@ -23,6 +26,12 @@ func TestGetStruct(t *testing.T) {
 	if err == nil {
 		t.Errorf("expected error but was not occurred")
 	}
+
+	_, err = get("foo", EmptyStruct{})
+
+	if err == nil {
+		t.Errorf("expected error but was not occurred")
+	}
 }
 
 func TestGetMap(t *testing.T) {
@@ -38,6 +47,34 @@ func TestGetMap(t *testing.T) {
 	}
 
 	_, err = get("Foo.baz", obj)
+
+	if err == nil {
+		t.Errorf("expected error but was not occurred")
+	}
+}
+
+func TestGet_Default(t *testing.T) {
+	obj := map[string]interface{}{"Foo": map[string]interface{}{}, "foo": 1}
+
+	v1, err := get("Foo.Bar", "Bar", obj)
+
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if v1 != "Bar" {
+		t.Errorf("unexpected value for path Foo.Bar in %v: expected=Bar, actual=%v", obj, v1)
+	}
+
+	v2, err := get("Baz", "Baz", obj)
+
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if v2 != "Baz" {
+		t.Errorf("unexpected value for path Baz in %v: expected=Baz, actual=%v", obj, v2)
+	}
+
+	_, err = get("foo.Bar", "fooBar", obj)
 
 	if err == nil {
 		t.Errorf("expected error but was not occurred")


### PR DESCRIPTION
`get` is now able to take one more optional argument, that is used as the default value when the value for the key does not exist.

Resolves #465
Fixes #427
Fixes #357
Ref #460