### PR TITLE
fix: `helmfile diff` should not leave temp values files

### DIFF
--- a/state/release.go
+++ b/state/release.go
@@ -67,3 +67,7 @@ func (r ReleaseSpec) Clone() (*ReleaseSpec, error) {
 
 	return &deserialized, nil
 }
+
+func (r ReleaseSpec) Desired() bool {
+	return r.Installed == nil || *r.Installed
+}


### PR DESCRIPTION
Fixes #503 once again. A follow-up to #520 which was incomplete.