### PR TITLE
fix: `helmfile destroy` should  delete releases in the specified tiller namespace

### DIFF
--- a/helmexec/exec.go
+++ b/helmexec/exec.go
@@ -103,16 +103,16 @@ func (helm *execer) SyncRelease(name, chart string, flags ...string) error {
 	return err
 }
 
-func (helm *execer) ReleaseStatus(name string) error {
+func (helm *execer) ReleaseStatus(name string, flags ...string) error {
 	helm.logger.Infof("Getting status %v", name)
-	out, err := helm.exec(append([]string{"status", name})...)
+	out, err := helm.exec(append([]string{"status", name}, flags...)...)
 	helm.write(out)
 	return err
 }
 
-func (helm *execer) List(filter string) (string, error) {
+func (helm *execer) List(filter string, flags ...string) (string, error) {
 	helm.logger.Infof("Listing releases matching %v", filter)
-	out, err := helm.exec(append([]string{"list", filter})...)
+	out, err := helm.exec(append([]string{"list", filter}, flags...)...)
 	helm.write(out)
 	return string(out), err
 }

--- a/helmexec/helmexec.go
+++ b/helmexec/helmexec.go
@@ -14,9 +14,9 @@ type Interface interface {
 	TemplateRelease(chart string, flags ...string) error
 	Fetch(chart string, flags ...string) error
 	Lint(chart string, flags ...string) error
-	ReleaseStatus(name string) error
+	ReleaseStatus(name string, flags ...string) error
 	DeleteRelease(name string, flags ...string) error
 	TestRelease(name string, flags ...string) error
-	List(filter string) (string, error)
+	List(filter string, flags ...string) (string, error)
 	DecryptSecret(name string) (string, error)
 }


### PR DESCRIPTION
Actually, 4 helm commands including "list", "diff", "status" and "delete" were not taking tiller-rerelated flags into account when called by helmfile. This fixes all these commands.

Fixes #534