### PR TITLE
fix:  with environment secrets

### DIFF
--- a/state/create.go
+++ b/state/create.go
@@ -158,7 +158,15 @@ func (st *HelmState) loadEnv(name string, readFile func(string) ([]byte, error))
 				if _, err := os.Stat(path); os.IsNotExist(err) {
 					return nil, err
 				}
-				release := &st.Releases[0]
+				// Work-around to allow decrypting environment secrets
+				//
+				// We don't have releases loaded yet and therefore unable to decide whether
+				// helmfile should use helm-tiller to call helm-secrets or not.
+				//
+				// This means that, when you use environment secrets + tillerless setup, you still need a tiller
+				// installed on the cluster, just for decrypting secrets!
+				// Related: https://github.com/futuresimple/helm-secrets/issues/83
+				release := &ReleaseSpec{}
 				flags := st.appendTillerFlags([]string{}, release)
 				decFile, err := helm.DecryptSecret(st.createHelmContext(release, 0), path, flags...)
 				if err != nil {


### PR DESCRIPTION
Since tillerless support we unintentionally broke this, and there isn't a real fix to this.
We must accept a limitation that helmfile needs a tiller installed on your cluster just for decrypting environment secrets.

Fixes #550