### PR TITLE
fix(struct): renamed Error struct field into Failed

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -157,7 +157,7 @@ type SetValue struct {
 type AffectedReleases struct {
 	Upgraded []*ReleaseSpec
 	Deleted  []*ReleaseSpec
-	Error    []*ReleaseSpec
+	Failed   []*ReleaseSpec
 }
 
 const DefaultEnv = "default"
@@ -346,14 +346,14 @@ func (st *HelmState) SyncReleases(affectedReleases *AffectedReleases, helm helme
 						relErr = &ReleaseError{release, err}
 					} else if installed {
 						if err := helm.DeleteRelease(context, release.Name, "--purge"); err != nil {
-							affectedReleases.Error = append(affectedReleases.Error, release)
+							affectedReleases.Failed = append(affectedReleases.Failed, release)
 							relErr = &ReleaseError{release, err}
 						} else {
 							affectedReleases.Deleted = append(affectedReleases.Deleted, release)
 						}
 					}
 				} else if err := helm.SyncRelease(context, release.Name, chart, flags...); err != nil {
-					affectedReleases.Error = append(affectedReleases.Error, release)
+					affectedReleases.Failed = append(affectedReleases.Failed, release)
 					relErr = &ReleaseError{release, err}
 				} else {
 					affectedReleases.Upgraded = append(affectedReleases.Upgraded, release)
@@ -816,7 +816,7 @@ func (st *HelmState) DeleteReleases(affectedReleases *AffectedReleases, helm hel
 		}
 		if installed {
 			if err := helm.DeleteRelease(context, release.Name, flags...); err != nil {
-				affectedReleases.Error = append(affectedReleases.Error, &release)
+				affectedReleases.Failed = append(affectedReleases.Failed, &release)
 				return err
 			} else {
 				affectedReleases.Deleted = append(affectedReleases.Deleted, &release)
@@ -1373,10 +1373,10 @@ func (ar *AffectedReleases) DisplayAffectedReleases(logger *zap.SugaredLogger) {
 			logger.Info(release.Name)
 		}
 	}
-	if ar.Error != nil {
+	if ar.Failed != nil {
 		logger.Info("\nList of releases in error :")
 		logger.Info("RELEASE")
-		for _, release := range ar.Error {
+		for _, release := range ar.Failed {
 			logger.Info(release.Name)
 		}
 	}

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -653,7 +653,7 @@ type mockRelease struct {
 type mockAffected struct {
 	upgraded []*mockRelease
 	deleted  []*mockRelease
-	error    []*mockRelease
+	failed   []*mockRelease
 }
 
 func (helm *mockHelmExec) UpdateDeps(chart string) error {
@@ -1007,8 +1007,8 @@ func TestHelmState_SyncReleasesAffectedRealeases(t *testing.T) {
 
 			affectedReleases := AffectedReleases{}
 			if err := state.SyncReleases(&affectedReleases, helm, []string{}, 1); err != nil {
-				if !testEq(affectedReleases.Error, tt.wantAffected.error) {
-					t.Errorf("HelmState.SynchAffectedRelease() error failed for [%s] = %v, want %v", tt.name, affectedReleases.Error, tt.wantAffected.error)
+				if !testEq(affectedReleases.Failed, tt.wantAffected.failed) {
+					t.Errorf("HelmState.SynchAffectedRelease() error failed for [%s] = %v, want %v", tt.name, affectedReleases.Failed, tt.wantAffected.failed)
 				} //else expected error
 			}
 			if !testEq(affectedReleases.Upgraded, tt.wantAffected.upgraded) {
@@ -1776,7 +1776,7 @@ func TestHelmState_Delete(t *testing.T) {
 			affectedReleases := AffectedReleases{}
 			errs := state.DeleteReleases(&affectedReleases, helm, tt.purge)
 			if errs != nil {
-				if !tt.wantErr || len(affectedReleases.Error) != 1 || affectedReleases.Error[0].Name != release.Name {
+				if !tt.wantErr || len(affectedReleases.Failed) != 1 || affectedReleases.Failed[0].Name != release.Name {
 					t.Errorf("DeleteReleases() for %s error = %v, wantErr %v", tt.name, errs, tt.wantErr)
 					return
 				}


### PR DESCRIPTION
as @mumoshu suggested I have renamed the AffectedReleases.Error field to AffectedReleases.Failed to be more homogeneous with the other fields and to avoir conflits with other Error references.