### PR TITLE
feat(#344): add sub helmfiles explicit selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,7 +660,7 @@ helmfiles:
 * When a selector is specified, only this selector applies and the parents or CLI selectors are ignored.
 * When not selector is specified there are 2 modes for the selector inheritance because we would like to change the current inheritance behavior (see [issue #344](https://github.com/roboll/helmfile/issues/344)  ).
   * Legacy mode, sub-helmfiles without selectors inherit selectors from their parent helmfile. The initial helmfiles inherit from the command line selectors. 
-  * explicit mode, sub-helmfile without selectors do not inherit from their parent or the CLI selector. If you want them to inherit from their parent selector then use `selectors: inherits`. To enable this explicit mode you need to set the following environment variable `EXPERIMENTAL=explicit-selector-inheritance`.
+  * explicit mode, sub-helmfile without selectors do not inherit from their parent or the CLI selector. If you want them to inherit from their parent selector then use `selectors: inherits`. To enable this explicit mode you need to set the following environment variable `HELMFILE_EXPERIMENTAL=explicit-selector-inheritance` (see [experimental](#experimental-features)).
 * Using `selector: {}` will for all releases to be used regardless of the parent selector or cli for the initial helmfile
 * using `selector: inherits` make the sub-helmfile selects release with the parent selector or the cli for the initial helmfile
 
@@ -828,10 +828,10 @@ See #155 for more information on this topic.
 
 ## Experimental features
 Some experimental features may be available for testing in perspective of being (or not) included in a future release.
-Those features are set using the environment variable `EXPERIMENTAL`. Here is the current experimental feature :
+Those features are set using the environment variable `HELMFILE_EXPERIMENTAL`. Here is the current experimental feature :
 * `explicit-selector-inheritance` : remove today implicit cli selectors inheritance for composed helmfiles, see [composition selector](#selectors)
 
-If you want to enable all experimental features set the env var to `EXPERIMENTAL=true`
+If you want to enable all experimental features set the env var to `HELMFILE_EXPERIMENTAL=true`
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ The `selector` parameter can be specified multiple times. Each parameter is reso
 
 `--selector tier=frontend --selector tier=backend` will select all the charts
 
-In addition to user supplied labels the name, namespace, and chart are available to be used as selectors.  The chart will just be the chart name excluding the repository (Example `stable/filebeat` would be selected using `--selector chart=filebeat`).
+In addition to user supplied labels, the name, the namespace, and the chart are available to be used as selectors.  The chart will just be the chart name excluding the repository (Example `stable/filebeat` would be selected using `--selector chart=filebeat`).
 
 ## Templates
 
@@ -643,6 +643,27 @@ Just run `helmfile sync` inside `myteam/`, and you are done.
 
 All the files are sorted alphabetically per group = array item inside `helmfiles:`, so that you have granular control over ordering, too.
 
+#### selectors
+When composing helmfiles you can use selectors from the command line as well as explicit selectors inside the parent helmfile to filter the releases to be used.
+```yaml
+helmfiles:
+- apps/*/helmfile.yaml
+- apps/a-helmfile.yaml:
+    selectors:          # list of selectors
+    - name=prometheus      
+    - tier=frontend    
+- apps/b-helmfile.yaml: # no selector, so all releases are used
+    selectors: {}
+- apps/c-helmfile.yaml: # parent selector to be used or cli selector for the initial helmfile
+    selectors: inherits
+```
+* When a selector is specified, only this selector applies and the parents or CLI selectors are ignored.
+* When not selector is specified there are 2 modes for the selector inheritance because we would like to change the current inheritance behavior (see [issue #344](https://github.com/roboll/helmfile/issues/344)  ).
+  * Legacy mode, sub-helmfiles without selectors inherit selectors from their parent helmfile. The initial helmfiles inherit from the command line selectors. 
+  * explicit mode, sub-helmfile without selectors do not inherit from their parent or the CLI selector. If you want them to inherit from their parent selector then use `selectors: inherits`. To enable this explicit mode you need to set the following environment variable `EXPERIMENTAL=explicit-selector-inheritance`.
+* Using `selector: {}` will for all releases to be used regardless of the parent selector or cli for the initial helmfile
+* using `selector: inherits` make the sub-helmfile selects release with the parent selector or the cli for the initial helmfile
+
 ## Importing values from any source
 
 The `exec` template function that is available in `values.yaml.gotmpl` is useful for importing values from any source
@@ -805,6 +826,12 @@ Once you download all required charts into your machine, you can run `helmfile c
 It basically run only `helm upgrade --install` with your already-downloaded charts, hence no Internet connection is required.
 See #155 for more information on this topic.
 
+## Experimental features
+Some experimental features may be available for testing in perspective of being (or not) included in a future release.
+Those features are set using the environment variable `EXPERIMENTAL`. Here is the current experimental feature :
+* `explicit-selector-inheritance` : remove today implicit cli selectors inheritance for composed helmfiles, see [composition selector](#selectors)
+
+If you want to enable all experimental features set the env var to `EXPERIMENTAL=true`
 
 ## Examples
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -27,7 +27,7 @@ func VisitAllDesiredStates(c *cli.Context, converge func(*state.HelmState, helme
 		return converge(st, helm, ctx)
 	}
 
-	err = a.VisitDesiredStates(fileOrDir, convergeWithHelmBinary)
+	err = a.VisitDesiredStates(fileOrDir, a.Selectors, convergeWithHelmBinary)
 
 	return toCliError(err)
 }

--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,12 @@ require (
 	github.com/Masterminds/semver v1.4.1 // indirect
 	github.com/Masterminds/sprig v2.15.0+incompatible
 	github.com/aokoli/goutils v1.0.1 // indirect
+	github.com/google/go-cmp v0.3.0 // indirect
 	github.com/google/uuid v0.0.0-20161128191214-064e2069ce9c // indirect
 	github.com/huandu/xstrings v1.0.0 // indirect
 	github.com/imdario/mergo v0.3.6
 	github.com/mattn/go-runewidth v0.0.4 // indirect
+	github.com/pkg/errors v0.8.1 // indirect
 	github.com/tatsushid/go-prettytable v0.0.0-20141013043238-ed2d14c29939
 	github.com/urfave/cli v0.0.0-20160620154522-6011f165dc28
 	go.uber.org/atomic v1.3.2 // indirect
@@ -17,4 +19,5 @@ require (
 	go.uber.org/zap v1.8.0
 	golang.org/x/crypto v0.0.0-20180403160946-b2aa35443fbc // indirect
 	gopkg.in/yaml.v2 v2.2.1
+	gotest.tools v2.2.0+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/Masterminds/sprig v2.15.0+incompatible h1:0gSxPGWS9PAr7U2NsQ2YQg6juRD
 github.com/Masterminds/sprig v2.15.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/aokoli/goutils v1.0.1 h1:7fpzNGoJ3VA8qcrm++XEE1QUe0mIwNeLa02Nwq7RDkg=
 github.com/aokoli/goutils v1.0.1/go.mod h1:SijmP0QR8LtwsmDs8Yii5Z/S4trXFGFC2oO5g9DP+DQ=
+github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
+github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/uuid v0.0.0-20161128191214-064e2069ce9c h1:jWtZjFEUE/Bz0IeIhqCnyZ3HG6KRXSntXe4SjtuTH7c=
 github.com/google/uuid v0.0.0-20161128191214-064e2069ce9c/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/huandu/xstrings v1.0.0 h1:pO2K/gKgKaat5LdpAhxhluX2GPQMaI3W5FUz/I/UnWk=
@@ -12,6 +14,8 @@ github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/p7Y=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/tatsushid/go-prettytable v0.0.0-20141013043238-ed2d14c29939 h1:BhIUXV2ySTLrKgh/Hnts+QTQlIbWtomXt3LMdzME0A0=
 github.com/tatsushid/go-prettytable v0.0.0-20141013043238-ed2d14c29939/go.mod h1:omGxs4/6hNjxPKUTjmaNkPzehSnNJOJN6pMEbrlYIT4=
 github.com/urfave/cli v0.0.0-20160620154522-6011f165dc28 h1:Yf7/DcGM+61oLBGXQV2Q+ztEGBcOe3EUnbKSOn4fQuE=
@@ -27,3 +31,5 @@ golang.org/x/crypto v0.0.0-20180403160946-b2aa35443fbc/go.mod h1:6SG95UA2DQfeDnf
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
+gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -108,7 +108,7 @@ func (a *App) visitStateFiles(fileOrDir string, do func(string) error) error {
 	return nil
 }
 
-func (a *App) VisitDesiredStates(fileOrDir string, converge func(*state.HelmState, helmexec.Interface) (bool, []error)) error {
+func (a *App) VisitDesiredStates(fileOrDir string, selector []string, converge func(*state.HelmState, helmexec.Interface) (bool, []error)) error {
 	noMatchInHelmfiles := true
 
 	err := a.visitStateFiles(fileOrDir, func(f string) error {
@@ -153,16 +153,21 @@ func (a *App) VisitDesiredStates(fileOrDir string, converge func(*state.HelmStat
 				return err
 			}
 		}
+		st.Selectors = selector
 
 		if len(st.Helmfiles) > 0 {
 			noMatchInSubHelmfiles := true
 			for _, m := range st.Helmfiles {
-				if err := a.VisitDesiredStates(m, converge); err != nil {
+				//assign parent selector to sub helm selector in legacy mode or do not inherit in experimental mode
+				if m.Selectors == nil && os.Getenv(ExperimentalEnvVar) != "true" {
+					m.Selectors = selector
+				}
+				if err := a.VisitDesiredStates(m.Path, m.Selectors, converge); err != nil {
 					switch err.(type) {
 					case *NoMatchingHelmfileError:
 
 					default:
-						return fmt.Errorf("failed processing %s: %v", m, err)
+						return fmt.Errorf("failed processing %s: %v", m.Path, err)
 					}
 				} else {
 					noMatchInSubHelmfiles = false
@@ -192,11 +197,10 @@ func (a *App) VisitDesiredStates(fileOrDir string, converge func(*state.HelmStat
 }
 
 func (a *App) VisitDesiredStatesWithReleasesFiltered(fileOrDir string, converge func(*state.HelmState, helmexec.Interface) []error) error {
-	selectors := a.Selectors
 
-	err := a.VisitDesiredStates(fileOrDir, func(st *state.HelmState, helm helmexec.Interface) (bool, []error) {
-		if len(selectors) > 0 {
-			err := st.FilterReleases(selectors)
+	err := a.VisitDesiredStates(fileOrDir, a.Selectors, func(st *state.HelmState, helm helmexec.Interface) (bool, []error) {
+		if len(st.Selectors) > 0 {
+			err := st.FilterReleases()
 			if err != nil {
 				return false, []error{err}
 			}
@@ -311,8 +315,9 @@ func (a *App) loadDesiredStateFromYaml(yaml []byte, file string, namespace strin
 		return nil, err
 	}
 
-	helmfiles := []string{}
-	for _, globPattern := range st.Helmfiles {
+	helmfiles := []state.SubHelmfileSpec{}
+	for _, hf := range st.Helmfiles {
+		globPattern := hf.Path
 		var absPathPattern string
 		if filepath.IsAbs(globPattern) {
 			absPathPattern = globPattern
@@ -324,8 +329,12 @@ func (a *App) loadDesiredStateFromYaml(yaml []byte, file string, namespace strin
 			return nil, fmt.Errorf("failed processing %s: %v", globPattern, err)
 		}
 		sort.Strings(matches)
+		for _, match := range matches {
+			newHelmfile := hf
+			newHelmfile.Path = match
+			helmfiles = append(helmfiles, newHelmfile)
+		}
 
-		helmfiles = append(helmfiles, matches...)
 	}
 	st.Helmfiles = helmfiles
 

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -159,7 +159,7 @@ func (a *App) VisitDesiredStates(fileOrDir string, selector []string, converge f
 			noMatchInSubHelmfiles := true
 			for _, m := range st.Helmfiles {
 				//assign parent selector to sub helm selector in legacy mode or do not inherit in experimental mode
-				if m.Selectors == nil && os.Getenv(ExperimentalEnvVar) != "true" {
+				if (m.Selectors == nil && !isExplicitSelectorInheritanceEnabled()) || m.Inherits {
 					m.Selectors = selector
 				}
 				if err := a.VisitDesiredStates(m.Path, m.Selectors, converge); err != nil {

--- a/pkg/app/constants.go
+++ b/pkg/app/constants.go
@@ -1,8 +1,18 @@
 package app
 
-const (
-	DefaultHelmfile          = "helmfile.yaml"
-	DeprecatedHelmfile       = "charts.yaml"
-	DefaultHelmfileDirectory = "helmfile.d"
-	ExperimentalEnvVar       = "EXPERIMENTAL" // environment variable for experimental features, expecting "true" lower case
+import (
+	"os"
+	"strings"
 )
+
+const (
+	DefaultHelmfile              = "helmfile.yaml"
+	DeprecatedHelmfile           = "charts.yaml"
+	DefaultHelmfileDirectory     = "helmfile.d"
+	ExperimentalEnvVar           = "EXPERIMENTAL"                  // environment variable for experimental features, expecting "true" lower case
+	ExperimentalSelectorExplicit = "explicit-selector-inheritance" // value to remove default selector inheritance to sub-helmfiles and use the explicit one
+)
+
+func isExplicitSelectorInheritanceEnabled() bool {
+	return os.Getenv(ExperimentalEnvVar) == "true" || strings.Contains(os.Getenv(ExperimentalEnvVar), ExperimentalSelectorExplicit)
+}

--- a/pkg/app/constants.go
+++ b/pkg/app/constants.go
@@ -4,4 +4,5 @@ const (
 	DefaultHelmfile          = "helmfile.yaml"
 	DeprecatedHelmfile       = "charts.yaml"
 	DefaultHelmfileDirectory = "helmfile.d"
+	ExperimentalEnvVar       = "EXPERIMENTAL" // environment variable for experimental features, expecting "true" lower case
 )

--- a/pkg/app/constants.go
+++ b/pkg/app/constants.go
@@ -9,7 +9,7 @@ const (
 	DefaultHelmfile              = "helmfile.yaml"
 	DeprecatedHelmfile           = "charts.yaml"
 	DefaultHelmfileDirectory     = "helmfile.d"
-	ExperimentalEnvVar           = "EXPERIMENTAL"                  // environment variable for experimental features, expecting "true" lower case
+	ExperimentalEnvVar           = "HELMFILE_EXPERIMENTAL"         // environment variable for experimental features, expecting "true" lower case
 	ExperimentalSelectorExplicit = "explicit-selector-inheritance" // value to remove default selector inheritance to sub-helmfiles and use the explicit one
 )
 

--- a/pkg/app/constants_test.go
+++ b/pkg/app/constants_test.go
@@ -1,0 +1,27 @@
+package app
+
+import (
+	. "gotest.tools/assert"
+	is "gotest.tools/assert/cmp"
+	"gotest.tools/env"
+	"os"
+	"testing"
+)
+
+func TestIsExplicitSelectorInheritanceEnabled(t *testing.T) {
+	//env var ExperimentalEnvVar is set
+	Assert(t, is.Equal(os.Getenv(ExperimentalEnvVar), ""))
+	Check(t, !isExplicitSelectorInheritanceEnabled())
+
+	//check for env var ExperimentalEnvVar set to true
+	defer env.Patch(t, ExperimentalEnvVar, "true")()
+	Check(t, isExplicitSelectorInheritanceEnabled())
+
+	//check for env var ExperimentalEnvVar set to anything
+	defer env.Patch(t, ExperimentalEnvVar, "foo")()
+	Check(t, !isExplicitSelectorInheritanceEnabled())
+
+	//check for env var ExperimentalEnvVar set to ExperimentalSelectorExplicit
+	defer env.Patch(t, ExperimentalEnvVar, ExperimentalSelectorExplicit)()
+	Check(t, isExplicitSelectorInheritanceEnabled())
+}

--- a/state/create_test.go
+++ b/state/create_test.go
@@ -269,13 +269,23 @@ func TestReadFromYaml_Helmfiles_Selectors(t *testing.T) {
     selectors: {}
 - inherits/selector.yaml:
     selectors: inherits
+- path: path/prefix/selector.yaml
+  selectors:
+    - name=zorba
+- path: path/prefix/empty/selector.yaml
+  selectors: {}
+- path: path/prefix/inherits/selector.yaml
+  selectors: inherits
 `),
 			wantErr: false,
 			helmfiles: []SubHelmfileSpec{{Path: "simple/helmfile.yaml"},
-				{Path: "simple/helmfile/with/semicolon.yaml"},
-				{Path: "two/selectors.yaml", Selectors: []string{"name=foo", "name=bar"}},
-				{Path: "empty/selector.yaml", Selectors: []string{}},
-				{Path: "inherits/selector.yaml", Inherits: true},
+				{Path: "simple/helmfile/with/semicolon.yaml", Selectors: nil, Inherits: false},
+				{Path: "two/selectors.yaml", Selectors: []string{"name=foo", "name=bar"}, Inherits: false},
+				{Path: "empty/selector.yaml", Selectors: []string{}, Inherits: false},
+				{Path: "inherits/selector.yaml", Selectors: nil, Inherits: true},
+				{Path: "path/prefix/selector.yaml", Selectors: []string{"name=zorba"}, Inherits: false},
+				{Path: "path/prefix/empty/selector.yaml", Selectors: []string{}, Inherits: false},
+				{Path: "path/prefix/inherits/selector.yaml", Selectors: nil, Inherits: true},
 			},
 		},
 		{
@@ -297,7 +307,7 @@ func TestReadFromYaml_Helmfiles_Selectors(t *testing.T) {
 			path: "failing3/selector",
 			content: []byte(`helmfiles:
 - failing3/helmfile.yaml: 
-    selector: foo
+    selectors: foo
 `),
 			wantErr: true,
 		},
@@ -305,7 +315,7 @@ func TestReadFromYaml_Helmfiles_Selectors(t *testing.T) {
 			path: "failing4/selector",
 			content: []byte(`helmfiles:
 - failing4/helmfile.yaml: 
-    selector:
+    selectors:
 `),
 			wantErr: true,
 		},
@@ -313,8 +323,16 @@ func TestReadFromYaml_Helmfiles_Selectors(t *testing.T) {
 			path: "failing4/selector",
 			content: []byte(`helmfiles:
 - failing4/helmfile.yaml: 
-		selector:
+		selectors:
 		  - colon: not-authorized
+`),
+			wantErr: true,
+		},
+		{
+			path: "failing5/selector",
+			content: []byte(`helmfiles:
+- selectors:
+	- colon: not-authorized
 `),
 			wantErr: true,
 		},

--- a/state/create_test.go
+++ b/state/create_test.go
@@ -2,10 +2,11 @@ package state
 
 import (
 	"fmt"
-	. "gotest.tools/assert"
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	. "gotest.tools/assert"
 )
 
 func TestReadFromYaml(t *testing.T) {
@@ -323,8 +324,8 @@ func TestReadFromYaml_Helmfiles_Selectors(t *testing.T) {
 			path: "failing4/selector",
 			content: []byte(`helmfiles:
 - failing4/helmfile.yaml: 
-		selectors:
-		  - colon: not-authorized
+    selectors:
+      - colon: not-authorized
 `),
 			wantErr: true,
 		},
@@ -332,7 +333,15 @@ func TestReadFromYaml_Helmfiles_Selectors(t *testing.T) {
 			path: "failing5/selector",
 			content: []byte(`helmfiles:
 - selectors:
-	- colon: not-authorized
+    - colon: not-authorized
+`),
+			wantErr: true,
+		},
+		{
+			path: "failing6/selector",
+			content: []byte(`helmfiles:
+- selectors:
+    - whatever
 `),
 			wantErr: true,
 		},

--- a/state/state.go
+++ b/state/state.go
@@ -18,13 +18,14 @@ import (
 	"os/exec"
 	"syscall"
 
+	"net/url"
+
 	"github.com/roboll/helmfile/environment"
 	"github.com/roboll/helmfile/event"
 	"github.com/roboll/helmfile/tmpl"
 	"github.com/tatsushid/go-prettytable"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v2"
-	"net/url"
 )
 
 // HelmState structure for the helmfile
@@ -1418,9 +1419,6 @@ func (hf *SubHelmfileSpec) UnmarshalYAML(unmarshal func(interface{}) error) erro
 				if key == "path" {
 					hf.Path = v.(string)
 				} else if key == "selectors" {
-					if hf.Path == "" {
-						return fmt.Errorf("Can't use a 'selector' without an associated path'")
-					} //else get selector content
 					if err := extractSelectorContent(hf, v); err != nil {
 						return err
 					}
@@ -1437,6 +1435,11 @@ func (hf *SubHelmfileSpec) UnmarshalYAML(unmarshal func(interface{}) error) erro
 				return fmt.Errorf("Expecting a \"string\" scalar for the helmfile collection but got: %v", key)
 			}
 		}
+	}
+	//since we cannot make sur the "console" string can be red after the "path" we must check we don't have
+	//a SubHelmfileSpec with only selector and no path
+	if hf.Selectors != nil && hf.Path == "" {
+		return fmt.Errorf("found 'selectors' definition without path: %v", hf.Selectors)
 	}
 
 	return nil

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1636,7 +1636,8 @@ func TestHelmState_NoReleaseMatched(t *testing.T) {
 				Releases: releases,
 				logger:   logger,
 			}
-			errs := state.FilterReleases([]string{tt.labels})
+			state.Selectors = []string{tt.labels}
+			errs := state.FilterReleases()
 			if (errs != nil) != tt.wantErr {
 				t.Errorf("ReleaseStatuses() for %s error = %v, wantErr %v", tt.name, errs, tt.wantErr)
 				return


### PR DESCRIPTION
Fixes #344 by allowing explicit selectors to be specified for composed helmfiles using the following structure
```
helmfiles:
- helmfile.d/a*.yaml:
    selectors:
    - name=prometheus      
    - name!=zipkin      
- helmfile.d/b*.yaml
- helmfile.d/c*.yaml:
    selectors: {}
```
2 modes here : 
* legacy mode when no the env var EXPERIMENTAL is not set to true
  * no selector : inherit from the command line.
  * selector:  is specified then it is used (an emty means no inheritance from command line and take everything).
* experimental when the env var EXPERIMENTAL=true
  * no selector : nothing is inherited from the command line so use all releases.
  * selector:  is specified then it is used (an emty means no inheritance from command line and take everything).
