### PR TITLE
feat: helmfile.yaml layering enhancements

### DIFF
--- a/docs/writing-helmfile.md
+++ b/docs/writing-helmfile.md
@@ -100,10 +100,10 @@ Use Layering to extract the common parts into a dedicated *library helmfile*s, s
 Let's assume that your `helmfile.yaml` looks like:
 
 ```
-{ readFile "commons.yaml" }}
----
-{{ readFile "environments.yaml" }}
----
+bases:
+- commons.yaml
+- environments.yaml
+
 releases:
 - name: myapp
   chart: mychart

--- a/docs/writing-helmfile.md
+++ b/docs/writing-helmfile.md
@@ -125,23 +125,26 @@ environments:
   production:
 ```
 
-At run time, template expressions in your `helmfile.yaml` are executed:
+At run time, `bases` in your `helmfile.yaml` are evaluated to produce:
 
 ```yaml
+# commons.yaml
 releases:
 - name: metricbaet
   chart: stable/metricbeat
 ---
+# environments.yaml
 environments:
   development:
   production:
 ---
+# helmfile.yaml
 releases:
 - name: myapp
   chart: mychart
 ```
 
-Resulting YAML documents are merged in the order of occurrence,
+Finally the resulting YAML documents are merged in the order of occurrence,
 so that your `helmfile.yaml` becomes:
 
 ```yaml
@@ -159,3 +162,5 @@ releases:
 Great!
 
 Now, repeat the above steps for each your `helmfile.yaml`, so that all your helmfiles becomes DRY.
+
+Please also see [the discussion in the issue 388](https://github.com/roboll/helmfile/issues/388#issuecomment-491710348) for more advanced layering examples.

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -702,8 +702,8 @@ releases:
 helmDefaults:
   tillerNamespace: {{ .Environment.Values.tillerNs }}
 `),
-"/path/to/yaml/environments/default/2.yaml": []byte(`tillerNs: TILLER_NS`),
-"/path/to/yaml/templates.yaml": []byte(`templates:
+		"/path/to/yaml/environments/default/2.yaml": []byte(`tillerNs: TILLER_NS`),
+		"/path/to/yaml/templates.yaml": []byte(`templates:
   default: &default
     missingFileHandler: Warn
     values: ["` + "{{`" + `{{.Release.Name}}` + "`}}" + `/values.yaml"]
@@ -739,5 +739,106 @@ helmDefaults:
 
 	if st.Releases[1].Values[0] != "{{`{{.Release.Name}}`}}/values.yaml" {
 		t.Errorf("unexpected releases[0].missingFileHandler: expected={{`{{.Release.Name}}`}}/values.yaml, got=%s", st.Releases[1].Values[0])
+	}
+}
+
+func TestLoadDesiredStateFromYaml_MultiPartTemplate(t *testing.T) {
+	yamlFile := "/path/to/yaml/file"
+	yamlContent := []byte(`bases:
+- ../base.yaml
+---
+bases:
+- ../base.gotmpl
+---
+helmDefaults:
+  kubeContext: {{ .Environment.Values.foo }}
+---
+releases:
+- name: myrelease0
+  chart: mychart0
+---
+
+{{ readFile "templates.yaml" }}
+
+releases:
+- name: myrelease1
+  chart: mychart1
+  labels:
+    stage: pre
+    foo: bar
+- name: myrelease1
+  chart: mychart2
+  labels:
+    stage: post
+  <<: *default
+`)
+	files := map[string][]byte{
+		yamlFile: yamlContent,
+		"/path/to/base.yaml": []byte(`environments:
+  default:
+    values:
+    - environments/default/1.yaml
+`),
+		"/path/to/yaml/environments/default/1.yaml": []byte(`foo: FOO`),
+		"/path/to/base.gotmpl": []byte(`environments:
+  default:
+    values:
+    - environments/default/2.yaml
+
+helmDefaults:
+  tillerNamespace: {{ .Environment.Values.tillerNs }}
+`),
+		"/path/to/yaml/environments/default/2.yaml": []byte(`tillerNs: TILLER_NS`),
+		"/path/to/yaml/templates.yaml": []byte(`templates:
+  default: &default
+    missingFileHandler: Warn
+    values: ["` + "{{`" + `{{.Release.Name}}` + "`}}" + `/values.yaml"]
+`),
+	}
+	readFile := func(filename string) ([]byte, error) {
+		content, ok := files[filename]
+		if !ok {
+			return nil, fmt.Errorf("unexpected filename: %s", filename)
+		}
+		return content, nil
+	}
+	app := &App{
+		readFile: readFile,
+		glob:     filepath.Glob,
+		abs:      filepath.Abs,
+		Env:      "default",
+		Logger:   helmexec.NewLogger(os.Stderr, "debug"),
+	}
+	st, err := app.loadDesiredStateFromYaml(yamlFile)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if st.HelmDefaults.TillerNamespace != "TILLER_NS" {
+		t.Errorf("unexpected helmDefaults.tillerNamespace: expected=TILLER_NS, got=%s", st.HelmDefaults.TillerNamespace)
+	}
+
+	if st.Releases[0].Name != "myrelease0" {
+		t.Errorf("unexpected releases[0].name: expected=myrelease0, got=%s", st.Releases[0].Name)
+	}
+	if st.Releases[1].Name != "myrelease1" {
+		t.Errorf("unexpected releases[1].name: expected=myrelease1, got=%s", st.Releases[1].Name)
+	}
+	if st.Releases[2].Name != "myrelease1" {
+		t.Errorf("unexpected releases[2].name: expected=myrelease1, got=%s", st.Releases[2].Name)
+	}
+	if st.Releases[2].Values[0] != "{{`{{.Release.Name}}`}}/values.yaml" {
+		t.Errorf("unexpected releases[2].missingFileHandler: expected={{`{{.Release.Name}}`}}/values.yaml, got=%s", st.Releases[1].Values[0])
+	}
+	if *st.Releases[2].MissingFileHandler != "Warn" {
+		t.Errorf("unexpected releases[2].missingFileHandler: expected=Warn, got=%s", *st.Releases[1].MissingFileHandler)
+	}
+
+	if st.Releases[2].Values[0] != "{{`{{.Release.Name}}`}}/values.yaml" {
+		t.Errorf("unexpected releases[2].missingFileHandler: expected={{`{{.Release.Name}}`}}/values.yaml, got=%s", st.Releases[1].Values[0])
+	}
+
+	if st.HelmDefaults.KubeContext != "FOO" {
+		t.Errorf("unexpected helmDefaults.kubeContext: expected=FOO, got=%s", st.HelmDefaults.KubeContext)
 	}
 }

--- a/pkg/app/constants.go
+++ b/pkg/app/constants.go
@@ -13,6 +13,10 @@ const (
 	ExperimentalSelectorExplicit = "explicit-selector-inheritance" // value to remove default selector inheritance to sub-helmfiles and use the explicit one
 )
 
+func experimentalModeEnabled() bool {
+	return os.Getenv(ExperimentalEnvVar) == "true"
+}
+
 func isExplicitSelectorInheritanceEnabled() bool {
-	return os.Getenv(ExperimentalEnvVar) == "true" || strings.Contains(os.Getenv(ExperimentalEnvVar), ExperimentalSelectorExplicit)
+	return experimentalModeEnabled() || strings.Contains(os.Getenv(ExperimentalEnvVar), ExperimentalSelectorExplicit)
 }

--- a/pkg/app/desired_state_file_loader.go
+++ b/pkg/app/desired_state_file_loader.go
@@ -1,8 +1,11 @@
 package app
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
 	"github.com/imdario/mergo"
+	"github.com/roboll/helmfile/environment"
 	"github.com/roboll/helmfile/state"
 	"go.uber.org/zap"
 	"log"
@@ -26,10 +29,10 @@ type desiredStateLoader struct {
 }
 
 func (ld *desiredStateLoader) Load(f string) (*state.HelmState, error) {
-	return ld.load(filepath.Dir(f), filepath.Base(f), true)
+	return ld.loadFile(filepath.Dir(f), filepath.Base(f), true)
 }
 
-func (ld *desiredStateLoader) load(baseDir, file string, evaluateBases bool) (*state.HelmState, error) {
+func (ld *desiredStateLoader) loadFile(baseDir, file string, evaluateBases bool) (*state.HelmState, error) {
 	var f string
 	if filepath.IsAbs(file) {
 		f = file
@@ -44,51 +47,28 @@ func (ld *desiredStateLoader) load(baseDir, file string, evaluateBases bool) (*s
 
 	ext := filepath.Ext(f)
 
-	var yamlBytes []byte
+	var self *state.HelmState
+
 	if !experimentalModeEnabled() || ext == ".gotmpl" {
-		yamlBuf, err := ld.renderTemplateToYaml(baseDir, f, fileBytes)
-		if err != nil {
-			return nil, fmt.Errorf("error during %s parsing: %v", f, err)
-		}
-		yamlBytes = yamlBuf.Bytes()
+		self, err = ld.renderAndLoad(
+			baseDir,
+			f,
+			fileBytes,
+			evaluateBases,
+		)
 	} else {
-		yamlBytes = fileBytes
+		self, err = ld.load(
+			fileBytes,
+			baseDir,
+			file,
+			evaluateBases,
+		)
 	}
 
-	self, err := ld.loadYaml(
-		yamlBytes,
-		baseDir,
-		file,
-	)
-
-	if err != nil {
-		return nil, err
-	}
-
-	if !evaluateBases {
-		return self, nil
-	}
-
-	layers := []*state.HelmState{}
-	for _, b := range self.Bases {
-		base, err := ld.load(baseDir, b, false)
-		if err != nil {
-			return nil, err
-		}
-		layers = append(layers, base)
-	}
-	layers = append(layers, self)
-
-	for i := 1; i < len(layers); i++ {
-		if err := mergo.Merge(layers[0], layers[i], mergo.WithAppendSlice); err != nil {
-			return nil, err
-		}
-	}
-
-	return layers[0], nil
+	return self, err
 }
 
-func (a *desiredStateLoader) loadYaml(yaml []byte, baseDir, file string) (*state.HelmState, error) {
+func (a *desiredStateLoader) load(yaml []byte, baseDir, file string, evaluateBases bool) (*state.HelmState, error) {
 	c := state.NewCreator(a.logger, a.readFile, a.abs)
 	st, err := c.ParseAndLoadEnv(yaml, baseDir, file, a.env)
 	if err != nil {
@@ -141,5 +121,83 @@ func (a *desiredStateLoader) loadYaml(yaml []byte, baseDir, file string) (*state
 		st.Namespace = a.namespace
 	}
 
-	return st, nil
+	if err != nil {
+		return nil, err
+	}
+
+	if !evaluateBases {
+		if len(st.Bases) > 0 {
+			return nil, errors.New("nested `base` helmfile is unsupported. please submit a feature request if you need this!")
+		}
+
+		return st, nil
+	}
+
+	layers := []*state.HelmState{}
+	for _, b := range st.Bases {
+		base, err := a.loadFile(baseDir, b, false)
+		if err != nil {
+			return nil, err
+		}
+		layers = append(layers, base)
+	}
+	layers = append(layers, st)
+
+	for i := 1; i < len(layers); i++ {
+		if err := mergo.Merge(layers[0], layers[i], mergo.WithAppendSlice); err != nil {
+			return nil, err
+		}
+	}
+
+	return layers[0], nil
+}
+
+func (ld *desiredStateLoader) renderAndLoad(baseDir, filename string, content []byte, evaluateBases bool) (*state.HelmState, error) {
+	parts := bytes.Split(content, []byte("\n---\n"))
+
+	var finalState *state.HelmState
+	var env *environment.Environment
+
+	for i, part := range parts {
+		var yamlBuf *bytes.Buffer
+		var err error
+
+		id := fmt.Sprintf("%s.part.%d", filename, i)
+
+		if env == nil {
+			yamlBuf, err = ld.renderTemplatesToYaml(baseDir, id, part)
+			if err != nil {
+				return nil, fmt.Errorf("error during %s parsing: %v", id, err)
+			}
+		} else {
+			yamlBuf, err = ld.renderTemplatesToYaml(baseDir, id, part, *env)
+			if err != nil {
+				return nil, fmt.Errorf("error during %s parsing: %v", id, err)
+			}
+		}
+
+		currentState, err := ld.load(
+			yamlBuf.Bytes(),
+			baseDir,
+			filename,
+			evaluateBases,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		if finalState == nil {
+			finalState = currentState
+		} else {
+			if err := mergo.Merge(finalState, currentState, mergo.WithAppendSlice); err != nil {
+				return nil, err
+			}
+		}
+
+		env = &finalState.Env
+
+		ld.logger.Debugf("merged environment: %v", env)
+	}
+
+	return finalState, nil
 }

--- a/pkg/app/desired_state_file_loader.go
+++ b/pkg/app/desired_state_file_loader.go
@@ -1,0 +1,145 @@
+package app
+
+import (
+	"fmt"
+	"github.com/imdario/mergo"
+	"github.com/roboll/helmfile/state"
+	"go.uber.org/zap"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+type desiredStateLoader struct {
+	KubeContext string
+	Reverse     bool
+
+	env       string
+	namespace string
+
+	readFile func(string) ([]byte, error)
+	abs      func(string) (string, error)
+	glob     func(string) ([]string, error)
+
+	logger *zap.SugaredLogger
+}
+
+func (ld *desiredStateLoader) Load(f string) (*state.HelmState, error) {
+	return ld.load(filepath.Dir(f), filepath.Base(f), true)
+}
+
+func (ld *desiredStateLoader) load(baseDir, file string, evaluateBases bool) (*state.HelmState, error) {
+	var f string
+	if filepath.IsAbs(file) {
+		f = file
+	} else {
+		f = filepath.Join(baseDir, file)
+	}
+
+	fileBytes, err := ld.readFile(f)
+	if err != nil {
+		return nil, err
+	}
+
+	ext := filepath.Ext(f)
+
+	var yamlBytes []byte
+	if !experimentalModeEnabled() || ext == ".gotmpl" {
+		yamlBuf, err := ld.renderTemplateToYaml(baseDir, f, fileBytes)
+		if err != nil {
+			return nil, fmt.Errorf("error during %s parsing: %v", f, err)
+		}
+		yamlBytes = yamlBuf.Bytes()
+	} else {
+		yamlBytes = fileBytes
+	}
+
+	self, err := ld.loadYaml(
+		yamlBytes,
+		baseDir,
+		file,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if !evaluateBases {
+		return self, nil
+	}
+
+	layers := []*state.HelmState{}
+	for _, b := range self.Bases {
+		base, err := ld.load(baseDir, b, false)
+		if err != nil {
+			return nil, err
+		}
+		layers = append(layers, base)
+	}
+	layers = append(layers, self)
+
+	for i := 1; i < len(layers); i++ {
+		if err := mergo.Merge(layers[0], layers[i], mergo.WithAppendSlice); err != nil {
+			return nil, err
+		}
+	}
+
+	return layers[0], nil
+}
+
+func (a *desiredStateLoader) loadYaml(yaml []byte, baseDir, file string) (*state.HelmState, error) {
+	c := state.NewCreator(a.logger, a.readFile, a.abs)
+	st, err := c.ParseAndLoadEnv(yaml, baseDir, file, a.env)
+	if err != nil {
+		return nil, err
+	}
+
+	helmfiles := []state.SubHelmfileSpec{}
+	for _, hf := range st.Helmfiles {
+		globPattern := hf.Path
+		var absPathPattern string
+		if filepath.IsAbs(globPattern) {
+			absPathPattern = globPattern
+		} else {
+			absPathPattern = st.JoinBase(globPattern)
+		}
+		matches, err := a.glob(absPathPattern)
+		if err != nil {
+			return nil, fmt.Errorf("failed processing %s: %v", globPattern, err)
+		}
+		sort.Strings(matches)
+		for _, match := range matches {
+			newHelmfile := hf
+			newHelmfile.Path = match
+			helmfiles = append(helmfiles, newHelmfile)
+		}
+
+	}
+	st.Helmfiles = helmfiles
+
+	if a.Reverse {
+		rev := func(i, j int) bool {
+			return j < i
+		}
+		sort.Slice(st.Releases, rev)
+		sort.Slice(st.Helmfiles, rev)
+	}
+
+	if a.KubeContext != "" {
+		if st.HelmDefaults.KubeContext != "" {
+			log.Printf("err: Cannot use option --kube-context and set attribute helmDefaults.kubeContext.")
+			os.Exit(1)
+		}
+		st.HelmDefaults.KubeContext = a.KubeContext
+	}
+	if a.namespace != "" {
+		if st.Namespace != "" {
+			log.Printf("err: Cannot use option --namespace and set attribute namespace.")
+			os.Exit(1)
+		}
+		st.Namespace = a.namespace
+	}
+
+	return st, nil
+}

--- a/pkg/app/two_pass_renderer.go
+++ b/pkg/app/two_pass_renderer.go
@@ -6,8 +6,6 @@ import (
 	"github.com/roboll/helmfile/environment"
 	"github.com/roboll/helmfile/state"
 	"github.com/roboll/helmfile/tmpl"
-	"go.uber.org/zap"
-	"path/filepath"
 	"strings"
 )
 
@@ -20,39 +18,30 @@ func prependLineNumbers(text string) string {
 	return buf.String()
 }
 
-type twoPassRenderer struct {
-	reader    func(string) ([]byte, error)
-	env       string
-	namespace string
-	filename  string
-	logger    *zap.SugaredLogger
-	abs       func(string) (string, error)
-}
-
-func (r *twoPassRenderer) renderEnvironment(content []byte) environment.Environment {
+func (r *desiredStateLoader) renderEnvironment(baseDir, filename string, content []byte) environment.Environment {
 	firstPassEnv := environment.Environment{Name: r.env, Values: map[string]interface{}(nil)}
 	tmplData := state.EnvironmentTemplateData{Environment: firstPassEnv, Namespace: r.namespace}
-	firstPassRenderer := tmpl.NewFirstPassRenderer(filepath.Dir(r.filename), tmplData)
+	firstPassRenderer := tmpl.NewFirstPassRenderer(baseDir, tmplData)
 
 	// parse as much as we can, tolerate errors, this is a preparse
 	yamlBuf, err := firstPassRenderer.RenderTemplateContentToBuffer(content)
 	if err != nil && r.logger != nil {
-		r.logger.Debugf("first-pass rendering input of \"%s\":\n%s", r.filename, prependLineNumbers(string(content)))
+		r.logger.Debugf("first-pass rendering input of \"%s\":\n%s", filename, prependLineNumbers(string(content)))
 		if yamlBuf == nil { // we have a template syntax error, let the second parse report
 			r.logger.Debugf("template syntax error: %v", err)
 			return firstPassEnv
 		}
 	}
-	c := state.NewCreator(r.logger, r.reader, r.abs)
+	c := state.NewCreator(r.logger, r.readFile, r.abs)
 	c.Strict = false
 	// create preliminary state, as we may have an environment. Tolerate errors.
-	prestate, err := c.CreateFromYaml(yamlBuf.Bytes(), r.filename, r.env)
+	prestate, err := c.ParseAndLoadEnv(yamlBuf.Bytes(), baseDir, filename, r.env)
 	if err != nil && r.logger != nil {
 		switch err.(type) {
 		case *state.StateLoadError:
 			r.logger.Infof("could not deduce `environment:` block, configuring only .Environment.Name. error: %v", err)
 		}
-		r.logger.Debugf("error in first-pass rendering: result of \"%s\":\n%s", r.filename, prependLineNumbers(yamlBuf.String()))
+		r.logger.Debugf("error in first-pass rendering: result of \"%s\":\n%s", filename, prependLineNumbers(yamlBuf.String()))
 	}
 	if prestate != nil {
 		firstPassEnv = prestate.Env
@@ -60,21 +49,21 @@ func (r *twoPassRenderer) renderEnvironment(content []byte) environment.Environm
 	return firstPassEnv
 }
 
-func (r *twoPassRenderer) renderTemplate(content []byte) (*bytes.Buffer, error) {
+func (r *desiredStateLoader) renderTemplateToYaml(baseDir, filename string, content []byte) (*bytes.Buffer, error) {
 	// try a first pass render. This will always succeed, but can produce a limited env
-	firstPassEnv := r.renderEnvironment(content)
+	firstPassEnv := r.renderEnvironment(baseDir, filename, content)
 
 	tmplData := state.EnvironmentTemplateData{Environment: firstPassEnv, Namespace: r.namespace}
-	secondPassRenderer := tmpl.NewFileRenderer(r.reader, filepath.Dir(r.filename), tmplData)
+	secondPassRenderer := tmpl.NewFileRenderer(r.readFile, baseDir, tmplData)
 	yamlBuf, err := secondPassRenderer.RenderTemplateContentToBuffer(content)
 	if err != nil {
 		if r.logger != nil {
-			r.logger.Debugf("second-pass rendering failed, input of \"%s\":\n%s", r.filename, prependLineNumbers(string(content)))
+			r.logger.Debugf("second-pass rendering failed, input of \"%s\":\n%s", filename, prependLineNumbers(string(content)))
 		}
 		return nil, err
 	}
 	if r.logger != nil {
-		r.logger.Debugf("second-pass rendering result of \"%s\":\n%s", r.filename, prependLineNumbers(yamlBuf.String()))
+		r.logger.Debugf("second-pass rendering result of \"%s\":\n%s", filename, prependLineNumbers(yamlBuf.String()))
 	}
 	return yamlBuf, nil
 }

--- a/pkg/app/two_pass_renderer_test.go
+++ b/pkg/app/two_pass_renderer_test.go
@@ -51,7 +51,7 @@ releases:
 	}
 
 	r := makeLoader(fileReader, "staging")
-	yamlBuf, err := r.renderTemplateToYaml("", "", yamlContent)
+	yamlBuf, err := r.renderTemplatesToYaml("", "", yamlContent)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -103,7 +103,7 @@ releases:
 
 	r := makeLoader(fileReader, "staging")
 	// test the double rendering
-	yamlBuf, err := r.renderTemplateToYaml("", "", yamlContent)
+	yamlBuf, err := r.renderTemplatesToYaml("", "", yamlContent)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -152,7 +152,7 @@ releases:
 
 	r := makeLoader(fileReader, "staging")
 	// test the double rendering
-	_, err := r.renderTemplateToYaml("", "", yamlContent)
+	_, err := r.renderTemplatesToYaml("", "", yamlContent)
 
 	if !strings.Contains(err.Error(), "stringTemplate:8") {
 		t.Fatalf("error should contain a stringTemplate error (reference to unknow key) %v", err)
@@ -190,7 +190,7 @@ releases:
 	}
 
 	r := makeLoader(fileReader, "staging")
-	rendered, _ := r.renderTemplateToYaml("", "", yamlContent)
+	rendered, _ := r.renderTemplatesToYaml("", "", yamlContent)
 
 	var state state.HelmState
 	yaml.Unmarshal(rendered.Bytes(), &state)
@@ -217,7 +217,7 @@ func TestReadFromYaml_RenderTemplateWithNamespace(t *testing.T) {
 	}
 
 	r := makeLoader(fileReader, "staging")
-	yamlBuf, err := r.renderTemplateToYaml("", "", yamlContent)
+	yamlBuf, err := r.renderTemplatesToYaml("", "", yamlContent)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -248,7 +248,7 @@ releases:
 	}
 
 	r := makeLoader(fileReader, "staging")
-	_, err := r.renderTemplateToYaml("", "", yamlContent)
+	_, err := r.renderTemplatesToYaml("", "", yamlContent)
 	if err == nil {
 		t.Fatalf("wanted error, none returned")
 	}

--- a/pkg/app/two_pass_renderer_test.go
+++ b/pkg/app/two_pass_renderer_test.go
@@ -12,12 +12,11 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-func makeRenderer(readFile func(string) ([]byte, error), env string) *twoPassRenderer {
-	return &twoPassRenderer{
-		reader:    readFile,
+func makeLoader(readFile func(string) ([]byte, error), env string) *desiredStateLoader {
+	return &desiredStateLoader{
+		readFile:  readFile,
 		env:       env,
 		namespace: "namespace",
-		filename:  "",
 		logger:    helmexec.NewLogger(os.Stdout, "debug"),
 		abs:       filepath.Abs,
 	}
@@ -51,8 +50,8 @@ releases:
 		return []byte(""), nil
 	}
 
-	r := makeRenderer(fileReader, "staging")
-	yamlBuf, err := r.renderTemplate(yamlContent)
+	r := makeLoader(fileReader, "staging")
+	yamlBuf, err := r.renderTemplateToYaml("", "", yamlContent)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -102,9 +101,9 @@ releases:
 		return defaultValuesYaml, nil
 	}
 
-	r := makeRenderer(fileReader, "staging")
+	r := makeLoader(fileReader, "staging")
 	// test the double rendering
-	yamlBuf, err := r.renderTemplate(yamlContent)
+	yamlBuf, err := r.renderTemplateToYaml("", "", yamlContent)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -151,9 +150,9 @@ releases:
 		return defaultValuesYaml, nil
 	}
 
-	r := makeRenderer(fileReader, "staging")
+	r := makeLoader(fileReader, "staging")
 	// test the double rendering
-	_, err := r.renderTemplate(yamlContent)
+	_, err := r.renderTemplateToYaml("", "", yamlContent)
 
 	if !strings.Contains(err.Error(), "stringTemplate:8") {
 		t.Fatalf("error should contain a stringTemplate error (reference to unknow key) %v", err)
@@ -190,8 +189,8 @@ releases:
 		return defaultValuesYamlGotmpl, nil
 	}
 
-	r := makeRenderer(fileReader, "staging")
-	rendered, _ := r.renderTemplate(yamlContent)
+	r := makeLoader(fileReader, "staging")
+	rendered, _ := r.renderTemplateToYaml("", "", yamlContent)
 
 	var state state.HelmState
 	yaml.Unmarshal(rendered.Bytes(), &state)
@@ -217,8 +216,8 @@ func TestReadFromYaml_RenderTemplateWithNamespace(t *testing.T) {
 		return defaultValuesYaml, nil
 	}
 
-	r := makeRenderer(fileReader, "staging")
-	yamlBuf, err := r.renderTemplate(yamlContent)
+	r := makeLoader(fileReader, "staging")
+	yamlBuf, err := r.renderTemplateToYaml("", "", yamlContent)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -231,7 +230,7 @@ func TestReadFromYaml_RenderTemplateWithNamespace(t *testing.T) {
 	}
 }
 
-func TestReadFromYaml_HelfileShouldBeResilentToTemplateErrors(t *testing.T) {
+func TestReadFromYaml_HelmfileShouldBeResilentToTemplateErrors(t *testing.T) {
 	yamlContent := []byte(`environments:
   staging:
 	production:
@@ -248,8 +247,8 @@ releases:
 		return yamlContent, nil
 	}
 
-	r := makeRenderer(fileReader, "staging")
-	_, err := r.renderTemplate(yamlContent)
+	r := makeLoader(fileReader, "staging")
+	_, err := r.renderTemplateToYaml("", "", yamlContent)
 	if err == nil {
 		t.Fatalf("wanted error, none returned")
 	}

--- a/state/state.go
+++ b/state/state.go
@@ -27,9 +27,11 @@ import (
 
 // HelmState structure for the helmfile
 type HelmState struct {
-	basePath           string
-	Environments       map[string]EnvironmentSpec
-	FilePath           string
+	basePath     string
+	Environments map[string]EnvironmentSpec
+	FilePath     string
+
+	Bases              []string          `yaml:"bases"`
 	HelmDefaults       HelmSpec          `yaml:"helmDefaults"`
 	Helmfiles          []SubHelmfileSpec `yaml:"helmfiles"`
 	DeprecatedContext  string            `yaml:"context"`


### PR DESCRIPTION
The current  [Layering](https://github.com/roboll/helmfile/blob/master/docs/writing-helmfile.md#layering) system didn't work as documented, as it relies on helmfile to template each "part" of your helmfile.yaml THEN merge them one by one.

The reality was that helmfile template all the parts of your helmfile.yaml at once, and then merge those YAML documents. In https://github.com/roboll/helmfile/issues/388#issuecomment-436186278, @sruon was making a GREAT point that we may need to change helmfile to render templates earlier - that is to evaluate a template per each helmfile.yaml part separated by `---`. Sorry I missed my expertise to follow your great idea last year @sruon  😭 

Anyways, this, in combination with the wrong documentation, has made so many people confused. To finally overcome this situation, here's a fairly large PR that introduces the 2 enhancements:

- `bases:` for easier layering without go template expressions, especially `{{ readFunc "path/to/file" }}`s. This is the first commit of this PR.
- `helmfile.yaml` is splited by the separator `---` at first. Each part is then rendered as a go template(double-render applies as before). Finally, All the results are merged in the order of occurence. I assume this as an enhanced version of @sruon's work. This is the second commit of this PR.

Resolves #388
Resolve #584
Resolves #585 (`HELMFILE_EXPERIMENTA=true -f helmfile.yaml helmfile` disables the whole-file templating, treating the helmfile.yaml as a regular YAML file as the file ext. denotes. Use `helmfile.yaml.gotmpl` or `helmfile.gotmpl` to enable)
Fixes #568 (Use `bases` or `readFile` rather than not importing implicitly with `helmfile.d`