### PR TITLE
feat: postsync hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,14 +714,17 @@ Once `events` are triggered, associated `hooks` are executed, by running the `co
 Currently supported `events` are:
 
 - `prepare`
-- `cleanup`
 - `presync`
+- `postsync`
+- `cleanup`
 
 Hooks associated to `prepare` events are triggered after each release in your helmfile is loaded from YAML, before execution.
 
 Hooks associated to `cleanup` events are triggered after each release is processed.
 
 Hooks associated to `presync` events are triggered before each release is applied to the remote cluster. This is the ideal event to execute any commands that may mutate the cluster state as it will not be run for read-only operations like `lint`, `diff` or `template`.
+
+Hooks associated to `postsync` events are triggered after each release is applied to the remote cluster. This is the ideal event to execute any commands that may mutate the cluster state as it will not be run for read-only operations like `lint`, `diff` or `template`.
 
 The following is an example hook that just prints the contextual information provided to hook:
 

--- a/state/state.go
+++ b/state/state.go
@@ -374,7 +374,11 @@ func (st *HelmState) SyncReleases(affectedReleases *AffectedReleases, helm helme
 					results <- syncResult{errors: []*ReleaseError{relErr}}
 				}
 
-				if _, err := st.triggerCleanupEvent(prep.release, "sync"); err != nil {
+				if _, err := st.triggerPostsyncEvent(release, "sync"); err != nil {
+					st.logger.Warnf("warn: %v\n", err)
+				}
+
+				if _, err := st.triggerCleanupEvent(release, "sync"); err != nil {
 					st.logger.Warnf("warn: %v\n", err)
 				}
 			}
@@ -936,6 +940,10 @@ func (st *HelmState) triggerCleanupEvent(r *ReleaseSpec, helmfileCommand string)
 
 func (st *HelmState) triggerPresyncEvent(r *ReleaseSpec, helmfileCommand string) (bool, error) {
 	return st.triggerReleaseEvent("presync", r, helmfileCommand)
+}
+
+func (st *HelmState) triggerPostsyncEvent(r *ReleaseSpec, helmfileCommand string) (bool, error) {
+	return st.triggerReleaseEvent("postsync", r, helmfileCommand)
 }
 
 func (st *HelmState) triggerReleaseEvent(evt string, r *ReleaseSpec, helmfileCmd string) (bool, error) {


### PR DESCRIPTION
`postsync` events are triggered after each release is applied to the cluster in `helmfile sync` or `helmfile apply`.

This should be a best hook to notify only after each sync failed or succeeded. This can be used for running operations like patching K8s resources managed by helm, but that should be the last-resort. Maybe you should fork/update the chart, or submit a feature request to add `replicated/ship` integration to `helmfile` in that case :)

Resolves #599