### PR TITLE
feat: expand glob pattern in environment values file path

### DIFF
--- a/state/testfs.go
+++ b/state/testfs.go
@@ -1,0 +1,130 @@
+package state
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+type TestFs struct {
+	Cwd   string
+	dirs  map[string]bool
+	files map[string]string
+
+	GlobFixtures map[string][]string
+
+	fileReaderCalls int
+	successfulReads []string
+}
+
+func NewTestFs(files map[string]string) *TestFs {
+	dirs := map[string]bool{}
+	for abs, _ := range files {
+		d := filepath.Dir(abs)
+		dirs[d] = true
+	}
+	return &TestFs{
+		Cwd:   "/path/to",
+		dirs:  dirs,
+		files: files,
+
+		successfulReads: []string{},
+
+		GlobFixtures: map[string][]string{},
+	}
+}
+
+func (f *TestFs) FileExistsAt(path string) bool {
+	var ok bool
+	if strings.Contains(path, "/") {
+		_, ok = f.files[path]
+	} else {
+		_, ok = f.files[filepath.Join(f.Cwd, path)]
+	}
+	return ok
+}
+
+func (f *TestFs) DirectoryExistsAt(path string) bool {
+	var ok bool
+	if strings.Contains(path, "/") {
+		_, ok = f.dirs[path]
+	} else {
+		_, ok = f.dirs[filepath.Join(f.Cwd, path)]
+	}
+	return ok
+}
+
+func (f *TestFs) ReadFile(filename string) ([]byte, error) {
+	var str string
+	var ok bool
+	if filename[0] == '/' {
+		str, ok = f.files[filename]
+	} else {
+		str, ok = f.files[filepath.Join(f.Cwd, filename)]
+	}
+	if !ok {
+		return []byte(nil), fmt.Errorf("no registered file found: %s", filename)
+	}
+
+	f.fileReaderCalls += 1
+
+	f.successfulReads = append(f.successfulReads, filename)
+
+	return []byte(str), nil
+}
+
+func (f *TestFs) SuccessfulReads() []string {
+	return f.successfulReads
+}
+
+func (f *TestFs) FileReaderCalls() int {
+	return f.fileReaderCalls
+}
+
+func (f *TestFs) Glob(relPattern string) ([]string, error) {
+	var pattern string
+	if relPattern[0] == '/' {
+		pattern = relPattern
+	} else {
+		pattern = filepath.Join(f.Cwd, relPattern)
+	}
+
+	fixtures, ok := f.GlobFixtures[pattern]
+	if ok {
+		return fixtures, nil
+	}
+
+	matches := []string{}
+	for name, _ := range f.files {
+		matched, err := filepath.Match(pattern, name)
+		if err != nil {
+			return nil, err
+		}
+		if matched {
+			matches = append(matches, name)
+		}
+	}
+	return matches, nil
+}
+
+func (f *TestFs) Abs(path string) (string, error) {
+	var p string
+	if path[0] == '/' {
+		p = path
+	} else {
+		p = filepath.Join(f.Cwd, path)
+	}
+	return filepath.Clean(p), nil
+}
+
+func (f *TestFs) Getwd() (string, error) {
+	return f.Cwd, nil
+}
+
+func (f *TestFs) Chdir(dir string) error {
+	if _, ok := f.dirs[dir]; ok {
+		f.Cwd = dir
+		return nil
+	}
+	return fmt.Errorf("unexpected chdir \"%s\"", dir)
+}


### PR DESCRIPTION
This enhances helmfile's internal environment values files loader to expand glob patterns (#606)

Fixes the existing bug that helmfile was unable to load environment values file from absolute path (#549)

Resolves #606
Fixes #549