### PR TITLE
feat: ability to exit zero with no releases match selector (Fixes: #597)

### DIFF
--- a/main.go
+++ b/main.go
@@ -83,7 +83,7 @@ func main() {
 	The name of a release can be used as a label. --selector name=myrelease`,
 		},
 		cli.BoolFlag{
-			Name: "allow-no-matching-release",
+			Name:  "allow-no-matching-release",
 			Usage: `Do not exit with an error code if the provided selector has no matching releases.`,
 		},
 		cli.BoolFlag{

--- a/main.go
+++ b/main.go
@@ -83,6 +83,10 @@ func main() {
 	The name of a release can be used as a label. --selector name=myrelease`,
 		},
 		cli.BoolFlag{
+			Name: "allow-no-matching-release",
+			Usage: `Do not exit with an error code if the provided selector has no matching releases.`,
+		},
+		cli.BoolFlag{
 			Name:  "interactive, i",
 			Usage: "Request confirmation before attempting to modify clusters",
 		},


### PR DESCRIPTION
- Change exit code from 2 to 3 when helmfiles have no releases that match a selector
- Introduces new flag `--allow-no-matching-release` to exit 0 when no releases match a selector.

See discussion at #597 