### PR TITLE
feat: optionally allow missing environment values/secrets files

### DIFF
--- a/pkg/app/two_pass_renderer_test.go
+++ b/pkg/app/two_pass_renderer_test.go
@@ -13,12 +13,13 @@ import (
 func makeLoader(files map[string]string, env string) (*desiredStateLoader, *state.TestFs) {
 	testfs := state.NewTestFs(files)
 	return &desiredStateLoader{
-		env:       env,
-		namespace: "namespace",
-		logger:    helmexec.NewLogger(os.Stdout, "debug"),
-		readFile:  testfs.ReadFile,
-		abs:       testfs.Abs,
-		glob:      testfs.Glob,
+		env:        env,
+		namespace:  "namespace",
+		logger:     helmexec.NewLogger(os.Stdout, "debug"),
+		readFile:   testfs.ReadFile,
+		fileExists: testfs.FileExists,
+		abs:        testfs.Abs,
+		glob:       testfs.Glob,
 	}, testfs
 }
 

--- a/state/create_test.go
+++ b/state/create_test.go
@@ -106,7 +106,7 @@ bar: {{ readFile "bar.txt" }}
 	})
 	testFs.Cwd = "/example/path/to"
 
-	state, err := NewCreator(logger, testFs.ReadFile, testFs.Abs, testFs.Glob).ParseAndLoad(yamlContent, filepath.Dir(yamlFile), yamlFile, "production", false, nil)
+	state, err := NewCreator(logger, testFs.ReadFile, testFs.FileExists, testFs.Abs, testFs.Glob).ParseAndLoad(yamlContent, filepath.Dir(yamlFile), yamlFile, "production", false, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/state/environment.go
+++ b/state/environment.go
@@ -3,4 +3,13 @@ package state
 type EnvironmentSpec struct {
 	Values  []string `yaml:"values"`
 	Secrets []string `yaml:"secrets"`
+
+	// MissingFileHandler instructs helmfile to fail when unable to find a environment values file listed
+	// under `environments.NAME.values`.
+	//
+	// Possible values are  "Error", "Warn", "Info", "Debug". The default is "Error".
+	//
+	// Use "Warn", "Info", or "Debug" if you want helmfile to not fail when a values file is missing, while just leaving
+	// a message about the missing file at the log-level.
+	MissingFileHandler *string `yaml:"missingFileHandler"`
 }


### PR DESCRIPTION
```yaml
environments:
  default:
    missingFileHandler: Warn
    values:
    - path/to/values.yaml
    secrets:
    - path/to/secrets.yaml
```

`missingFileHandler` set to `Warn`, `Info`, or `Debug` results in helmfile NOT stop when `path/to/values.yaml` or `path/to/secrets.yaml` is missing.

Resolves #548

While implementing the above feature, I also found a bug that has been causing #559. This also fixes that.

To verify it is actually fixed, create an example helmfile.yaml that looks like the below, and run `helmfile diff`:

```
$ cat helmfile.yaml
environments:
  default:
    secrets:
      - env-secrets.yaml

releases:
  - name: myapp
    chart: nginx
    namespace: default
    secrets: [secrets.yaml]    # Notice this file does not exist
    values:
      - ingress:
          enabled: true

$ helmfile diff
could not deduce `environment:` block, configuring only .Environment.Name. error: failed to read helmfile.yaml.part.0: environment values file matching "env-secrets.yaml" does not exist
in ./helmfile.yaml: failed to read helmfile.yaml: environment values file matching "env-secrets.yaml" does not exist
```

Fixes #559