### PR TITLE
 feat: specify env values from the parent to the nested state

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -25,7 +25,7 @@ func VisitAllDesiredStates(c *cli.Context, converge func(*state.HelmState, helme
 		return converge(st, helm, ctx)
 	}
 
-	err = a.VisitDesiredStates(fileOrDir, a.Selectors, convergeWithHelmBinary)
+	err = a.VisitDesiredStates(fileOrDir, app.LoadOpts{Selectors: a.Selectors}, convergeWithHelmBinary)
 
 	return toCliError(c, err)
 }

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -1,8 +1,25 @@
 package environment
 
+import "encoding/json"
+
 type Environment struct {
 	Name   string
 	Values map[string]interface{}
 }
 
 var EmptyEnvironment Environment
+
+func (e Environment) DeepCopy() Environment {
+	bytes, err := json.Marshal(e.Values)
+	if err != nil {
+		panic(err)
+	}
+	var values map[string]interface{}
+	if err := json.Unmarshal(bytes, &values); err != nil {
+		panic(err)
+	}
+	return Environment{
+		Name:   e.Name,
+		Values: values,
+	}
+}

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -1,6 +1,9 @@
 package environment
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"github.com/imdario/mergo"
+)
 
 type Environment struct {
 	Name   string
@@ -22,4 +25,21 @@ func (e Environment) DeepCopy() Environment {
 		Name:   e.Name,
 		Values: values,
 	}
+}
+
+func (e *Environment) Merge(other *Environment) (*Environment, error) {
+	if e == nil {
+		if other != nil {
+			copy := other.DeepCopy()
+			return &copy, nil
+		}
+		return nil, nil
+	}
+	copy := e.DeepCopy()
+	if other != nil {
+		if err := mergo.Merge(&copy, other, mergo.WithOverride); err != nil {
+			return nil, err
+		}
+	}
+	return &copy, nil
 }

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -1013,25 +1013,23 @@ helmDefaults:
 	if st.HelmDefaults.TillerNamespace != "TILLER_NS" {
 		t.Errorf("unexpected helmDefaults.tillerNamespace: expected=TILLER_NS, got=%s", st.HelmDefaults.TillerNamespace)
 	}
-
-	if st.Releases[0].Name != "myrelease0" {
-		t.Errorf("unexpected releases[0].name: expected=myrelease0, got=%s", st.Releases[0].Name)
+	firstRelease := st.Releases[0]
+	if firstRelease.Name != "myrelease1" {
+		t.Errorf("unexpected releases[1].name: expected=myrelease1, got=%s", firstRelease.Name)
 	}
-	if st.Releases[1].Name != "myrelease1" {
-		t.Errorf("unexpected releases[1].name: expected=myrelease1, got=%s", st.Releases[1].Name)
+	secondRelease := st.Releases[1]
+	if secondRelease.Name != "myrelease1" {
+		t.Errorf("unexpected releases[2].name: expected=myrelease1, got=%s", secondRelease.Name)
 	}
-	if st.Releases[2].Name != "myrelease1" {
-		t.Errorf("unexpected releases[2].name: expected=myrelease1, got=%s", st.Releases[2].Name)
+	if secondRelease.Values[0] != "{{`{{.Release.Name}}`}}/values.yaml" {
+		t.Errorf("unexpected releases[2].missingFileHandler: expected={{`{{.Release.Name}}`}}/values.yaml, got=%s", firstRelease.Values[0])
 	}
-	if st.Releases[2].Values[0] != "{{`{{.Release.Name}}`}}/values.yaml" {
-		t.Errorf("unexpected releases[2].missingFileHandler: expected={{`{{.Release.Name}}`}}/values.yaml, got=%s", st.Releases[1].Values[0])
-	}
-	if *st.Releases[2].MissingFileHandler != "Warn" {
-		t.Errorf("unexpected releases[2].missingFileHandler: expected=Warn, got=%s", *st.Releases[1].MissingFileHandler)
+	if *secondRelease.MissingFileHandler != "Warn" {
+		t.Errorf("unexpected releases[2].missingFileHandler: expected=Warn, got=%s", *firstRelease.MissingFileHandler)
 	}
 
-	if st.Releases[2].Values[0] != "{{`{{.Release.Name}}`}}/values.yaml" {
-		t.Errorf("unexpected releases[2].missingFileHandler: expected={{`{{.Release.Name}}`}}/values.yaml, got=%s", st.Releases[1].Values[0])
+	if secondRelease.Values[0] != "{{`{{.Release.Name}}`}}/values.yaml" {
+		t.Errorf("unexpected releases[2].missingFileHandler: expected={{`{{.Release.Name}}`}}/values.yaml, got=%s", firstRelease.Values[0])
 	}
 
 	if st.HelmDefaults.KubeContext != "FOO" {
@@ -1230,24 +1228,23 @@ helmDefaults:
 		t.Errorf("unexpected helmDefaults.tillerNamespace: expected=TILLER_NS, got=%s", st.HelmDefaults.TillerNamespace)
 	}
 
-	if st.Releases[0].Name != "myrelease0" {
-		t.Errorf("unexpected releases[0].name: expected=myrelease0, got=%s", st.Releases[0].Name)
+	firstRelease := st.Releases[0]
+	if firstRelease.Name != "myrelease1" {
+		t.Errorf("unexpected releases[1].name: expected=myrelease1, got=%s", firstRelease.Name)
 	}
-	if st.Releases[1].Name != "myrelease1" {
-		t.Errorf("unexpected releases[1].name: expected=myrelease1, got=%s", st.Releases[1].Name)
+	secondRelease := st.Releases[1]
+	if secondRelease.Name != "myrelease1" {
+		t.Errorf("unexpected releases[2].name: expected=myrelease1, got=%s", secondRelease.Name)
 	}
-	if st.Releases[2].Name != "myrelease1" {
-		t.Errorf("unexpected releases[2].name: expected=myrelease1, got=%s", st.Releases[2].Name)
+	if secondRelease.Values[0] != "{{`{{.Release.Name}}`}}/values.yaml" {
+		t.Errorf("unexpected releases[2].missingFileHandler: expected={{`{{.Release.Name}}`}}/values.yaml, got=%s", firstRelease.Values[0])
 	}
-	if st.Releases[2].Values[0] != "{{`{{.Release.Name}}`}}/values.yaml" {
-		t.Errorf("unexpected releases[2].missingFileHandler: expected={{`{{.Release.Name}}`}}/values.yaml, got=%s", st.Releases[1].Values[0])
-	}
-	if *st.Releases[2].MissingFileHandler != "Warn" {
-		t.Errorf("unexpected releases[2].missingFileHandler: expected=Warn, got=%s", *st.Releases[1].MissingFileHandler)
+	if *secondRelease.MissingFileHandler != "Warn" {
+		t.Errorf("unexpected releases[2].missingFileHandler: expected=Warn, got=%s", *firstRelease.MissingFileHandler)
 	}
 
-	if st.Releases[2].Values[0] != "{{`{{.Release.Name}}`}}/values.yaml" {
-		t.Errorf("unexpected releases[2].missingFileHandler: expected={{`{{.Release.Name}}`}}/values.yaml, got=%s", st.Releases[1].Values[0])
+	if secondRelease.Values[0] != "{{`{{.Release.Name}}`}}/values.yaml" {
+		t.Errorf("unexpected releases[2].missingFileHandler: expected={{`{{.Release.Name}}`}}/values.yaml, got=%s", firstRelease.Values[0])
 	}
 
 	if st.HelmDefaults.KubeContext != "FOO" {
@@ -1304,10 +1301,58 @@ releases:
 	if st.Releases[1].Name != "myrelease2" {
 		t.Errorf("unexpected releases[0].name: expected=myrelease2, got=%s", st.Releases[1].Name)
 	}
-	if st.Releases[2].Name != "myrelease1" {
-		t.Errorf("unexpected releases[0].name: expected=myrelease1, got=%s", st.Releases[2].Name)
+
+	if len(st.Releases) != 2 {
+		t.Errorf("unexpected number of releases: expected=2, got=%d", len(st.Releases))
 	}
-	if st.Releases[3].Name != "myrelease0" {
-		t.Errorf("unexpected releases[0].name: expected=myrelease0, got=%s", st.Releases[3].Name)
+}
+
+// See https://github.com/roboll/helmfile/issues/615
+func TestLoadDesiredStateFromYaml_MultiPartTemplate_NoMergeArrayInEnvVal(t *testing.T) {
+	statePath := "/path/to/helmfile.yaml"
+	stateContent := `
+environments:
+  default:
+    values:
+    - foo: ["foo"]
+---
+environments:
+  default:
+    values:
+    - foo: ["FOO"]
+    - 1.yaml
+---
+environments:
+  default:
+    values:
+    - 2.yaml
+---
+releases:
+- name: {{ .Environment.Values.foo | quote }}
+  chart: {{ .Environment.Values.bar | quote }}
+`
+	testFs := state.NewTestFs(map[string]string{
+		statePath:         stateContent,
+		"/path/to/1.yaml": `bar: ["bar"]`,
+		"/path/to/2.yaml": `bar: ["BAR"]`,
+	})
+	app := &App{
+		readFile: testFs.ReadFile,
+		glob:     testFs.Glob,
+		abs:      testFs.Abs,
+		Env:      "default",
+		Logger:   helmexec.NewLogger(os.Stderr, "debug"),
+		Reverse:  true,
+	}
+	st, err := app.loadDesiredStateFromYaml(statePath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if st.Releases[0].Name != "[FOO]" {
+		t.Errorf("unexpected releases[0].name: expected=FOO, got=%s", st.Releases[0].Name)
+	}
+	if st.Releases[0].Chart != "[BAR]" {
+		t.Errorf("unexpected releases[0].chart: expected=BAR, got=%s", st.Releases[0].Chart)
 	}
 }

--- a/pkg/app/desired_state_file_loader.go
+++ b/pkg/app/desired_state_file_loader.go
@@ -182,7 +182,7 @@ func (ld *desiredStateLoader) renderAndLoad(env *environment.Environment, baseDi
 		if finalState == nil {
 			finalState = currentState
 		} else {
-			if err := mergo.Merge(finalState, currentState, mergo.WithAppendSlice); err != nil {
+			if err := mergo.Merge(finalState, currentState, mergo.WithOverride); err != nil {
 				return nil, err
 			}
 		}

--- a/state/create.go
+++ b/state/create.go
@@ -228,7 +228,7 @@ func (st *HelmState) loadEnvValues(name string, ctxEnv *environment.Environment,
 	if ctxEnv != nil {
 		intEnv := *ctxEnv
 
-		if err := mergo.Merge(&intEnv, newEnv, mergo.WithAppendSlice); err != nil {
+		if err := mergo.Merge(&intEnv, newEnv, mergo.WithOverride); err != nil {
 			return nil, fmt.Errorf("error while merging environment values for \"%s\": %v", name, err)
 		}
 

--- a/state/create.go
+++ b/state/create.go
@@ -4,17 +4,13 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io"
-	"os"
-	"path/filepath"
-	"sort"
-
 	"github.com/imdario/mergo"
 	"github.com/roboll/helmfile/environment"
 	"github.com/roboll/helmfile/helmexec"
-	"github.com/roboll/helmfile/tmpl"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v2"
+	"io"
+	"os"
 )
 
 type StateLoadError struct {
@@ -164,68 +160,19 @@ func (c *StateCreator) loadBases(envValues *environment.Environment, st *HelmSta
 	return layers[0], nil
 }
 
-func (st *HelmState) ExpandPaths(globPattern string) ([]string, error) {
-	result := []string{}
-	absPathPattern := st.normalizePath(globPattern)
-	matches, err := st.glob(absPathPattern)
-	if err != nil {
-		return nil, fmt.Errorf("failed processing %s: %v", globPattern, err)
-	}
-
-	sort.Strings(matches)
-
-	result = append(result, matches...)
-	return result, nil
-}
-
 func (st *HelmState) loadEnvValues(name string, ctxEnv *environment.Environment, readFile func(string) ([]byte, error), glob func(string) ([]string, error)) (*environment.Environment, error) {
 	envVals := map[string]interface{}{}
 	envSpec, ok := st.Environments[name]
 	if ok {
-		for _, v := range envSpec.Values {
-			switch typedValue := v.(type) {
-			case string:
-				urlOrPath := typedValue
-				resolved, skipped, err := st.resolveFile(envSpec.MissingFileHandler, "environment values", urlOrPath)
-				if err != nil {
-					return nil, err
-				}
-				if skipped {
-					continue
-				}
-
-				for _, envvalFullPath := range resolved {
-					tmplData := EnvironmentTemplateData{Environment: environment.EmptyEnvironment, Namespace: ""}
-					r := tmpl.NewFileRenderer(readFile, filepath.Dir(envvalFullPath), tmplData)
-					bytes, err := r.RenderToBytes(envvalFullPath)
-					if err != nil {
-						return nil, fmt.Errorf("failed to load environment values file \"%s\": %v", envvalFullPath, err)
-					}
-					m := map[string]interface{}{}
-					if err := yaml.Unmarshal(bytes, &m); err != nil {
-						return nil, fmt.Errorf("failed to load environment values file \"%s\": %v", envvalFullPath, err)
-					}
-					if err := mergo.Merge(&envVals, &m, mergo.WithOverride); err != nil {
-						return nil, fmt.Errorf("failed to load \"%s\": %v", envvalFullPath, err)
-					}
-				}
-			case map[interface{}]interface{}:
-				m := map[string]interface{}{}
-				for k, v := range typedValue {
-					switch typedKey := k.(type) {
-					case string:
-						m[typedKey] = v
-					default:
-						return nil, fmt.Errorf("unexpected type of key in inline environment values %v: expected string, got %T", typedValue, typedKey)
-					}
-				}
-				if err := mergo.Merge(&envVals, &m, mergo.WithOverride); err != nil {
-					return nil, fmt.Errorf("failed to merge %v: %v", typedValue, err)
-				}
-				continue
-			default:
-				return nil, fmt.Errorf("unexpected type of values entry: %T", typedValue)
-			}
+		envValues := append([]interface{}{}, envSpec.Values...)
+		ld := &EnvironmentValuesLoader{
+			storage:  st.storage(),
+			readFile: st.readFile,
+		}
+		var err error
+		envVals, err = ld.LoadEnvironmentValues(envSpec.MissingFileHandler, envValues)
+		if err != nil {
+			return nil, err
 		}
 
 		if len(envSpec.Secrets) > 0 {
@@ -233,7 +180,7 @@ func (st *HelmState) loadEnvValues(name string, ctxEnv *environment.Environment,
 
 			var envSecretFiles []string
 			for _, urlOrPath := range envSpec.Secrets {
-				resolved, skipped, err := st.resolveFile(envSpec.MissingFileHandler, "environment values", urlOrPath)
+				resolved, skipped, err := st.storage().resolveFile(envSpec.MissingFileHandler, "environment values", urlOrPath)
 				if err != nil {
 					return nil, err
 				}

--- a/state/environment_values_loader.go
+++ b/state/environment_values_loader.go
@@ -1,0 +1,75 @@
+package state
+
+import (
+	"fmt"
+	"github.com/imdario/mergo"
+	"github.com/roboll/helmfile/environment"
+	"github.com/roboll/helmfile/tmpl"
+	"gopkg.in/yaml.v2"
+	"path/filepath"
+)
+
+type EnvironmentValuesLoader struct {
+	storage *Storage
+
+	readFile func(string) ([]byte, error)
+}
+
+func NewEnvironmentValuesLoader(storage *Storage, readFile func(string) ([]byte, error)) *EnvironmentValuesLoader {
+	return &EnvironmentValuesLoader{
+		storage:  storage,
+		readFile: readFile,
+	}
+}
+
+func (ld *EnvironmentValuesLoader) LoadEnvironmentValues(missingFileHandler *string, envValues []interface{}) (map[string]interface{}, error) {
+	envVals := map[string]interface{}{}
+
+	for _, v := range envValues {
+		switch typedValue := v.(type) {
+		case string:
+			urlOrPath := typedValue
+			resolved, skipped, err := ld.storage.resolveFile(missingFileHandler, "environment values", urlOrPath)
+			if err != nil {
+				return nil, err
+			}
+			if skipped {
+				continue
+			}
+
+			for _, envvalFullPath := range resolved {
+				tmplData := EnvironmentTemplateData{Environment: environment.EmptyEnvironment, Namespace: ""}
+				r := tmpl.NewFileRenderer(ld.readFile, filepath.Dir(envvalFullPath), tmplData)
+				bytes, err := r.RenderToBytes(envvalFullPath)
+				if err != nil {
+					return nil, fmt.Errorf("failed to load environment values file \"%s\": %v", envvalFullPath, err)
+				}
+				m := map[string]interface{}{}
+				if err := yaml.Unmarshal(bytes, &m); err != nil {
+					return nil, fmt.Errorf("failed to load environment values file \"%s\": %v", envvalFullPath, err)
+				}
+				if err := mergo.Merge(&envVals, &m, mergo.WithOverride); err != nil {
+					return nil, fmt.Errorf("failed to load \"%s\": %v", envvalFullPath, err)
+				}
+			}
+		case map[interface{}]interface{}:
+			m := map[string]interface{}{}
+			for k, v := range typedValue {
+				switch typedKey := k.(type) {
+				case string:
+					m[typedKey] = v
+				default:
+					return nil, fmt.Errorf("unexpected type of key in inline environment values %v: expected string, got %T", typedValue, typedKey)
+				}
+			}
+			if err := mergo.Merge(&envVals, &m, mergo.WithOverride); err != nil {
+				return nil, fmt.Errorf("failed to merge %v: %v", typedValue, err)
+			}
+			continue
+		default:
+			return nil, fmt.Errorf("unexpected type of values entry: %T", typedValue)
+		}
+	}
+
+	return envVals, nil
+}

--- a/state/state.go
+++ b/state/state.go
@@ -66,7 +66,7 @@ type SubHelmfileSpec struct {
 }
 
 type SubhelmfileEnvironmentSpec struct {
-	AdditionalValues []interface{} `yaml:"values"`
+	OverrideValues []interface{} `yaml:"values"`
 }
 
 // HelmSpec to defines helmDefault values

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1001,7 +1001,7 @@ func TestHelmState_SyncReleases_MissingValuesFileForUndesiredRelease(t *testing.
 				Values: []interface{}{"noexistent.values.yaml"},
 			},
 			listResult:    ``,
-			expectedError: `failed processing release foo: values file matching "noexistent.values.yaml" does not exist`,
+			expectedError: `failed processing release foo: values file matching "noexistent.values.yaml" does not exist in "."`,
 		},
 		{
 			name: "should fail upgrading due to missing values file",
@@ -1012,7 +1012,7 @@ func TestHelmState_SyncReleases_MissingValuesFileForUndesiredRelease(t *testing.
 			},
 			listResult: `NAME 	REVISION	UPDATED                 	STATUS  	CHART                      	APP VERSION	NAMESPACE
 										foo	1       	Wed Apr 17 17:39:04 2019	DEPLOYED	foo-bar-2.0.4	0.1.0      	default`,
-			expectedError: `failed processing release foo: values file matching "noexistent.values.yaml" does not exist`,
+			expectedError: `failed processing release foo: values file matching "noexistent.values.yaml" does not exist in "."`,
 		},
 		{
 			name: "should uninstall even when there is a missing values file",
@@ -1031,6 +1031,7 @@ func TestHelmState_SyncReleases_MissingValuesFileForUndesiredRelease(t *testing.
 		tt := tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			state := &HelmState{
+				basePath: ".",
 				Releases: []ReleaseSpec{tt.release},
 				logger:   logger,
 			}

--- a/state/storage.go
+++ b/state/storage.go
@@ -1,0 +1,99 @@
+package state
+
+import (
+	"fmt"
+	"go.uber.org/zap"
+	"net/url"
+	"path/filepath"
+	"sort"
+)
+
+type Storage struct {
+	logger *zap.SugaredLogger
+
+	FilePath string
+
+	basePath string
+	glob     func(string) ([]string, error)
+}
+
+func NewStorage(forFile string, logger *zap.SugaredLogger, glob func(string) ([]string, error)) *Storage {
+	return &Storage{
+		FilePath: forFile,
+		basePath: filepath.Dir(forFile),
+		logger:   logger,
+		glob:     glob,
+	}
+}
+
+func (st *Storage) resolveFile(missingFileHandler *string, tpe, path string) ([]string, bool, error) {
+	title := fmt.Sprintf("%s file", tpe)
+
+	files, err := st.ExpandPaths(path)
+	if err != nil {
+		return nil, false, err
+	}
+
+	var handlerId string
+
+	if missingFileHandler != nil {
+		handlerId = *missingFileHandler
+	} else {
+		handlerId = MissingFileHandlerError
+	}
+
+	if len(files) == 0 {
+		switch handlerId {
+		case MissingFileHandlerError:
+			return nil, false, fmt.Errorf("%s matching \"%s\" does not exist in \"%s\"", title, path, st.basePath)
+		case MissingFileHandlerWarn:
+			st.logger.Warnf("skipping missing %s matching \"%s\"", title, path)
+			return nil, true, nil
+		case MissingFileHandlerInfo:
+			st.logger.Infof("skipping missing %s matching \"%s\"", title, path)
+			return nil, true, nil
+		case MissingFileHandlerDebug:
+			st.logger.Debugf("skipping missing %s matching \"%s\"", title, path)
+			return nil, true, nil
+		default:
+			available := []string{
+				MissingFileHandlerError,
+				MissingFileHandlerWarn,
+				MissingFileHandlerInfo,
+				MissingFileHandlerDebug,
+			}
+			return nil, false, fmt.Errorf("invalid missing file handler \"%s\" while processing \"%s\" in \"%s\": it must be one of %s", handlerId, path, st.FilePath, available)
+		}
+	}
+
+	return files, false, nil
+}
+
+func (st *Storage) ExpandPaths(globPattern string) ([]string, error) {
+	result := []string{}
+	absPathPattern := st.normalizePath(globPattern)
+	matches, err := st.glob(absPathPattern)
+	if err != nil {
+		return nil, fmt.Errorf("failed processing %s: %v", globPattern, err)
+	}
+
+	sort.Strings(matches)
+
+	result = append(result, matches...)
+	return result, nil
+}
+
+// normalizes relative path to absolute one
+func (st *Storage) normalizePath(path string) string {
+	u, _ := url.Parse(path)
+	if u.Scheme != "" || filepath.IsAbs(path) {
+		return path
+	} else {
+		return st.JoinBase(path)
+	}
+}
+
+// JoinBase returns an absolute path in the form basePath/relative
+func (st *Storage) JoinBase(relPath string) string {
+	return filepath.Join(st.basePath, relPath)
+}


### PR DESCRIPTION
Adds the `helmfiles[].environment.values` that accepts a mix of file pathes and inline dicts:

```yaml
helmfiles:
- path: path/to/nested/helmfile.yaml
  environment:
    values:
    - key1: val1
    - values.yaml
```

The values files are loaded in the context of the parent state file. For example, in case the above state file is located at `/path/to/helmfile.yaml`,
`values.yaml` is located at `/path/to/values.yaml` instead of `/path/to/nested/values.yaml`.

Resolves #523 

---

I've also included the fix for #615 and the another fix that fixes the regression due to that. I've included all hese 3 commits into this one PR, because all of them correlate to each other(I think).