### PR TITLE
change the nest level of envvals overrides for nested state files(sub-helmfiles)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,12 +175,12 @@ helmfiles:
   #   helmfile -f path/to/subhelmfile.yaml -l name=prometheus sync
   selectors:
   - name=prometheus
-  environment:
-    values:
-    # Environment values files merged into the nested state
-    - additiona.values.yaml
-    # Inline environment values merged into the nested state
-    - key1: val1
+  # Override state values
+  values:
+  # Values files merged into the nested state's values
+  - additiona.values.yaml
+  # Inline state values merged into the nested state's values
+  - key1: val1
 - # All the nested state files under `helmfiles:` is processed in the order of definition.
   # So it can be used for preparation for your main `releases`. An example would be creating CRDs required by `reelases` in the parent state file. 
   path: path/to/mycrd.helmfile.yaml

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -664,15 +664,13 @@ func TestVisitDesiredStatesWithReleasesFiltered_EmbeddedNestedStateAdditionalEnv
 		"/path/to/helmfile.yaml": `
 helmfiles:
 - path: helmfile.d/a*.yaml
-  environment:
-    values:
-     - env.values.yaml
+  values:
+  - env.values.yaml
 - helmfile.d/b*.yaml
 - path: helmfile.d/c*.yaml
-  environment:
-    values:
-     - env.values.yaml
-     - tillerNs: INLINE_TILLER_NS_3
+  values:
+  - env.values.yaml
+  - tillerNs: INLINE_TILLER_NS_3
 `,
 		"/path/to/helmfile.d/a1.yaml": `
 environments:

--- a/state/state.go
+++ b/state/state.go
@@ -1477,7 +1477,7 @@ func (hf *SubHelmfileSpec) UnmarshalYAML(unmarshal func(interface{}) error) erro
 			Selectors          []string `yaml:"selectors"`
 			SelectorsInherited bool     `yaml:"selectorsInherited"`
 
-			Environment SubhelmfileEnvironmentSpec `yaml:"environment"`
+			Environment SubhelmfileEnvironmentSpec `yaml:",inline"`
 		}
 		if err := unmarshal(&subHelmfileSpecTmp); err != nil {
 			return err


### PR DESCRIPTION
We added envvals overrides in the state file via #622 two days ago:

```
helmfiles:
- name: sub.helmfile.yaml
  environment:
    values:
    - mykey: myvalue
```

This change removes the `environment` level in the above cofig, so that it looks like:

```
helmfiles:
- name: sub.helmfile.yaml
  values:
  - mykey: myvalue
``

This is an inevitable breaking change towards #361. But I wanted to break it earlier so that less folks are affected.`

Ref https://github.com/roboll/helmfile/issues/361#issuecomment-497530819