### PR TITLE
fix: "cannot unmarshal !!str `<no value>` into bool" errors in state templates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/semver v1.4.1
 	github.com/Masterminds/sprig v2.16.0+incompatible
 	github.com/aokoli/goutils v1.0.1 // indirect
-	github.com/google/go-cmp v0.3.0 // indirect
+	github.com/google/go-cmp v0.3.0
 	github.com/google/uuid v0.0.0-20161128191214-064e2069ce9c // indirect
 	github.com/huandu/xstrings v1.0.0 // indirect
 	github.com/imdario/mergo v0.3.6

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -838,7 +838,7 @@ releases:
 	}
 }
 
-func TestVisitDesiredStatesWithReleasesFiltered_StateValueOverrides(t *testing.T) {
+func TestVisitDesiredStatesWithReleasesFiltered_EnvironmentValueOverrides(t *testing.T) {
 	files := map[string]string{
 		"/path/to/helmfile.yaml": `
 environments:

--- a/pkg/tmpl/context_tmpl.go
+++ b/pkg/tmpl/context_tmpl.go
@@ -13,9 +13,9 @@ func (c *Context) stringTemplate() *template.Template {
 	}
 	tmpl := template.New("stringTemplate").Funcs(funcMap)
 	if c.preRender {
-		tmpl.Option("missingkey=zero")
+		tmpl = tmpl.Option("missingkey=zero")
 	} else {
-		tmpl.Option("missingkey=error")
+		tmpl = tmpl.Option("missingkey=error")
 	}
 	return tmpl
 }


### PR DESCRIPTION
Seems like we are affected by https://github.com/golang/go/issues/24963. That is, even though we internally use the template option `missingkey=zero`, in some cases it still prints `<no value>` instead of zero values, which has been confusing the state yaml parsing.

This fixes the issue by naively replacing all the remaining occurrences of `<no value>` in the rendered text, while printing debug logs to ease debugging in the future when there is unexpected side-effects introduced by this native method.

Fixes #553