### PR TITLE
feat: state values

### DIFF
--- a/pkg/app/desired_state_file_loader.go
+++ b/pkg/app/desired_state_file_loader.go
@@ -83,6 +83,7 @@ func (ld *desiredStateLoader) Load(f string, opts LoadOpts) (*state.HelmState, e
 func (ld *desiredStateLoader) loadFile(inheritedEnv *environment.Environment, baseDir, file string, evaluateBases bool) (*state.HelmState, error) {
 	return ld.loadFileWithOverrides(inheritedEnv, nil, baseDir, file, evaluateBases)
 }
+
 func (ld *desiredStateLoader) loadFileWithOverrides(inheritedEnv, overrodeEnv *environment.Environment, baseDir, file string, evaluateBases bool) (*state.HelmState, error) {
 	var f string
 	if filepath.IsAbs(file) {

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -7,28 +7,44 @@ import (
 )
 
 type Environment struct {
-	Name   string
-	Values map[string]interface{}
+	Name     string
+	Values   map[string]interface{}
+	Defaults map[string]interface{}
 }
 
 var EmptyEnvironment Environment
 
 func (e Environment) DeepCopy() Environment {
-	bytes, err := yaml.Marshal(e.Values)
+	valuesBytes, err := yaml.Marshal(e.Values)
 	if err != nil {
 		panic(err)
 	}
 	var values map[string]interface{}
-	if err := yaml.Unmarshal(bytes, &values); err != nil {
+	if err := yaml.Unmarshal(valuesBytes, &values); err != nil {
 		panic(err)
 	}
 	values, err = maputil.CastKeysToStrings(values)
 	if err != nil {
 		panic(err)
 	}
+
+	defaultsBytes, err := yaml.Marshal(e.Defaults)
+	if err != nil {
+		panic(err)
+	}
+	var defaults map[string]interface{}
+	if err := yaml.Unmarshal(defaultsBytes, &defaults); err != nil {
+		panic(err)
+	}
+	defaults, err = maputil.CastKeysToStrings(defaults)
+	if err != nil {
+		panic(err)
+	}
+
 	return Environment{
-		Name:   e.Name,
-		Values: values,
+		Name:     e.Name,
+		Values:   values,
+		Defaults: defaults,
 	}
 }
 

--- a/pkg/maputil/maputil_test.go
+++ b/pkg/maputil/maputil_test.go
@@ -1,0 +1,61 @@
+package maputil
+
+import "testing"
+
+func TestMapUtil_StrKeys(t *testing.T) {
+	m := map[string]interface{}{
+		"a": []interface{}{
+			map[string]interface{}{
+				"b": []interface{}{
+					map[string]interface{}{
+						"c": "C",
+					},
+				},
+			},
+		},
+	}
+
+	r, err := CastKeysToStrings(m)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	a := r["a"].([]interface{})
+	a0 := a[0].(map[string]interface{})
+	b := a0["b"].([]interface{})
+	b0 := b[0].(map[string]interface{})
+	c := b0["c"]
+
+	if c != "C" {
+		t.Errorf("unexpected c: expected=C, got=%s", c)
+	}
+}
+
+func TestMapUtil_IFKeys(t *testing.T) {
+	m := map[interface{}]interface{}{
+		"a": []interface{}{
+			map[interface{}]interface{}{
+				"b": []interface{}{
+					map[interface{}]interface{}{
+						"c": "C",
+					},
+				},
+			},
+		},
+	}
+
+	r, err := CastKeysToStrings(m)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	a := r["a"].([]interface{})
+	a0 := a[0].(map[string]interface{})
+	b := a0["b"].([]interface{})
+	b0 := b[0].(map[string]interface{})
+	c := b0["c"]
+
+	if c != "C" {
+		t.Errorf("unexpected c: expected=C, got=%s", c)
+	}
+}

--- a/pkg/state/environment_values_loader.go
+++ b/pkg/state/environment_values_loader.go
@@ -39,7 +39,7 @@ func (ld *EnvironmentValuesLoader) LoadEnvironmentValues(missingFileHandler *str
 			}
 
 			for _, envvalFullPath := range resolved {
-				tmplData := EnvironmentTemplateData{Environment: environment.EmptyEnvironment, Namespace: ""}
+				tmplData := EnvironmentTemplateData{environment.EmptyEnvironment, "", map[string]interface{}{}}
 				r := tmpl.NewFileRenderer(ld.readFile, filepath.Dir(envvalFullPath), tmplData)
 				bytes, err := r.RenderToBytes(envvalFullPath)
 				if err != nil {

--- a/pkg/state/release.go
+++ b/pkg/state/release.go
@@ -16,6 +16,14 @@ func (r ReleaseSpec) ExecuteTemplateExpressions(renderer *tmpl.FileRenderer) (*R
 	}
 
 	{
+		ts := result.Name
+		result.Name, err = renderer.RenderTemplateContentToString([]byte(ts))
+		if err != nil {
+			return nil, fmt.Errorf("failed executing template expressions in release \"%s\".name = \"%s\": %v", r.Name, ts, err)
+		}
+	}
+
+	{
 		ts := result.Chart
 		result.Chart, err = renderer.RenderTemplateContentToString([]byte(ts))
 		if err != nil {

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -27,6 +27,9 @@ type HelmState struct {
 	basePath string
 	FilePath string
 
+	// DefaultValues is the default values to be overrode by environment values and command-line overrides
+	DefaultValues []interface{} `yaml:"values"`
+
 	Environments map[string]EnvironmentSpec `yaml:"environments"`
 
 	Bases              []string          `yaml:"bases"`
@@ -1243,7 +1246,7 @@ func (st *HelmState) flagsForLint(helm helmexec.Interface, release *ReleaseSpec,
 }
 
 func (st *HelmState) RenderValuesFileToBytes(path string) ([]byte, error) {
-	r := tmpl.NewFileRenderer(st.readFile, filepath.Dir(path), st.envTemplateData())
+	r := tmpl.NewFileRenderer(st.readFile, filepath.Dir(path), st.valuesFileTemplateData())
 	return r.RenderToBytes(path)
 }
 

--- a/pkg/state/state_exec_tmpl.go
+++ b/pkg/state/state_exec_tmpl.go
@@ -2,23 +2,58 @@ package state
 
 import (
 	"fmt"
+	"github.com/imdario/mergo"
+	"github.com/roboll/helmfile/pkg/maputil"
 	"github.com/roboll/helmfile/pkg/tmpl"
 )
 
-func (st *HelmState) envTemplateData() EnvironmentTemplateData {
+func (st *HelmState) Values() (map[string]interface{}, error) {
+	vals := map[string]interface{}{}
+
+	if err := mergo.Merge(&vals, st.Env.Defaults, mergo.WithOverride); err != nil {
+		return nil, err
+	}
+	if err := mergo.Merge(&vals, st.Env.Values, mergo.WithOverride); err != nil {
+		return nil, err
+	}
+
+	vals, err := maputil.CastKeysToStrings(vals)
+	if err != nil {
+		return nil, err
+	}
+
+	return vals, nil
+}
+
+func (st *HelmState) mustLoadVals() map[string]interface{} {
+	vals, err := st.Values()
+	if err != nil {
+		panic(err)
+	}
+	return vals
+}
+
+func (st *HelmState) valuesFileTemplateData() EnvironmentTemplateData {
 	return EnvironmentTemplateData{
-		st.Env,
-		st.Namespace,
+		Environment: st.Env,
+		Namespace:   st.Namespace,
+		Values:      st.mustLoadVals(),
 	}
 }
 
 func (st *HelmState) ExecuteTemplates() (*HelmState, error) {
 	r := *st
 
+	vals, err := st.Values()
+	if err != nil {
+		return nil, err
+	}
+
 	for i, rt := range st.Releases {
-		tmplData := ReleaseTemplateData{
+		tmplData := releaseTemplateData{
 			Environment: st.Env,
 			Release:     rt,
+			Values:      vals,
 		}
 		renderer := tmpl.NewFileRenderer(st.readFile, st.basePath, tmplData)
 		r, err := rt.ExecuteTemplateExpressions(renderer)

--- a/pkg/state/types.go
+++ b/pkg/state/types.go
@@ -15,12 +15,16 @@ type EnvironmentTemplateData struct {
 	Environment environment.Environment
 	// Namespace is accessible as `.Namespace` from any non-values template executed by the renderer
 	Namespace string
+	// Values is accessible as `.Values` and it contains default state values overrode by environment values and override values.
+	Values map[string]interface{}
 }
 
-// ReleaseTemplateData provides variables accessible while executing golang text/template expressions in releases of a helmfile YAML file
-type ReleaseTemplateData struct {
+// releaseTemplateData provides variables accessible while executing golang text/template expressions in releases of a helmfile YAML file
+type releaseTemplateData struct {
 	// Environment is accessible as `.Environment` from any template expression executed by the renderer
 	Environment environment.Environment
 	// Release is accessible as `.Release` from any template expression executed by the renderer
 	Release ReleaseSpec
+	// Values is accessible as `.Values` and it contains default state values overrode by environment values and override values.
+	Values map[string]interface{}
 }


### PR DESCRIPTION
This adds `values` to state files as proposed in #640.

```yaml
values:
- key1: val1
- defaults.yaml

environments:
  default:
  - values:
    - environments/default.yaml
  production:
  - values:
    - environments/production.yaml
```

`{{ .Valuese.key1 }}` evaluates to `val1` if and only if it is not overrode via the production or the default env, or command-line args.

Resolves #640