### PR TITLE
fix: use the same logic as helm-secrets when decoding secrets

### DIFF
--- a/pkg/helmexec/exec.go
+++ b/pkg/helmexec/exec.go
@@ -145,10 +145,16 @@ func (helm *execer) DecryptSecret(context HelmContext, name string, flags ...str
 	}
 	defer tmpFile.Close()
 
+	// HELM_SECRETS_DEC_SUFFIX is used by the helm-secrets plugin to define the output file
+	decSuffix := os.Getenv("HELM_SECRETS_DEC_SUFFIX")
+	if len(decSuffix) == 0 {
+		decSuffix = ".yaml.dec"
+	}
+	decFilename := strings.Replace(name, ".yaml", decSuffix, 1)
+
 	// os.Rename seems to results in "cross-device link` errors in some cases
 	// Instead of moving, copy it to the destination temp file as a work-around
 	// See https://github.com/roboll/helmfile/issues/251#issuecomment-417166296f
-	decFilename := name + ".dec"
 	decFile, err := os.Open(decFilename)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
helm-secrets uses the `HELM_SECRETS_DEC_SUFFIX` env var to define the name of the output file
we should have the same logic in helmfile, to come up with the same filename

It only affects people using the `HELM_SECRETS_DEC_SUFFIX` env var

Use-case: if you want to run multiple `helmfile` commands in parallel, without conflicts. in this case, you need to decrypt secrets with different suffixes.