### PR TITLE
fix: fixes a regexp issue for release summary

### DIFF
--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -3,11 +3,6 @@ package state
 import (
 	"errors"
 	"fmt"
-	"github.com/roboll/helmfile/pkg/environment"
-	"github.com/roboll/helmfile/pkg/event"
-	"github.com/roboll/helmfile/pkg/helmexec"
-	"github.com/roboll/helmfile/pkg/remote"
-	"github.com/roboll/helmfile/pkg/tmpl"
 	"io/ioutil"
 	"os"
 	"path"
@@ -15,6 +10,12 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/roboll/helmfile/pkg/environment"
+	"github.com/roboll/helmfile/pkg/event"
+	"github.com/roboll/helmfile/pkg/helmexec"
+	"github.com/roboll/helmfile/pkg/remote"
+	"github.com/roboll/helmfile/pkg/tmpl"
 
 	"regexp"
 
@@ -434,7 +435,8 @@ func (st *HelmState) getDeployedVersion(context helmexec.HelmContext, helm helme
 	//retrieve the version
 	if out, err := helm.List(context, "^"+release.Name+"$", st.tillerFlags(release)...); err == nil {
 		chartName := filepath.Base(release.Chart)
-		pat := regexp.MustCompile(chartName + "-(.*?)\\s")
+		//the regexp without escapes : .*\s.*\s.*\s.*\schartName-(.*?)\s
+		pat := regexp.MustCompile(".*\\s.*\\s.*\\s.*\\s" + chartName + "-(.*?)\\s")
 		versions := pat.FindStringSubmatch(out)
 		if len(versions) > 0 {
 			return versions[1], nil

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -1,13 +1,14 @@
 package state
 
 import (
-	"github.com/roboll/helmfile/pkg/helmexec"
-	"github.com/roboll/helmfile/pkg/testhelper"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/roboll/helmfile/pkg/helmexec"
+	"github.com/roboll/helmfile/pkg/testhelper"
 
 	"errors"
 	"strings"
@@ -1230,6 +1231,16 @@ func TestGetDeployedVersion(t *testing.T) {
 			},
 			listResult: `NAME 	REVISION	UPDATED                 	STATUS  	CHART                      	APP VERSION	NAMESPACE
 										foo	1       	Wed Apr 17 17:39:04 2019	DEPLOYED	foo-bar-1.0.0-alpha+001	0.1.0      	default`,
+			installedVersion: "1.0.0-alpha+001",
+		},
+		{
+			name: "chart version with dash and release with dash",
+			release: ReleaseSpec{
+				Name:  "foo-bar",
+				Chart: "registry/foo-bar",
+			},
+			listResult: `NAME 	REVISION	UPDATED                 	STATUS  	CHART                      	APP VERSION	NAMESPACE
+										foo-bar-release	1       	Wed Apr 17 17:39:04 2019	DEPLOYED	foo-bar-1.0.0-alpha+001	0.1.0      	default`,
 			installedVersion: "1.0.0-alpha+001",
 		},
 	}


### PR DESCRIPTION
fixes #665.
There was an issue a the regexp reding the version from helm output.