### PR TITLE
feat: `helmfile -f <go-getter url>`

### DIFF
--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -179,6 +179,10 @@ func (r *Remote) Fetch(goGetterSrc string) (string, error) {
 
 	cacheDirPath := filepath.Join(r.Home, getterDst)
 
+	r.Logger.Debugf("home: %s", r.Home)
+	r.Logger.Debugf("getter dest: %s", getterDst)
+	r.Logger.Debugf("cached dir: %s", cacheDirPath)
+
 	{
 		if r.FileExists(cacheDirPath) {
 			return "", fmt.Errorf("%s is not directory. please remove it so that variant could use it for dependency caching", getterDst)


### PR DESCRIPTION
Extends the remote-helmfile feature to also work when loading the first state file.
This should be useful for people who wants to give helmfile a try without ever opening `$EDITOR`.