### PR TITLE
feat: make release version templatized

### DIFF
--- a/pkg/state/release.go
+++ b/pkg/state/release.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"fmt"
+
 	"github.com/roboll/helmfile/pkg/tmpl"
 	"gopkg.in/yaml.v2"
 )
@@ -36,6 +37,14 @@ func (r ReleaseSpec) ExecuteTemplateExpressions(renderer *tmpl.FileRenderer) (*R
 		result.Namespace, err = renderer.RenderTemplateContentToString([]byte(ts))
 		if err != nil {
 			return nil, fmt.Errorf("failed executing template expressions in release \"%s\".namespace = \"%s\": %v", r.Name, ts, err)
+		}
+	}
+
+	{
+		ts := result.Version
+		result.Version, err = renderer.RenderTemplateContentToString([]byte(ts))
+		if err != nil {
+			return nil, fmt.Errorf("failed executing template expressions in release \"%s\".version = \"%s\": %v", r.Name, ts, err)
 		}
 	}
 

--- a/pkg/state/state_exec_tmpl_test.go
+++ b/pkg/state/state_exec_tmpl_test.go
@@ -16,7 +16,7 @@ func TestHelmState_executeTemplates(t *testing.T) {
 			name: "Has template expressions in chart, values, and secrets",
 			input: ReleaseSpec{
 				Chart:     "test-charts/{{ .Release.Name }}",
-				Version:   "0.1",
+				Version:   "{{ .Release.Name }}-0.1",
 				Verify:    nil,
 				Name:      "test-app",
 				Namespace: "test-namespace-{{ .Release.Name }}",
@@ -25,7 +25,7 @@ func TestHelmState_executeTemplates(t *testing.T) {
 			},
 			want: ReleaseSpec{
 				Chart:     "test-charts/test-app",
-				Version:   "0.1",
+				Version:   "test-app-0.1",
 				Verify:    nil,
 				Name:      "test-app",
 				Namespace: "test-namespace-test-app",
@@ -70,6 +70,9 @@ func TestHelmState_executeTemplates(t *testing.T) {
 			}
 			if !reflect.DeepEqual(actual.Secrets, tt.want.Secrets) {
 				t.Errorf("expected %+v, got %+v", tt.want.Secrets, actual.Secrets)
+			}
+			if !reflect.DeepEqual(actual.Version, tt.want.Version) {
+				t.Errorf("expected %+v, got %+v", tt.want.Version, actual.Version)
 			}
 		})
 	}


### PR DESCRIPTION
Allows the release version to be a Go template.
Fixes #669
