### PR TITLE
fix: persist original file path when using bases

### DIFF
--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -1127,6 +1127,10 @@ helmDefaults:
 	if st.Releases[1].Values[0] != "{{`{{.Release.Name}}`}}/values.yaml" {
 		t.Errorf("unexpected releases[0].missingFileHandler: expected={{`{{.Release.Name}}`}}/values.yaml, got=%s", st.Releases[1].Values[0])
 	}
+
+	if st.FilePath != yamlFile {
+		t.Errorf("unexpected filePath: expected=%s, got=%s", yamlFile, st.FilePath)
+	}
 }
 
 func TestLoadDesiredStateFromYaml_MultiPartTemplate(t *testing.T) {

--- a/pkg/state/create.go
+++ b/pkg/state/create.go
@@ -148,6 +148,8 @@ func (c *StateCreator) ParseAndLoad(content []byte, baseDir, file string, envNam
 		return nil, err
 	}
 
+	state.FilePath = file
+
 	return state, nil
 }
 


### PR DESCRIPTION
Prior to this change, the resulting lock file was called `<bases[0]>.lock`, instead of `<filename>.lock`.

This change ensures the final, merged state has the correct `.FilePath`.

Please let me know how I can improve/augment this one-liner. It'd be nice, for example, to have a test that prevents regressions.