### PR TITLE
fix: helmDefaults.kubeContext ignored in `helm diff` of `helmfile apply`

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ releases:
     tlsCert: "path/to/cert.pem"
     # path to TLS key file (default "$HELM_HOME/key.pem")
     tlsKey: "path/to/key.pem"
+    # --kube-context to be passed to helm commands
+    # CAUTION: this doesn't work as expected for `tilerless: true`.
+    # See https://github.com/roboll/helmfile/issues/642
+    kubeContext: kube-context
 
   # Local chart example
   - name: grafana                            # name of this release

--- a/pkg/argparser/args.go
+++ b/pkg/argparser/args.go
@@ -82,10 +82,6 @@ func GetArgs(args string, state *state.HelmState) []string {
 		}
 	}
 
-	if state.HelmDefaults.KubeContext != "" {
-		argsMap.SetArg("--kube-context", state.HelmDefaults.KubeContext, false)
-	}
-
 	var argArr []string
 
 	for _, flag := range argsMap.flags {

--- a/pkg/argparser/args_test.go
+++ b/pkg/argparser/args_test.go
@@ -13,7 +13,7 @@ func TestGetArgs(t *testing.T) {
 	testState := &state.HelmState{HelmDefaults: Helmdefaults}
 	receivedArgs := GetArgs(args, testState)
 
-	expectedOutput := "--timeout=3600 --set app1.bootstrap=true --set app2.bootstrap=false --tiller-namespace ns --recreate-pods --force --kube-context=test"
+	expectedOutput := "--timeout=3600 --set app1.bootstrap=true --set app2.bootstrap=false --tiller-namespace ns --recreate-pods --force"
 
 	if compareArgs(expectedOutput, receivedArgs) == false {
 		t.Errorf("expected %s, got %s", expectedOutput, strings.Join(receivedArgs, " "))
@@ -27,7 +27,7 @@ func Test2(t *testing.T) {
 	testState := &state.HelmState{HelmDefaults: Helmdefaults}
 	receivedArgs := GetArgs(args, testState)
 
-	expectedOutput := "--timeout=3600 --set app1.bootstrap=true --set app2.bootstrap=false,app3.bootstrap=true --tiller-namespace ns --recreate-pods --force --kube-context=test"
+	expectedOutput := "--timeout=3600 --set app1.bootstrap=true --set app2.bootstrap=false,app3.bootstrap=true --tiller-namespace ns --recreate-pods --force"
 
 	if compareArgs(expectedOutput, receivedArgs) == false {
 		t.Errorf("expected %s, got %s", expectedOutput, strings.Join(receivedArgs, " "))

--- a/pkg/state/create.go
+++ b/pkg/state/create.go
@@ -209,7 +209,7 @@ func (st *HelmState) loadEnvValues(name string, ctxEnv *environment.Environment,
 				// installed on the cluster, just for decrypting secrets!
 				// Related: https://github.com/futuresimple/helm-secrets/issues/83
 				release := &ReleaseSpec{}
-				flags := st.appendTillerFlags([]string{}, release)
+				flags := st.appendConnectionFlags([]string{}, release)
 				decFile, err := helm.DecryptSecret(st.createHelmContext(release, 0), path, flags...)
 				if err != nil {
 					return nil, err


### PR DESCRIPTION
The root cause of this bug was due to that `--kube-context` and `kubeContext` had been treated specifically in code. So on the way I have made it consistent with other per-release settings - by adding `kubeContext` for each release and treating `helmDefaults.kubeContext` as just the default value for per-release setting.

Fixes #674