### PR TITLE
fix: `installed: false` not respecting TLS settings and tiller namespace

### DIFF
--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -383,7 +383,8 @@ func (st *HelmState) SyncReleases(affectedReleases *AffectedReleases, helm helme
 					if err != nil {
 						relErr = newReleaseError(release, err)
 					} else if installed {
-						if err := helm.DeleteRelease(context, release.Name, "--purge"); err != nil {
+						deletionFlags := st.appendConnectionFlags([]string{"--purge"}, release)
+						if err := helm.DeleteRelease(context, release.Name, deletionFlags...); err != nil {
 							affectedReleases.Failed = append(affectedReleases.Failed, release)
 							relErr = newReleaseError(release, err)
 						} else {


### PR DESCRIPTION
It was just missing the appendConnectionFlags call to compose flags passed to `helm delete` there. This fixes it.

Fixes #605