### PR TITLE
feat(689): optionally show logs for hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -829,9 +829,10 @@ A Helmfile hook is a per-release extension point that is composed of:
 - `events`
 - `command`
 - `args`
+- `showlogs`
 
 Helmfile triggers various `events` while it is running.
-Once `events` are triggered, associated `hooks` are executed, by running the `command` with `args`.
+Once `events` are triggered, associated `hooks` are executed, by running the `command` with `args`. The standard output of the `command` will be displayed if `showlogs` is set and it's value is `true`.
 
 Currently supported `events` are:
 
@@ -857,6 +858,7 @@ releases:
   # *snip*
   hooks:
   - events: ["prepare", "cleanup"]
+    showlogs: true
     command: "echo"
     args: ["{{`{{.Environment.Name}}`}}", "{{`{{.Release.Name}}`}}", "{{`{{.HelmfileCommand}}`}}\
 "]

--- a/pkg/event/bus.go
+++ b/pkg/event/bus.go
@@ -2,18 +2,21 @@ package event
 
 import (
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/roboll/helmfile/pkg/environment"
 	"github.com/roboll/helmfile/pkg/helmexec"
 	"github.com/roboll/helmfile/pkg/tmpl"
 	"go.uber.org/zap"
-	"os"
 )
 
 type Hook struct {
-	Name    string   `yaml:"name"`
-	Events  []string `yaml:"events"`
-	Command string   `yaml:"command"`
-	Args    []string `yaml:"args"`
+	Name     string   `yaml:"name"`
+	Events   []string `yaml:"events"`
+	Command  string   `yaml:"command"`
+	Args     []string `yaml:"args"`
+	ShowLogs bool     `yaml:"showlogs"`
 }
 
 type event struct {
@@ -90,6 +93,10 @@ func (bus *Bus) Trigger(evt string, context map[string]interface{}) (bool, error
 
 		bytes, err := bus.Runner.Execute(command, args, map[string]string{})
 		bus.Logger.Debugf("hook[%s]: %s\n", name, string(bytes))
+		if hook.ShowLogs {
+			prefix := fmt.Sprintf("\nhook[%s] logs | ", evt)
+			bus.Logger.Infow(prefix + strings.ReplaceAll(string(bytes), "\n", prefix))
+		}
 
 		if err != nil {
 			return false, fmt.Errorf("hook[%s]: command `%s` failed: %v", name, command, err)


### PR DESCRIPTION
Fixes #689 
This adds a new yaml entry for the hook definition to allow the users to specifcy if they want to show the `command` logs or not.

here is an example.
```
releases:
- name: myapp
  chart: mychart
  # *snip*
  hooks:
  - events: ["cleanup"]
    showlogs: true
    command: "kubectl"
    args: ["get", "ingress"]
```
this will display the following output:
```
hook[cleanup] logs | NAME              HOSTS                          ADDRESS   PORTS   AGE
hook[cleanup] logs | catalog-gateway   tdc.foo                                  80      2d6h
hook[cleanup] logs | dataset           foobar.barr.foo.xxxxxxx.com              80      2d6h
hook[cleanup] logs | rating            fooba.barr.foo.xxxxxxx.com               80      2d6h
hook[cleanup] logs | sharing           foobar.barr.foo.xxxxxxx.com              80      2d6h
hook[cleanup] logs | tpsvc-iam-dev     foo.barr.foo.xxxxxxx.com                 80      2d6h
hook[cleanup] logs | tpsvc-iam-front   bar.barr.foo.xxxxxxx.com                 80      2d6h
```