### PR TITLE
feat: When values.yaml.gotmpl can't be parsed as YAML, print the YAML.

### DIFF
--- a/pkg/state/envvals_loader.go
+++ b/pkg/state/envvals_loader.go
@@ -53,7 +53,7 @@ func (ld *EnvironmentValuesLoader) LoadEnvironmentValues(missingFileHandler *str
 				}
 				m := map[string]interface{}{}
 				if err := yaml.Unmarshal(bytes, &m); err != nil {
-					return nil, fmt.Errorf("failed to load environment values file \"%s\": %v", f, err)
+					return nil, fmt.Errorf("failed to load environment values file \"%s\": %v\n\nOffending YAML:\n%s", f, err, bytes)
 				}
 				maps = append(maps, m)
 				if ld.logger != nil {


### PR DESCRIPTION
This helps a lot when debugging go templates. Especially if you're not so good at go template, like me.. :-)