### PR TITLE
fix: enabled '=' in a value for --state-values-set

### DIFF
--- a/main.go
+++ b/main.go
@@ -419,7 +419,7 @@ func NewUrfaveCliConfigImpl(c *cli.Context) (configImpl, error) {
 		for i := range optsSet {
 			ops := strings.Split(optsSet[i], ",")
 			for j := range ops {
-				op := strings.Split(ops[j], "=")
+				op := strings.SplitN(ops[j], "=", 2)
 				k := strings.Split(op[0], ".")
 				v := op[1]
 


### PR DESCRIPTION
This adds the possibility to use a "=" in the parameters passed to --state-values-set

previous comportment:
`helmfile --state-values-set 'test="abcde==fg",test2="abcde"'` => outputs 'test="abcde",test2="abcde"'

new comportment:
`helmfile --state-values-set 'test="abcde==fg",test2="abcde"'` => outputs 'test="abcde==fg",test2="abcde"'