### PR TITLE
feat: Adopt existing K8s resources as Helm release on install

### DIFF
--- a/pkg/state/helmx.go
+++ b/pkg/state/helmx.go
@@ -19,7 +19,7 @@ func (st *HelmState) appendHelmXFlags(flags []string, release *ReleaseSpec) ([]s
 		flags = append(flags, "--dependency", dep)
 	}
 
-	for  _, adopt := range release.Adopt {
+	for _, adopt := range release.Adopt {
 		flags = append(flags, "--adopt", adopt)
 	}
 

--- a/pkg/state/helmx.go
+++ b/pkg/state/helmx.go
@@ -19,6 +19,10 @@ func (st *HelmState) appendHelmXFlags(flags []string, release *ReleaseSpec) ([]s
 		flags = append(flags, "--dependency", dep)
 	}
 
+	for  _, adopt := range release.Adopt {
+		flags = append(flags, "--adopt", adopt)
+	}
+
 	jsonPatches := release.JSONPatches
 	if len(jsonPatches) > 0 {
 		generatedFiles, err := st.generateTemporaryValuesFiles(jsonPatches, release.MissingFileHandler)

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -165,6 +165,7 @@ type ReleaseSpec struct {
 	Dependencies          []Dependency  `yaml:"dependencies"`
 	JSONPatches           []interface{} `yaml:"jsonPatches"`
 	StrategicMergePatches []interface{} `yaml:"strategicMergePatches"`
+	Adopt                 []string      `yaml:"adopt"`
 
 	// generatedValues are values that need cleaned up on exit
 	generatedValues []string


### PR DESCRIPTION
Use with the helm-x support(#673)

This enhances config syntax to accept adopt: [NS/KIND/RESOURCE_NAME] at the release level so that helmfile calls helm-x to transparently import existing resources at the installation time.

Resolves #84