### PR TITLE
print yaml content on error in fromYaml

### DIFF
--- a/pkg/tmpl/context_funcs.go
+++ b/pkg/tmpl/context_funcs.go
@@ -149,7 +149,7 @@ func FromYaml(str string) (Values, error) {
 	m := Values{}
 
 	if err := yaml.Unmarshal([]byte(str), &m); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%s, offending yaml: %s", err, str)
 	}
 	return m, nil
 }


### PR DESCRIPTION
When fromYaml fails, it is sometimes useful to see the offending yaml for debugging purposes. This prints adds the content of the yaml to the error message.