### PR TITLE
Add kubectl and jq to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,10 @@ RUN wget ${HELM_LOCATION}/${HELM_FILENAME} && \
 # using the install documentation found at https://kubernetes.io/docs/tasks/tools/install-kubectl/
 # for now but in a future version of alpine (in the testing version at the time of writing)
 # we should be able to install using apk add.
-RUN KUBERNETES_STABLE=$(curl -s "https://storage.googleapis.com/kubernetes-release/release/stable.txt") && \
-    curl -LO "https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_STABLE}/bin/linux/amd64/kubectl" && \
+ENV KUBECTL_VERSION="v1.14.5"
+ENV KUBECTL_SHA256="26681319de56820a8467c9407e9203d5b15fb010ffc75ac5b99c9945ad0bd28c"
+RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
+    sha256sum kubectl | grep ${KUBECTL_SHA256} && \
     chmod +x kubectl && \
     mv kubectl /usr/local/bin/kubectl
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN make static-linux
 
 FROM alpine:3.8
 
-RUN apk add --no-cache ca-certificates git bash curl
+RUN apk add --no-cache ca-certificates git bash curl jq
 
 ARG HELM_VERSION=v2.13.0
 ARG HELM_LOCATION="https://kubernetes-helm.storage.googleapis.com"
@@ -19,6 +19,14 @@ RUN wget ${HELM_LOCATION}/${HELM_FILENAME} && \
     sha256sum ${HELM_FILENAME} | grep -q "${HELM_SHA256}" && \
     tar zxf ${HELM_FILENAME} && mv /linux-amd64/helm /usr/local/bin/ && \
     rm ${HELM_FILENAME} && rm -r /linux-amd64
+
+# using the install documentation found at https://kubernetes.io/docs/tasks/tools/install-kubectl/
+# for now but in a future version of alpine (in the testing version at the time of writing)
+# we should be able to install using apk add.
+RUN KUBERNETES_STABLE=$(curl -s "https://storage.googleapis.com/kubernetes-release/release/stable.txt") && \
+    curl -LO "https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_STABLE}/bin/linux/amd64/kubectl" && \
+    chmod +x kubectl && \
+    mv kubectl /usr/local/bin/kubectl
 
 RUN mkdir -p "$(helm home)/plugins"
 RUN helm plugin install https://github.com/databus23/helm-diff && \


### PR DESCRIPTION
As referenced in issue: https://github.com/roboll/helmfile/issues/789 and https://github.com/roboll/helmfile/issues/792.

For now I've made it contact kubernetes for the latest version every time, looking at the implementation of the helm installation would you prefer for it to be a hardcoded and checksum confirmed version added?