### PR TITLE
Shared helmexec for Environment Secrets

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -2,15 +2,16 @@ package app
 
 import (
 	"fmt"
-	"github.com/roboll/helmfile/pkg/helmexec"
-	"github.com/roboll/helmfile/pkg/remote"
-	"github.com/roboll/helmfile/pkg/state"
 	"io/ioutil"
 	"log"
 	"os"
 	"os/signal"
 	"strings"
 	"syscall"
+
+	"github.com/roboll/helmfile/pkg/helmexec"
+	"github.com/roboll/helmfile/pkg/remote"
+	"github.com/roboll/helmfile/pkg/state"
 
 	"go.uber.org/zap"
 
@@ -239,6 +240,7 @@ func (a *App) loadDesiredStateFromYaml(file string, opts ...LoadOpts) (*state.He
 		Reverse:     a.Reverse,
 		KubeContext: a.KubeContext,
 		glob:        a.glob,
+		helm:        a.helmExecer,
 	}
 
 	var op LoadOpts

--- a/pkg/app/desired_state_file_loader.go
+++ b/pkg/app/desired_state_file_loader.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/imdario/mergo"
-	"github.com/roboll/helmfile/pkg/environment"
-	"github.com/roboll/helmfile/pkg/state"
-	"go.uber.org/zap"
 	"path/filepath"
 	"sort"
+
+	"github.com/imdario/mergo"
+	"github.com/roboll/helmfile/pkg/environment"
+	"github.com/roboll/helmfile/pkg/helmexec"
+	"github.com/roboll/helmfile/pkg/state"
+	"go.uber.org/zap"
 )
 
 type desiredStateLoader struct {
@@ -25,6 +27,7 @@ type desiredStateLoader struct {
 	glob       func(string) ([]string, error)
 
 	logger *zap.SugaredLogger
+	helm   helmexec.Interface
 }
 
 func (ld *desiredStateLoader) Load(f string, opts LoadOpts) (*state.HelmState, error) {
@@ -125,7 +128,7 @@ func (ld *desiredStateLoader) loadFileWithOverrides(inheritedEnv, overrodeEnv *e
 }
 
 func (a *desiredStateLoader) underlying() *state.StateCreator {
-	c := state.NewCreator(a.logger, a.readFile, a.fileExists, a.abs, a.glob)
+	c := state.NewCreator(a.logger, a.readFile, a.fileExists, a.abs, a.glob, a.helm)
 	c.LoadFile = a.loadFile
 	return c
 }

--- a/pkg/state/create_test.go
+++ b/pkg/state/create_test.go
@@ -1,12 +1,13 @@
 package state
 
 import (
-	"github.com/roboll/helmfile/pkg/testhelper"
-	"go.uber.org/zap"
 	"io/ioutil"
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/roboll/helmfile/pkg/testhelper"
+	"go.uber.org/zap"
 
 	. "gotest.tools/assert"
 	"gotest.tools/assert/cmp"
@@ -107,7 +108,7 @@ bar: {{ readFile "bar.txt" }}
 	})
 	testFs.Cwd = "/example/path/to"
 
-	state, err := NewCreator(logger, testFs.ReadFile, testFs.FileExists, testFs.Abs, testFs.Glob).ParseAndLoad(yamlContent, filepath.Dir(yamlFile), yamlFile, "production", false, nil)
+	state, err := NewCreator(logger, testFs.ReadFile, testFs.FileExists, testFs.Abs, testFs.Glob, nil).ParseAndLoad(yamlContent, filepath.Dir(yamlFile), yamlFile, "production", false, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -62,6 +62,7 @@ type HelmState struct {
 	tempDir    func(string, string) (string, error)
 
 	runner helmexec.Runner
+	helm   helmexec.Interface
 }
 
 // SubHelmfileSpec defines the subhelmfile path and options


### PR DESCRIPTION
Closes #444 and #782 

This is the final PR to fully cache and parallelize helm secret decryption.  It threads the shared helmexec.Interface into the StateCreator and HelmState structs to be used during environment secret decryption.  This should effectively cache secrets for the duration of a helmfile run, regardless of where they are first decrypted.

This is based on the work in #800, so it is draft until that PR is final.