### PR TITLE
fix: add helm-tiller plugin to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,8 @@ RUN mkdir -p "$(helm home)/plugins"
 RUN helm plugin install https://github.com/databus23/helm-diff && \
     helm plugin install https://github.com/futuresimple/helm-secrets && \
     helm plugin install https://github.com/hypnoglow/helm-s3.git && \
-    helm plugin install https://github.com/aslafy-z/helm-git.git
+    helm plugin install https://github.com/aslafy-z/helm-git.git && \
+    helm plugin install https://github.com/rimusz/helm-tiller
 
 COPY --from=builder /workspace/helmfile/dist/helmfile_linux_amd64 /usr/local/bin/helmfile
 


### PR DESCRIPTION
This adds helm-tiller plugin to published docker image.

Without helm-tiller, having following `helmfile.yaml` (using helmfile as a templating tool):

```
repositories: []

helmDefaults:
  tillerNamespace: helm-releases  #dedicated default key for tiller-namespace
  tillerless: true #dedicated default key for tillerless

releases:
- name: talk
  chart: ../charts/nunl-talk
  values:
    - releases/talk-values.yaml.gotmpl
environments:
  test:
    values:
      - environments/test/values.yaml
    secrets:
      - common/secrets.sops.yaml
      - environments/test/secrets.sops.yaml
```

And executing `helmfile -e test template`, this results in following error:

```
Decrypting secret /workspace/deploy/helmfile/common/secrets.sops.yaml
Decrypting secret /workspace/deploy/helmfile/environments/test/secrets.sops.yaml
helm exited with status 1:
  Error: unknown command "tiller" for "helm"
  Run 'helm --help' for usage.
helm exited with status 1:
  Error: unknown command "tiller" for "helm"
  Run 'helm --help' for usage.

# truncated
```

Uploaded a poc image to Dockerhub tbeijen/helmfile:v0.81.3-helm-tiller

----
As a sidenote: When attempting to build the image I ran into following error:
```
env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GOFLAGS=-mod=vendor go build -o "dist/helmfile_linux_amd64" -ldflags '-X main.Version=v0.81.3'
build github.com/roboll/helmfile: cannot load github.com/Masterminds/semver: open /workspace/helmfile/vendor/github.com/Masterminds/semver: no such file or directory
make: *** [Makefile:33: static-linux] Error 1
The command '/bin/sh -c make static-linux' returned a non-zero code: 2
make: *** [image] Error 2
```
Image on Dockerhub is simply a proof of concept via following Dockerfile:
```
FROM quay.io/roboll/helmfile:v0.81.3

RUN helm plugin install https://github.com/rimusz/helm-tiller
```
