### PR TITLE
move context outside to limit duplicate repo updates

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -348,9 +348,8 @@ func (a *App) visitStates(fileOrDir string, defOpts LoadOpts, converge func(*sta
 }
 
 func (a *App) ForEachState(do func(*Run) []error) error {
+	ctx := NewContext()
 	err := a.VisitDesiredStatesWithReleasesFiltered(a.FileOrDir, func(st *state.HelmState, helm helmexec.Interface) []error {
-		ctx := NewContext()
-
 		run := NewRun(st, helm, ctx)
 
 		return do(run)


### PR DESCRIPTION
* `0.60.2` would only update repos once
  * 38.92s user 13.14s system 61% cpu 1:24.04 total

* `0.81.3` will update repos for each helmfile
  * 93.18s user 14.82s system 119% cpu 1:30.69 total

* `fix` restores old behavior
  * 31.90s user 7.35s system 74% cpu 52.700 total
