### PR TITLE
feat: `helm repo add --ca-file` via repositories definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ repositories:
   keyFile: optional_client_key
   username: optional_username
   password: optional_password
+# Advanced configuration: You can use a ca bundle to use an https repo
+# with a self-signed certificate
+- name: insecure
+   url: https://charts.my-insecure-domain.com
+   caFile: optional_ca_crt
 
 # context: kube-context # this directive is deprecated, please consider using helmDefaults.kubeContext
 

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -1871,7 +1871,7 @@ func (helm *mockHelmExec) SetExtraArgs(args ...string) {
 func (helm *mockHelmExec) SetHelmBinary(bin string) {
 	return
 }
-func (helm *mockHelmExec) AddRepo(name, repository, certfile, keyfile, username, password string) error {
+func (helm *mockHelmExec) AddRepo(name, repository, cafile, certfile, keyfile, username, password string) error {
 	return nil
 }
 func (helm *mockHelmExec) UpdateRepo() error {

--- a/pkg/helmexec/exec.go
+++ b/pkg/helmexec/exec.go
@@ -68,11 +68,14 @@ func (helm *execer) SetHelmBinary(bin string) {
 	helm.helmBinary = bin
 }
 
-func (helm *execer) AddRepo(name, repository, certfile, keyfile, username, password string) error {
+func (helm *execer) AddRepo(name, repository, cafile, certfile, keyfile, username, password string) error {
 	var args []string
 	args = append(args, "repo", "add", name, repository)
 	if certfile != "" && keyfile != "" {
 		args = append(args, "--cert-file", certfile, "--key-file", keyfile)
+	}
+	if cafile != "" {
+		args = append(args, "--ca-file", cafile)
 	}
 	if username != "" && password != "" {
 		args = append(args, "--username", username, "--password", password)

--- a/pkg/helmexec/exec_test.go
+++ b/pkg/helmexec/exec_test.go
@@ -86,7 +86,7 @@ func Test_AddRepo(t *testing.T) {
 	var buffer bytes.Buffer
 	logger := NewLogger(&buffer, "debug")
 	helm := MockExecer(logger, "dev")
-	helm.AddRepo("myRepo", "https://repo.example.com/", "cert.pem", "key.pem", "", "")
+	helm.AddRepo("myRepo", "https://repo.example.com/", "", "cert.pem", "key.pem", "", "")
 	expected := `Adding repo myRepo https://repo.example.com/
 exec: helm repo add myRepo https://repo.example.com/ --cert-file cert.pem --key-file key.pem --kube-context dev
 exec: helm repo add myRepo https://repo.example.com/ --cert-file cert.pem --key-file key.pem --kube-context dev: 
@@ -96,7 +96,17 @@ exec: helm repo add myRepo https://repo.example.com/ --cert-file cert.pem --key-
 	}
 
 	buffer.Reset()
-	helm.AddRepo("myRepo", "https://repo.example.com/", "", "", "", "")
+	helm.AddRepo("myRepo", "https://repo.example.com/", "ca.crt", "", "", "", "")
+	expected = `Adding repo myRepo https://repo.example.com/
+exec: helm repo add myRepo https://repo.example.com/ --ca-file ca.crt --kube-context dev
+exec: helm repo add myRepo https://repo.example.com/ --ca-file ca.crt --kube-context dev: 
+`
+	if buffer.String() != expected {
+		t.Errorf("helmexec.AddRepo()\nactual = %v\nexpect = %v", buffer.String(), expected)
+	}
+
+	buffer.Reset()
+	helm.AddRepo("myRepo", "https://repo.example.com/", "", "", "", "", "")
 	expected = `Adding repo myRepo https://repo.example.com/
 exec: helm repo add myRepo https://repo.example.com/ --kube-context dev
 exec: helm repo add myRepo https://repo.example.com/ --kube-context dev: 
@@ -106,7 +116,7 @@ exec: helm repo add myRepo https://repo.example.com/ --kube-context dev:
 	}
 
 	buffer.Reset()
-	helm.AddRepo("myRepo", "https://repo.example.com/", "", "", "example_user", "example_password")
+	helm.AddRepo("myRepo", "https://repo.example.com/", "", "", "", "example_user", "example_password")
 	expected = `Adding repo myRepo https://repo.example.com/
 exec: helm repo add myRepo https://repo.example.com/ --username example_user --password example_password --kube-context dev
 exec: helm repo add myRepo https://repo.example.com/ --username example_user --password example_password --kube-context dev: 
@@ -453,7 +463,7 @@ func Test_LogLevels(t *testing.T) {
 		buffer.Reset()
 		logger := NewLogger(&buffer, logLevel)
 		helm := MockExecer(logger, "")
-		helm.AddRepo("myRepo", "https://repo.example.com/", "", "", "example_user", "example_password")
+		helm.AddRepo("myRepo", "https://repo.example.com/", "", "", "", "example_user", "example_password")
 		if buffer.String() != expected {
 			t.Errorf("helmexec.AddRepo()\nactual = %v\nexpect = %v", buffer.String(), expected)
 		}

--- a/pkg/helmexec/helmexec.go
+++ b/pkg/helmexec/helmexec.go
@@ -5,7 +5,7 @@ type Interface interface {
 	SetExtraArgs(args ...string)
 	SetHelmBinary(bin string)
 
-	AddRepo(name, repository, certfile, keyfile, username, password string) error
+	AddRepo(name, repository, cafile, certfile, keyfile, username, password string) error
 	UpdateRepo() error
 	BuildDeps(name, chart string) error
 	UpdateDeps(chart string) error

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -111,6 +111,7 @@ type HelmSpec struct {
 type RepositorySpec struct {
 	Name     string `yaml:"name,omitempty"`
 	URL      string `yaml:"url,omitempty"`
+	CaFile   string `yaml:"caFile,omitempty"`
 	CertFile string `yaml:"certFile,omitempty"`
 	KeyFile  string `yaml:"keyFile,omitempty"`
 	Username string `yaml:"username,omitempty"`
@@ -218,7 +219,7 @@ func (st *HelmState) applyDefaultsTo(spec *ReleaseSpec) {
 }
 
 type RepoUpdater interface {
-	AddRepo(name, repository, certfile, keyfile, username, password string) error
+	AddRepo(name, repository, cafile, certfile, keyfile, username, password string) error
 	UpdateRepo() error
 }
 
@@ -227,7 +228,7 @@ func (st *HelmState) SyncRepos(helm RepoUpdater) []error {
 	errs := []error{}
 
 	for _, repo := range st.Repositories {
-		if err := helm.AddRepo(repo.Name, repo.URL, repo.CertFile, repo.KeyFile, repo.Username, repo.Password); err != nil {
+		if err := helm.AddRepo(repo.Name, repo.URL, repo.CaFile, repo.CertFile, repo.KeyFile, repo.Username, repo.Password); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -720,8 +720,8 @@ func (helm *mockHelmExec) SetExtraArgs(args ...string) {
 func (helm *mockHelmExec) SetHelmBinary(bin string) {
 	return
 }
-func (helm *mockHelmExec) AddRepo(name, repository, certfile, keyfile, username, password string) error {
-	helm.repo = []string{name, repository, certfile, keyfile, username, password}
+func (helm *mockHelmExec) AddRepo(name, repository, cafile, certfile, keyfile, username, password string) error {
+	helm.repo = []string{name, repository, cafile, certfile, keyfile, username, password}
 	return nil
 }
 func (helm *mockHelmExec) UpdateRepo() error {
@@ -796,7 +796,7 @@ func TestHelmState_SyncRepos(t *testing.T) {
 				},
 			},
 			helm: &mockHelmExec{},
-			want: []string{"name", "http://example.com/", "", "", "", ""},
+			want: []string{"name", "http://example.com/", "", "", "", "", ""},
 		},
 		{
 			name: "repository with cert and key",
@@ -811,7 +811,21 @@ func TestHelmState_SyncRepos(t *testing.T) {
 				},
 			},
 			helm: &mockHelmExec{},
-			want: []string{"name", "http://example.com/", "certfile", "keyfile", "", ""},
+			want: []string{"name", "http://example.com/", "", "certfile", "keyfile", "", ""},
+		},
+		{
+			name: "repository with ca file",
+			repos: []RepositorySpec{
+				{
+					Name:     "name",
+					URL:      "http://example.com/",
+					CaFile:   "cafile",
+					Username: "",
+					Password: "",
+				},
+			},
+			helm: &mockHelmExec{},
+			want: []string{"name", "http://example.com/", "cafile", "", "", "", ""},
 		},
 		{
 			name: "repository with username and password",
@@ -826,7 +840,7 @@ func TestHelmState_SyncRepos(t *testing.T) {
 				},
 			},
 			helm: &mockHelmExec{},
-			want: []string{"name", "http://example.com/", "", "", "example_user", "example_password"},
+			want: []string{"name", "http://example.com/", "", "", "", "example_user", "example_password"},
 		},
 	}
 	for i := range tests {


### PR DESCRIPTION
This adds support for the `--ca-file` option to the `helm repo add` command via the RepositorySpec. The implementation for this is identical to the implementation for `RepositorySpec.CertFile` and `RepositorySpec.KeyFile`, and adds an example to the README.

While the use-case for this is fairly rare, it's a fairly easy implementation (unless I'm missing something here).

##### Possible Concern

Our helmfile usage is fairly vanilla, but this could be a breaking change if anyone uses helmfile as a Go library. I'm just not familiar enough with the various use-cases to know whether that's a problem, but I think that would be the main concern with this change.

resolves #855 