### PR TITLE
Fix: Change use of `tmpl` to `gotmpl` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,10 +559,10 @@ releases:
     namespace: {{ requiredEnv "NAME" }}
     chart: roboll/vault-secret-manager
     values:
-    - values.yaml.tmpl
+    - values.yaml.gotmpl
 ```
 
-`values.yaml.tmpl`:
+`values.yaml.gotmpl`:
 
 ```yaml
 db:


### PR DESCRIPTION
This adds clarity in docs by:

- Changing references to the supported file extension
- Previously, using `values.tmpl` in helmfile.yaml would throw errors. `values.gotmpl` gives expected output
