### PR TITLE
feat: Enhance postsync event to include `.Error`

### DIFF
--- a/pkg/event/bus.go
+++ b/pkg/event/bus.go
@@ -20,8 +20,8 @@ type Hook struct {
 }
 
 type event struct {
-	Name    string
-	Success bool
+	Name  string
+	Error error
 }
 
 type Bus struct {
@@ -38,7 +38,7 @@ type Bus struct {
 	Logger   *zap.SugaredLogger
 }
 
-func (bus *Bus) Trigger(evt string, success bool, context map[string]interface{}) (bool, error) {
+func (bus *Bus) Trigger(evt string, evtErr error, context map[string]interface{}) (bool, error) {
 	if bus.Runner == nil {
 		bus.Runner = helmexec.ShellRunner{
 			Dir: bus.BasePath,
@@ -69,8 +69,8 @@ func (bus *Bus) Trigger(evt string, success bool, context map[string]interface{}
 			"Environment": bus.Env,
 			"Namespace":   bus.Namespace,
 			"Event": event{
-				Name:    evt,
-				Success: success,
+				Name:  evt,
+				Error: evtErr,
 			},
 		}
 		for k, v := range context {

--- a/pkg/event/bus.go
+++ b/pkg/event/bus.go
@@ -20,7 +20,8 @@ type Hook struct {
 }
 
 type event struct {
-	Name string
+	Name    string
+	Success bool
 }
 
 type Bus struct {
@@ -37,7 +38,7 @@ type Bus struct {
 	Logger   *zap.SugaredLogger
 }
 
-func (bus *Bus) Trigger(evt string, context map[string]interface{}) (bool, error) {
+func (bus *Bus) Trigger(evt string, success bool, context map[string]interface{}) (bool, error) {
 	if bus.Runner == nil {
 		bus.Runner = helmexec.ShellRunner{
 			Dir: bus.BasePath,
@@ -68,7 +69,8 @@ func (bus *Bus) Trigger(evt string, context map[string]interface{}) (bool, error
 			"Environment": bus.Env,
 			"Namespace":   bus.Namespace,
 			"Event": event{
-				Name: evt,
+				Name:    evt,
+				Success: success,
 			},
 		}
 		for k, v := range context {

--- a/pkg/event/bus_test.go
+++ b/pkg/event/bus_test.go
@@ -104,7 +104,7 @@ func TestTrigger(t *testing.T) {
 			"Release":         "myrel",
 			"HelmfileCommand": "mycmd",
 		}
-		ok, err := bus.Trigger(c.triggeredEvt, data)
+		ok, err := bus.Trigger(c.triggeredEvt, true, data)
 
 		if ok != c.expectedResult {
 			t.Errorf("unexpected result for case \"%s\": expected=%v, actual=%v", c.name, c.expectedResult, ok)

--- a/pkg/event/bus_test.go
+++ b/pkg/event/bus_test.go
@@ -104,7 +104,7 @@ func TestTrigger(t *testing.T) {
 			"Release":         "myrel",
 			"HelmfileCommand": "mycmd",
 		}
-		ok, err := bus.Trigger(c.triggeredEvt, true, data)
+		ok, err := bus.Trigger(c.triggeredEvt, nil, data)
 
 		if ok != c.expectedResult {
 			t.Errorf("unexpected result for case \"%s\": expected=%v, actual=%v", c.name, c.expectedResult, ok)

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -461,7 +461,7 @@ func (st *HelmState) SyncReleases(affectedReleases *AffectedReleases, helm helme
 					results <- syncResult{errors: []*ReleaseError{relErr}}
 				}
 
-				if _, err := st.triggerPostsyncEvent(release, relErr != nil, "sync"); err != nil {
+				if _, err := st.triggerPostsyncEvent(release, relErr, "sync"); err != nil {
 					st.logger.Warnf("warn: %v\n", err)
 				}
 
@@ -1148,22 +1148,22 @@ func (st *HelmState) PrepareReleases(helm helmexec.Interface, helmfileCommand st
 }
 
 func (st *HelmState) triggerPrepareEvent(r *ReleaseSpec, helmfileCommand string) (bool, error) {
-	return st.triggerReleaseEvent("prepare", true, r, helmfileCommand)
+	return st.triggerReleaseEvent("prepare", nil, r, helmfileCommand)
 }
 
 func (st *HelmState) triggerCleanupEvent(r *ReleaseSpec, helmfileCommand string) (bool, error) {
-	return st.triggerReleaseEvent("cleanup", true, r, helmfileCommand)
+	return st.triggerReleaseEvent("cleanup", nil, r, helmfileCommand)
 }
 
 func (st *HelmState) triggerPresyncEvent(r *ReleaseSpec, helmfileCommand string) (bool, error) {
-	return st.triggerReleaseEvent("presync", true, r, helmfileCommand)
+	return st.triggerReleaseEvent("presync", nil, r, helmfileCommand)
 }
 
-func (st *HelmState) triggerPostsyncEvent(r *ReleaseSpec, success bool, helmfileCommand string) (bool, error) {
-	return st.triggerReleaseEvent("postsync", success, r, helmfileCommand)
+func (st *HelmState) triggerPostsyncEvent(r *ReleaseSpec, evtErr error, helmfileCommand string) (bool, error) {
+	return st.triggerReleaseEvent("postsync", evtErr, r, helmfileCommand)
 }
 
-func (st *HelmState) triggerReleaseEvent(evt string, success bool, r *ReleaseSpec, helmfileCmd string) (bool, error) {
+func (st *HelmState) triggerReleaseEvent(evt string, evtErr error, r *ReleaseSpec, helmfileCmd string) (bool, error) {
 	bus := &event.Bus{
 		Hooks:         r.Hooks,
 		StateFilePath: st.FilePath,
@@ -1177,7 +1177,7 @@ func (st *HelmState) triggerReleaseEvent(evt string, success bool, r *ReleaseSpe
 		"Release":         r,
 		"HelmfileCommand": helmfileCmd,
 	}
-	return bus.Trigger(evt, success, data)
+	return bus.Trigger(evt, evtErr, data)
 }
 
 // ResolveDeps returns a copy of this helmfile state with the concrete chart version numbers filled in for remote chart dependencies


### PR DESCRIPTION
This resolves #826 by adding a success flag to the event template data for use in hooks. See the related issue for use-cases.

I've made a first pass that is rather crude so please provide feedback if you would like it done a different way. I had some other ideas but I couldn't think of one that felt much cleaner so I've opted for this simplest one at this point.