### PR TITLE
Feature/autobuild docker image for each release thru dockerhub auto builds

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo "=> Building container"
+docker build \
+  --tag "$IMAGE_NAME" \
+  --file Dockerfile .

--- a/hooks/pre_build
+++ b/hooks/pre_build
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+go()
+{
+  docker run --rm -v "$(pwd):/workspace" -w /workspace golang:latest go $@;
+}
+
+go get -u github.com/tcnksm/ghr github.com/mitchellh/gox
+go mod vendor

--- a/hooks/push
+++ b/hooks/push
@@ -4,7 +4,8 @@ echo "=> Fetch unshallow origin"
 git fetch --unshallow origin || true
 
 echo "=> Tag image:"
-docker tag "${IMAGE_NAME}" "${DOCKER_REPO}:$(git describe --long --always)"
+docker tag "${IMAGE_NAME}" "${DOCKER_REPO}:$(git describe --tags --abbrev=0 HEAD^)"
+docker tag "${IMAGE_NAME}" "${DOCKER_REPO}:$(git describe --tags --abbrev=0 HEAD)"
 
 echo "=> Push images"
 docker push "${DOCKER_REPO}"

--- a/hooks/push
+++ b/hooks/push
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+echo "=> Fetch unshallow origin"
+git fetch --unshallow origin || true
+
+echo "=> Tag image:"
+docker tag "${IMAGE_NAME}" "${DOCKER_REPO}:$(git describe --long --always)"
+
+echo "=> Push images"
+docker push "${DOCKER_REPO}"


### PR DESCRIPTION
It resolves one of items mentioned in #783

> Helmfile versions(Docker image tag or Git tag of Helmfile binary releases. Probably out of scope os Helmfile itself but worth discussing

----

Leveraging dockerhub auto-builds, we can automatically push an updated docker image for each new release.
Once this PR is merged :
- go to your dockerhub account,
- Create new repository "yourusername/helmfile"
- Edit Build configuration : https://cloud.docker.com/repository/docker/<yourusername>/helmfile/builds/edit
- These are the default Build configuration
![image](https://user-images.githubusercontent.com/1788384/66242040-4fbcb580-e709-11e9-97b2-2a90bc69da81.png)
- Then, Save & Build

Congrats!




