### PR TITLE
Run "helm init --client-only" in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/${KUBECT
     chmod +x kubectl && \
     mv kubectl /usr/local/bin/kubectl
 
-RUN mkdir -p "$(helm home)/plugins"
+RUN ["helm", "init", "--client-only"]
 RUN helm plugin install https://github.com/databus23/helm-diff && \
     helm plugin install https://github.com/futuresimple/helm-secrets && \
     helm plugin install https://github.com/hypnoglow/helm-s3.git && \


### PR DESCRIPTION
In trying to use the base quay.io/roboll/helmfile image to deploy a chart that depended on an external repository, I ran into this error:

```
Adding repo bitnami https://charts.bitnami.com/bitnami
in ./helmfile.yaml: in .helmfiles[0]: in dirac/helmfile.yaml: helm exited with status 1:
  Error: Couldn't load repositories file (/root/.helm/repository/repositories.yaml).
  You might need to run `helm init` (or `helm init --client-only` if tiller is already installed)
```

The minimum to work around that error would be approximately:

```
mkdir /root/.helm/repository && echo apiVersion: v1 > /root/.helm/repository/repositories.yaml
```

Though there might be other things that I'm unwittingly depending on in the base `helm init`. What do you think?