### PR TITLE
Set HelmBinary in execer constructor

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ func main() {
 		cli.StringFlag{
 			Name:  "helm-binary, b",
 			Usage: "path to helm binary",
+			Value: "helm",
 		},
 		cli.StringFlag{
 			Name:  "file, f",

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -33,7 +33,6 @@ type App struct {
 	Env         string
 	Namespace   string
 	Selectors   []string
-	HelmBinary  string
 	Args        string
 	ValuesFiles []string
 	Set         map[string]interface{}
@@ -66,12 +65,11 @@ func New(conf ConfigProvider) *App {
 		Env:         conf.Env(),
 		Namespace:   conf.Namespace(),
 		Selectors:   conf.Selectors(),
-		HelmBinary:  conf.HelmBinary(),
 		Args:        conf.Args(),
 		FileOrDir:   conf.FileOrDir(),
 		ValuesFiles: conf.StateValuesFiles(),
 		Set:         conf.StateValuesSet(),
-		helmExecer: helmexec.New(conf.Logger(), conf.KubeContext(), &helmexec.ShellRunner{
+		helmExecer: helmexec.New(conf.HelmBinary(), conf.Logger(), conf.KubeContext(), &helmexec.ShellRunner{
 			Logger: conf.Logger(),
 		}),
 	})
@@ -456,10 +454,6 @@ func (a *App) VisitDesiredStatesWithReleasesFiltered(fileOrDir string, converge 
 			if err != nil {
 				return false, []error{err}
 			}
-		}
-
-		if a.HelmBinary != "" {
-			helm.SetHelmBinary(a.HelmBinary)
 		}
 
 		type Key struct {

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -1850,7 +1850,7 @@ func (mock *mockRunner) Execute(cmd string, args []string, env map[string]string
 }
 
 func MockExecer(logger *zap.SugaredLogger, kubeContext string) helmexec.Interface {
-	execer := helmexec.New(logger, kubeContext, &mockRunner{})
+	execer := helmexec.New("helm", logger, kubeContext, &mockRunner{})
 	return execer
 }
 

--- a/pkg/helmexec/exec.go
+++ b/pkg/helmexec/exec.go
@@ -13,10 +13,6 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-const (
-	command = "helm"
-)
-
 type decryptedSecret struct {
 	mutex sync.RWMutex
 	bytes []byte
@@ -50,9 +46,9 @@ func NewLogger(writer io.Writer, logLevel string) *zap.SugaredLogger {
 }
 
 // New for running helm commands
-func New(logger *zap.SugaredLogger, kubeContext string, runner Runner) *execer {
+func New(helmBinary string, logger *zap.SugaredLogger, kubeContext string, runner Runner) *execer {
 	return &execer{
-		helmBinary:       command,
+		helmBinary:       helmBinary,
 		logger:           logger,
 		kubeContext:      kubeContext,
 		runner:           runner,

--- a/pkg/helmexec/exec_test.go
+++ b/pkg/helmexec/exec_test.go
@@ -24,7 +24,7 @@ func (mock *mockRunner) Execute(cmd string, args []string, env map[string]string
 }
 
 func MockExecer(logger *zap.SugaredLogger, kubeContext string) *execer {
-	execer := New(logger, kubeContext, &mockRunner{})
+	execer := New("helm", logger, kubeContext, &mockRunner{})
 	return execer
 }
 
@@ -33,7 +33,7 @@ func MockExecer(logger *zap.SugaredLogger, kubeContext string) *execer {
 func TestNewHelmExec(t *testing.T) {
 	buffer := bytes.NewBufferString("something")
 	logger := NewLogger(buffer, "debug")
-	helm := New(logger, "dev", &ShellRunner{
+	helm := New("helm", logger, "dev", &ShellRunner{
 		Logger: logger,
 	})
 	if helm.kubeContext != "dev" {
@@ -50,7 +50,7 @@ func TestNewHelmExec(t *testing.T) {
 func Test_SetExtraArgs(t *testing.T) {
 	buffer := bytes.NewBufferString("something")
 	logger := NewLogger(buffer, "debug")
-	helm := New(NewLogger(os.Stdout, "info"), "dev", &ShellRunner{
+	helm := New("helm", NewLogger(os.Stdout, "info"), "dev", &ShellRunner{
 		Logger: logger,
 	})
 	helm.SetExtraArgs()
@@ -70,7 +70,7 @@ func Test_SetExtraArgs(t *testing.T) {
 func Test_SetHelmBinary(t *testing.T) {
 	buffer := bytes.NewBufferString("something")
 	logger := NewLogger(buffer, "debug")
-	helm := New(NewLogger(os.Stdout, "info"), "dev", &ShellRunner{
+	helm := New("helm", NewLogger(os.Stdout, "info"), "dev", &ShellRunner{
 		Logger: logger,
 	})
 	if helm.helmBinary != "helm" {

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -527,7 +527,7 @@ func TestHelmState_flagsForUpgrade(t *testing.T) {
 				HelmDefaults:      tt.defaults,
 				valsRuntime:       valsRuntime,
 			}
-			helm := helmexec.New(logger, "default", &helmexec.ShellRunner{
+			helm := helmexec.New("helm", logger, "default", &helmexec.ShellRunner{
 				Logger: logger,
 			})
 			args, err := state.flagsForUpgrade(helm, tt.release, 0)


### PR DESCRIPTION
This overrides the default helm command, if provided, as soon as possible.
This way it is already used in `visitStates`.


I ran into an issue using `HELM3` and `--helm-binary` together with helm-secrets. 
I previously used tillerless, which i could now remove. This however caused `DecryptSecret` to fail, as it would still use the helm2 binary; because it runs before the first `helm.SetHelmBinary` call.

While helm-secrets is not fully helm3 compatible yet, its uses within helmfile are, and i was able to just install it as a helm3 plugin. 
   