### PR TITLE
Make helmfile + helm v3 pass the integration test suite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,51 @@ jobs:
             export TERM=xterm
             make integration
 
+  integration_tests_helmv3:
+    machine:
+      image: circleci/classic:201808-01
+    environment:
+      CHANGE_MINIKUBE_NONE_USER: true
+      MINIKUBE_WANTUPDATENOTIFICATION: false
+      MINIKUBE_WANTREPORTERRORPROMPT: false
+    steps:
+    - checkout
+    - run: mkdir ~/build
+    - attach_workspace:
+        at: ~/build
+    - run: cp ~/build/helmfile ~/project/helmfile
+    - run:
+        name: Install helm
+        environment:
+          HELM_VERSION: v3.0.0-rc.2
+        command: |
+          HELM_FILENAME="helm-${HELM_VERSION}-linux-amd64.tar.gz"
+          curl -Lo ${HELM_FILENAME} "https://get.helm.sh/${HELM_FILENAME}"
+          tar zxf ${HELM_FILENAME} linux-amd64/helm
+          chmod +x linux-amd64/helm
+          sudo mv linux-amd64/helm /usr/local/bin/
+    - run:
+        name: Deploy minikube
+        environment:
+          CHANGE_MINIKUBE_NONE_USER: true
+          K8S_VERSION: v1.12.3
+          MINIKUBE_VERSION: v0.30.0
+        command: |
+          curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl
+          chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+          curl -Lo minikube https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-linux-amd64
+          chmod +x minikube && sudo mv minikube /usr/local/bin/
+          sudo -E minikube start --vm-driver=none --kubernetes-version=${K8S_VERSION}
+          sudo -E minikube update-context
+    - run:
+        name: Wait for nodes to become ready
+        command: JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
+    - run:
+        name: Execute integration tests
+        command: |
+          export TERM=xterm
+          HELMFILE_HELM3=1 make integration
+
 # GITHUB_TOKEN env var must be setup in circleci console
 
   release:
@@ -133,11 +178,9 @@ workflows:
       - integration_tests:
           requires:
             - build
-          filters:
-            branches:
-              only:
-                - master
-                - /pull.*/
+      - integration_tests_helmv3:
+          requires:
+            - build
       - release:
           filters:
             branches:

--- a/pkg/helmexec/exec.go
+++ b/pkg/helmexec/exec.go
@@ -133,6 +133,17 @@ func (helm *execer) List(context HelmContext, filter string, flags ...string) (s
 	}
 
 	out, err := helm.exec(append(append(preArgs, args...), flags...), env)
+	// In v2 we have been expecting `helm list FILTER` prints nothing.
+	// In v3 helm still prints the header like `NAME	NAMESPACE	REVISION	UPDATED	STATUS	CHART	APP VERSION`,
+	// which confuses helmfile's existing logic that treats any non-empty output from `helm list` is considered as the indication
+	// of the release to exist.
+	//
+	// This fixes it by removing the header from the v3 output, so that the output is formatted the same as that of v2.
+	if helm.isHelm3() {
+		lines := strings.Split(string(out), "\n")
+		lines = lines[1:]
+		out = []byte(strings.Join(lines, "\n"))
+	}
 	helm.write(out)
 	return string(out), err
 }

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1143,6 +1143,8 @@ func (st *HelmState) DeleteReleases(affectedReleases *AffectedReleases, helm hel
 			return nil
 		}
 
+		st.ApplyOverrides(&release)
+
 		flags := []string{}
 		if purge && !isHelm3() {
 			flags = append(flags, "--purge")


### PR DESCRIPTION
This enhances the integration test suite so that it can be run against not only helmfile + helm v2 but also with helm v3.

Also added two fixes to Helmfile that needed to pass the test.

Finally, from now on the integration test is run against pull requests from forks, so that we can catch more bugs before merging PRs, which helps maintaining this project. I believe it is intended to be so but that didn't work until now due to misconfiguration.