### PR TITLE
Build alternative container image for use with Helm v3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
             - .
   image:
     docker:
-      - image: circleci/golang:1.13.3
+    - image: circleci/golang:1.13.3
     working_directory: /home/circleci/workspace/helmfile
     steps:
     - checkout
@@ -40,6 +40,23 @@ jobs:
           make tools
           go mod vendor
           ORG=roboll BUILD_URL="$CIRCLE_BUILD_URL" make image
+
+  image_helm3:
+    docker:
+    - image: circleci/golang:1.13.3
+    working_directory: /home/circleci/workspace/helmfile
+    steps:
+    - checkout
+    - restore_cache:
+        keys:
+        - go-mod-cache-v1-{{ checksum "./go.sum" }}
+        - go-mod-cache-v1-
+    - setup_remote_docker
+    - run:
+        command: |
+          make tools
+          go mod vendor
+          ORG=roboll BUILD_URL="$CIRCLE_BUILD_URL" make image/helm3
 
   test:
     environment:
@@ -103,7 +120,7 @@ jobs:
             export TERM=xterm
             make integration
 
-  integration_tests_helmv3:
+  integration_tests_helm3:
     machine:
       image: circleci/classic:201808-01
     environment:
@@ -166,7 +183,7 @@ jobs:
           docker login -u="$DOCKER_USER" -p="$DOCKER_PASS" quay.io
           make tools
           go mod vendor
-          ORG=roboll BUILD_URL="$CIRCLE_BUILD_URL" make push release
+          ORG=roboll BUILD_URL="$CIRCLE_BUILD_URL" make push push/helm3 release
 
 workflows:
   version: 2
@@ -174,11 +191,12 @@ workflows:
     jobs:
       - build
       - image
+      - image_helm3
       - test
       - integration_tests:
           requires:
             - build
-      - integration_tests_helmv3:
+      - integration_tests_helm3:
           requires:
             - build
       - release:

--- a/Dockerfile.helm3
+++ b/Dockerfile.helm3
@@ -1,0 +1,45 @@
+FROM golang:1.13.3-alpine3.10 as builder
+
+RUN apk add --no-cache make git
+WORKDIR /workspace/helmfile
+COPY . /workspace/helmfile
+RUN make static-linux
+
+# -----------------------------------------------------------------------------
+
+FROM alpine:3.10
+
+RUN apk add --no-cache ca-certificates git bash curl jq
+
+ARG HELM_VERSION=v3.0.0-rc.2
+ARG HELM_LOCATION="https://get.helm.sh"
+ARG HELM_FILENAME="helm-${HELM_VERSION}-linux-amd64.tar.gz"
+ARG HELM_SHA256="b6fff8e01aa6cd9a4541bd48172bb53b9a0ae38d7e7783a8e0fcc1db63802aaa"
+RUN wget ${HELM_LOCATION}/${HELM_FILENAME} && \
+    echo Verifying ${HELM_FILENAME}... && \
+    sha256sum ${HELM_FILENAME} | grep -q "${HELM_SHA256}" && \
+    echo Extracting ${HELM_FILENAME}... && \
+    tar zxvf ${HELM_FILENAME} && mv /linux-amd64/helm /usr/local/bin/ && \
+    rm ${HELM_FILENAME} && rm -r /linux-amd64
+
+# using the install documentation found at https://kubernetes.io/docs/tasks/tools/install-kubectl/
+# for now but in a future version of alpine (in the testing version at the time of writing)
+# we should be able to install using apk add.
+ENV KUBECTL_VERSION="v1.14.5"
+ENV KUBECTL_SHA256="26681319de56820a8467c9407e9203d5b15fb010ffc75ac5b99c9945ad0bd28c"
+RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
+    sha256sum kubectl | grep ${KUBECTL_SHA256} && \
+    chmod +x kubectl && \
+    mv kubectl /usr/local/bin/kubectl
+
+RUN helm plugin install https://github.com/databus23/helm-diff && \
+    helm plugin install https://github.com/futuresimple/helm-secrets && \
+    helm plugin install https://github.com/hypnoglow/helm-s3.git && \
+    helm plugin install https://github.com/aslafy-z/helm-git.git && \
+    helm plugin install https://github.com/rimusz/helm-tiller
+
+COPY --from=builder /workspace/helmfile/dist/helmfile_linux_amd64 /usr/local/bin/helmfile
+
+ENV HELMFILE_HELM3="1"
+
+CMD ["/usr/local/bin/helmfile"]

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,13 @@ run: image
 push: image
 	docker push quay.io/${ORG}/helmfile:${TAG}
 
+
+image/helm3:
+	docker build -f Dockerfile.helm3 -t quay.io/${ORG}/helmfile:helm3-${TAG} .
+
+push/helm3: image/helm3
+	docker push quay.io/${ORG}/helmfile:helm3-${TAG}
+
 tools:
 	go get -u github.com/tcnksm/ghr github.com/mitchellh/gox
 .PHONY: tools


### PR DESCRIPTION
Adds the Dockerfile for Helm v3(Dockerfile.helm3) that contains both Helmfile and Helm v3(currently 3.0.0-rc.2).

Changes the CircleCI workflow to include a job to build the v3 image on every PR. The release job is enhanced to build and push the image with a tag prefixed with `helm3-`. So the resulting image should be available via e.g. `quay.io/roboll/helmfile:helm3-v0.90.5`.