### PR TITLE
Enable readFile in first-pass renderer

### DIFF
--- a/pkg/tmpl/context_funcs.go
+++ b/pkg/tmpl/context_funcs.go
@@ -31,9 +31,6 @@ func (c *Context) createFuncMap() template.FuncMap {
 		funcMap["exec"] = func(string, []interface{}, ...string) (string, error) {
 			return "", nil
 		}
-		funcMap["readFile"] = func(string) (string, error) {
-			return "", nil
-		}
 	}
 
 	return funcMap


### PR DESCRIPTION
It's not clear to me why `readFile` is disabled in the first-pass renderer. The implementation talks about "side-effect template calls" but I don't really see why reading a file is considered a side effect.

For me, the main thing is that I don't want to see the message
```
could not deduce `environment:` block, configuring only .Environment.Name. error: failed to read iae.yaml.part.0: reading document at index 1: yaml: unknown anchor 'iae' referenced
```
in my log files: it sounds like an error while it's not.

But when you think about it, using `readFile` seems useful in combination with the feature that the two-pass renderer adds (using values defined in `environment` blocks).