### PR TITLE
Allow combining valuesTemplate and values, same for setTemplate

### DIFF
--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -3593,6 +3593,64 @@ myrelease4	         	true     	id:myrelease1
 	assert.Equal(t, expected, out)
 }
 
+func TestSetValuesTemplate(t *testing.T) {
+	files := map[string]string{
+		"/path/to/helmfile.yaml": `
+releases:
+- name: zipkin
+  chart: stable/zipkin
+  values:
+  - val2: "val2"
+  valuesTemplate:
+  - val1: '{{"{{ .Release.Name }}"}}'
+  set:
+  - name: "name"
+    value: "val"
+  setTemplate:
+  - name: name-{{"{{ .Release.Name }}"}}
+    value: val-{{"{{ .Release.Name }}"}}
+`,
+	}
+	expectedValues := []interface{}{
+		map[interface{}]interface{}{"val1": "zipkin"},
+		map[interface{}]interface{}{"val2": "val2"}}
+	expectedSetValues := []state.SetValue{
+		state.SetValue{Name: "name-zipkin", Value: "val-zipkin"},
+		state.SetValue{Name: "name", Value: "val"}}
+
+	app := appWithFs(&App{
+		KubeContext: "default",
+		Logger:      helmexec.NewLogger(os.Stderr, "debug"),
+		Env:         "default",
+	}, files)
+
+	var specs []state.ReleaseSpec
+	collectReleases := func(st *state.HelmState, helm helmexec.Interface) []error {
+		specs = append(specs, st.Releases...)
+		return nil
+	}
+
+	err := app.VisitDesiredStatesWithReleasesFiltered(
+		"helmfile.yaml", collectReleases,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(specs) != 1 {
+		t.Fatalf("expected 1 release; got %d releases", len(specs))
+	}
+	actualValues := specs[0].Values
+	actualSetValues := specs[0].SetValues
+
+	if !reflect.DeepEqual(expectedValues, actualValues) {
+		t.Errorf("expected values: %v; got values: %v", expectedValues, actualValues)
+	}
+	if !reflect.DeepEqual(expectedSetValues, actualSetValues) {
+		t.Errorf("expected set: %v; got set: %v", expectedValues, actualValues)
+	}
+}
+
 func location() string {
 	_, fn, line, _ := runtime.Caller(1)
 	return fmt.Sprintf("%s:%d", filepath.Base(fn), line)

--- a/pkg/state/release.go
+++ b/pkg/state/release.go
@@ -93,7 +93,7 @@ func (r ReleaseSpec) ExecuteTemplateExpressions(renderer *tmpl.FileRenderer) (*R
 		result.Labels[key] = s.String()
 	}
 
-	if result.ValuesTemplate != nil && len(result.ValuesTemplate) > 0 {
+	if len(result.ValuesTemplate) > 0 {
 		for i, t := range result.ValuesTemplate {
 			switch ts := t.(type) {
 			case map[interface{}]interface{}:
@@ -117,7 +117,9 @@ func (r ReleaseSpec) ExecuteTemplateExpressions(renderer *tmpl.FileRenderer) (*R
 			}
 		}
 
-		result.Values = result.ValuesTemplate
+		var newvals []interface{}
+		newvals = append(newvals, result.ValuesTemplate...)
+		result.Values = append(newvals, result.Values...)
 	}
 
 	for i, t := range result.Values {
@@ -139,7 +141,7 @@ func (r ReleaseSpec) ExecuteTemplateExpressions(renderer *tmpl.FileRenderer) (*R
 		result.Secrets[i] = s.String()
 	}
 
-	if result.SetValuesTemplate != nil && len(result.SetValuesTemplate) > 0 {
+	if len(result.SetValuesTemplate) > 0 {
 		for i, val := range result.SetValuesTemplate {
 			{
 				// name
@@ -178,7 +180,9 @@ func (r ReleaseSpec) ExecuteTemplateExpressions(renderer *tmpl.FileRenderer) (*R
 			}
 		}
 
-		result.SetValues = result.SetValuesTemplate
+		var newvals []SetValue
+		newvals = append(newvals, result.SetValuesTemplate...)
+		result.SetValues = append(newvals, result.SetValues...)
 	}
 
 	return result, nil


### PR DESCRIPTION
Right now, one has to use either `valuesTemplate` or `values`. This is unexpected, it would be much more natural to allow using both at the same time. This implements that. The same for `setTemplate` and `set`.