### PR TITLE
Port the `needs` fix for `helmfile apply` to `delete` and `destroy`

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -158,15 +158,15 @@ func (a *App) Status(c StatusesConfigProvider) error {
 }
 
 func (a *App) Delete(c DeleteConfigProvider) error {
-	return a.reverse().ForEachStateFiltered(func(run *Run) []error {
-		return run.Delete(c)
-	}, true)
+	return a.reverse().ForEachState(func(run *Run) (bool, []error) {
+		return a.delete(run, c.Purge(), c)
+	})
 }
 
 func (a *App) Destroy(c DestroyConfigProvider) error {
-	return a.reverse().ForEachStateFiltered(func(run *Run) []error {
-		return run.Destroy(c)
-	}, true)
+	return a.reverse().ForEachState(func(run *Run) (bool, []error) {
+		return a.delete(run, true, c)
+	})
 }
 
 func (a *App) Test(c TestConfigProvider) error {
@@ -460,7 +460,7 @@ func withDAG(templated *state.HelmState, helm helmexec.Interface, logger *zap.Su
 
 	logger.Debugf("processing %d groups of releases in this order:\n%s", numBatches, printBatches(batches))
 
-	all := true
+	any := false
 
 	for i, batch := range batches {
 		var targets []state.ReleaseSpec
@@ -485,10 +485,10 @@ func withDAG(templated *state.HelmState, helm helmexec.Interface, logger *zap.Su
 			return false, errs
 		}
 
-		all = all && processed
+		any = any || processed
 	}
 
-	return all, nil
+	return any, nil
 }
 
 type Opts struct {
@@ -833,6 +833,78 @@ Do you really want to apply?
 
 	affectedReleases.DisplayAffectedReleases(c.Logger())
 	return true, syncErrs
+}
+
+func (a *App) delete(r *Run, purge bool, c DestroyConfigProvider) (bool, []error) {
+	st := r.state
+	helm := r.helm
+
+	affectedReleases := state.AffectedReleases{}
+
+	var deletingReleases []state.ReleaseSpec
+
+	if len(st.Selectors) > 0 {
+		var err error
+		deletingReleases, err = st.GetFilteredReleases()
+		if err != nil {
+			return false, []error{err}
+		}
+		if len(deletingReleases) == 0 {
+			return false, nil
+		}
+	} else {
+		deletingReleases = st.Releases
+	}
+
+	releasesToBeDeleted := map[string]state.ReleaseSpec{}
+	for _, r := range deletingReleases {
+		id := state.ReleaseToID(&r)
+		releasesToBeDeleted[id] = r
+	}
+
+	names := make([]string, len(deletingReleases))
+	for i, r := range deletingReleases {
+		names[i] = fmt.Sprintf("  %s (%s)", r.Name, r.Chart)
+	}
+
+	var errs []error
+	var any bool
+
+	msg := fmt.Sprintf(`Affected releases are:
+%s
+
+Do you really want to delete?
+  Helmfile will delete all your releases, as shown above.
+
+`, strings.Join(names, "\n"))
+	interactive := c.Interactive()
+	if !interactive || interactive && r.askForConfirmation(msg) {
+		r.helm.SetExtraArgs(argparser.GetArgs(c.Args(), r.state)...)
+
+		if len(releasesToBeDeleted) > 0 {
+			deleted, deletionErrs := withDAG(st, helm, a.Logger, true, a.Wrap(func(subst *state.HelmState, helm helmexec.Interface) []error {
+				var rs []state.ReleaseSpec
+
+				for _, r := range subst.Releases {
+					if _, ok := releasesToBeDeleted[state.ReleaseToID(&r)]; ok {
+						rs = append(rs, r)
+					}
+				}
+
+				subst.Releases = rs
+
+				return subst.DeleteReleases(&affectedReleases, helm, c.Concurrency(), purge)
+			}))
+
+			any = any || deleted
+
+			if deletionErrs != nil && len(deletionErrs) > 0 {
+				errs = append(errs, deletionErrs...)
+			}
+		}
+	}
+	affectedReleases.DisplayAffectedReleases(c.Logger())
+	return any, errs
 }
 
 func fileExistsAt(path string) bool {

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -1,9 +1,6 @@
 package app
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/roboll/helmfile/pkg/argparser"
 	"github.com/roboll/helmfile/pkg/helmexec"
 	"github.com/roboll/helmfile/pkg/state"
@@ -62,60 +59,6 @@ func (r *Run) Status(c StatusesConfigProvider) []error {
 	r.helm.SetExtraArgs(argparser.GetArgs(c.Args(), r.state)...)
 
 	return r.state.ReleaseStatuses(r.helm, workers)
-}
-
-func (r *Run) Delete(c DeleteConfigProvider) []error {
-	affectedReleases := state.AffectedReleases{}
-	purge := c.Purge()
-
-	errs := []error{}
-
-	names := make([]string, len(r.state.Releases))
-	for i, r := range r.state.Releases {
-		names[i] = fmt.Sprintf("  %s (%s)", r.Name, r.Chart)
-	}
-
-	msg := fmt.Sprintf(`Affected releases are:
-%s
-
-Do you really want to delete?
-  Helmfile will delete all your releases, as shown above.
-
-`, strings.Join(names, "\n"))
-	interactive := c.Interactive()
-	if !interactive || interactive && r.askForConfirmation(msg) {
-		r.helm.SetExtraArgs(argparser.GetArgs(c.Args(), r.state)...)
-
-		errs = r.state.DeleteReleases(&affectedReleases, r.helm, c.Concurrency(), purge)
-	}
-	affectedReleases.DisplayAffectedReleases(c.Logger())
-	return errs
-}
-
-func (r *Run) Destroy(c DestroyConfigProvider) []error {
-	errs := []error{}
-	affectedReleases := state.AffectedReleases{}
-
-	names := make([]string, len(r.state.Releases))
-	for i, r := range r.state.Releases {
-		names[i] = fmt.Sprintf("  %s (%s)", r.Name, r.Chart)
-	}
-
-	msg := fmt.Sprintf(`Affected releases are:
-%s
-
-Do you really want to delete?
-  Helmfile will delete all your releases, as shown above.
-
-`, strings.Join(names, "\n"))
-	interactive := c.Interactive()
-	if !interactive || interactive && r.askForConfirmation(msg) {
-		r.helm.SetExtraArgs(argparser.GetArgs(c.Args(), r.state)...)
-
-		errs = r.state.DeleteReleases(&affectedReleases, r.helm, c.Concurrency(), true)
-	}
-	affectedReleases.DisplayAffectedReleases(c.Logger())
-	return errs
 }
 
 func (r *Run) Diff(c DiffConfigProvider) []error {


### PR DESCRIPTION
This ports the fix for `helfmile apply` to `delete` and `destroy`, so that specifying `--selector` does not break those commands anymore.

Ref #919