### PR TITLE
fix: release not found on uninstall through sync/apply

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -914,19 +914,12 @@ func (a *App) sync(r *Run, c SyncConfigProvider) (bool, []error) {
 		return false, errs
 	}
 
-	var toSync []state.ReleaseSpec
-
-	if len(st.Selectors) > 0 {
-		var err error
-		toSync, err = st.GetSelectedReleasesWithOverrides()
-		if err != nil {
-			return false, []error{err}
-		}
-		if len(toSync) == 0 {
-			return false, nil
-		}
-	} else {
-		toSync = st.Releases
+	toSync, err := st.GetSelectedReleasesWithOverrides()
+	if err != nil {
+		return false, []error{err}
+	}
+	if len(toSync) == 0 {
+		return false, nil
 	}
 
 	toDelete, err := st.DetectReleasesToBeDeletedForSync(helm, toSync)

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -381,7 +381,7 @@ func (st *HelmState) isReleaseInstalled(context helmexec.HelmContext, helm helme
 	return false, nil
 }
 
-func (st *HelmState) DetectReleasesToBeDeleted(helm helmexec.Interface, releases []ReleaseSpec) ([]ReleaseSpec, error) {
+func (st *HelmState) DetectReleasesToBeDeletedForSync(helm helmexec.Interface, releases []ReleaseSpec) ([]ReleaseSpec, error) {
 	detected := []ReleaseSpec{}
 	for i := range releases {
 		release := releases[i]
@@ -395,6 +395,23 @@ func (st *HelmState) DetectReleasesToBeDeleted(helm helmexec.Interface, releases
 				r := release
 				detected = append(detected, r)
 			}
+		}
+	}
+	return detected, nil
+}
+
+func (st *HelmState) DetectReleasesToBeDeleted(helm helmexec.Interface, releases []ReleaseSpec) ([]ReleaseSpec, error) {
+	detected := []ReleaseSpec{}
+	for i := range releases {
+		release := releases[i]
+
+		installed, err := st.isReleaseInstalled(st.createHelmContext(&release, 0), helm, release)
+		if err != nil {
+			return nil, err
+		} else if installed {
+			// Otherwise `release` messed up(https://github.com/roboll/helmfile/issues/554)
+			r := release
+			detected = append(detected, r)
 		}
 	}
 	return detected, nil
@@ -462,6 +479,9 @@ func (st *HelmState) DeleteReleasesForSync(affectedReleases *AffectedReleases, h
 					var args []string
 					if isHelm3() {
 						args = []string{}
+						if release.Namespace != "" {
+							args = append(args, "--namespace", release.Namespace)
+						}
 					} else {
 						args = []string{"--purge"}
 					}
@@ -1136,13 +1156,8 @@ func (st *HelmState) ReleaseStatuses(helm helmexec.Interface, workerLimit int) [
 }
 
 // DeleteReleases wrapper for executing helm delete on the releases
-// This function traverses the DAG of the releases in the reverse order, so that the releases that are NOT depended by any others are deleted first.
 func (st *HelmState) DeleteReleases(affectedReleases *AffectedReleases, helm helmexec.Interface, concurrency int, purge bool) []error {
 	return st.scatterGatherReleases(helm, concurrency, func(release ReleaseSpec, workerIndex int) error {
-		if !release.Desired() {
-			return nil
-		}
-
 		st.ApplyOverrides(&release)
 
 		flags := []string{}
@@ -1155,20 +1170,13 @@ func (st *HelmState) DeleteReleases(affectedReleases *AffectedReleases, helm hel
 		}
 		context := st.createHelmContext(&release, workerIndex)
 
-		installed, err := st.isReleaseInstalled(context, helm, release)
-		if err != nil {
+		if err := helm.DeleteRelease(context, release.Name, flags...); err != nil {
+			affectedReleases.Failed = append(affectedReleases.Failed, &release)
 			return err
+		} else {
+			affectedReleases.Deleted = append(affectedReleases.Deleted, &release)
+			return nil
 		}
-		if installed {
-			if err := helm.DeleteRelease(context, release.Name, flags...); err != nil {
-				affectedReleases.Failed = append(affectedReleases.Failed, &release)
-				return err
-			} else {
-				affectedReleases.Deleted = append(affectedReleases.Deleted, &release)
-				return nil
-			}
-		}
-		return nil
 	})
 }
 

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1242,11 +1242,6 @@ func (st *HelmState) SelectReleasesWithOverrides() ([]Release, error) {
 	if err != nil {
 		return nil, err
 	}
-	for _, r := range rs {
-		spec := r.ReleaseSpec
-		st.ApplyOverrides(&spec)
-		r.ReleaseSpec = spec
-	}
 	return rs, nil
 }
 

--- a/pkg/state/state_run.go
+++ b/pkg/state/state_run.go
@@ -108,8 +108,8 @@ type PlanOpts struct {
 	Reverse bool
 }
 
-func PlanReleases(releases []ReleaseSpec, selectors []string, reverse bool) ([][]Release, error) {
-	marked, err := MarkFilteredReleases(releases, selectors)
+func (st *HelmState) PlanReleases(reverse bool) ([][]Release, error) {
+	marked, err := st.SelectReleasesWithOverrides()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -1926,7 +1926,7 @@ func TestHelmState_Delete(t *testing.T) {
 			desired:   boolValue(true),
 			installed: false,
 			purge:     false,
-			deleted:   []exectest.Release{},
+			deleted:   []exectest.Release{{Name: "releaseA", Flags: []string{}}},
 		},
 		{
 			name:      "desired but not installed (purge=true)",
@@ -1934,7 +1934,7 @@ func TestHelmState_Delete(t *testing.T) {
 			desired:   boolValue(true),
 			installed: false,
 			purge:     true,
-			deleted:   []exectest.Release{},
+			deleted:   []exectest.Release{{Name: "releaseA", Flags: []string{"--purge"}}},
 		},
 		{
 			name:      "installed but filtered (purge=false)",
@@ -1942,7 +1942,7 @@ func TestHelmState_Delete(t *testing.T) {
 			desired:   boolValue(false),
 			installed: true,
 			purge:     false,
-			deleted:   []exectest.Release{},
+			deleted:   []exectest.Release{{Name: "releaseA", Flags: []string{}}},
 		},
 		{
 			name:      "installed but filtered (purge=true)",
@@ -1950,7 +1950,7 @@ func TestHelmState_Delete(t *testing.T) {
 			desired:   boolValue(false),
 			installed: true,
 			purge:     true,
-			deleted:   []exectest.Release{},
+			deleted:   []exectest.Release{{Name: "releaseA", Flags: []string{"--purge"}}},
 		},
 		{
 			name:      "not installed, and filtered (purge=false)",
@@ -1958,7 +1958,7 @@ func TestHelmState_Delete(t *testing.T) {
 			desired:   boolValue(false),
 			installed: false,
 			purge:     false,
-			deleted:   []exectest.Release{},
+			deleted:   []exectest.Release{{Name: "releaseA", Flags: []string{}}},
 		},
 		{
 			name:      "not installed, and filtered (purge=true)",
@@ -1966,7 +1966,7 @@ func TestHelmState_Delete(t *testing.T) {
 			desired:   boolValue(false),
 			installed: false,
 			purge:     true,
-			deleted:   []exectest.Release{},
+			deleted:   []exectest.Release{{Name: "releaseA", Flags: []string{"--purge"}}},
 		},
 		{
 			name:            "with tiller args",


### PR DESCRIPTION
The recent addition of the DAG support(`needs`) and the fixes on it broke the delete-on-sync functionality. And there were two more bugs. One is that it was not correctly running `helm delete` when needed and the another is that it was failing when `--selector` is specified and the releases to delete by sync found, but nothing actually got deleted. This fixes all of them.

Fixes #941