### PR TITLE
feat: Automatically enable Helm v3 mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ jobs:
     - run:
         name: Install helm
         environment:
-          HELM_VERSION: v3.0.0-rc.2
+          HELM_VERSION: v3.0.0
         command: |
           HELM_FILENAME="helm-${HELM_VERSION}-linux-amd64.tar.gz"
           curl -Lo ${HELM_FILENAME} "https://get.helm.sh/${HELM_FILENAME}"

--- a/Dockerfile.helm3
+++ b/Dockerfile.helm3
@@ -11,10 +11,10 @@ FROM alpine:3.10
 
 RUN apk add --no-cache ca-certificates git bash curl jq
 
-ARG HELM_VERSION=v3.0.0-rc.2
+ARG HELM_VERSION=v3.0.0
 ARG HELM_LOCATION="https://get.helm.sh"
 ARG HELM_FILENAME="helm-${HELM_VERSION}-linux-amd64.tar.gz"
-ARG HELM_SHA256="b6fff8e01aa6cd9a4541bd48172bb53b9a0ae38d7e7783a8e0fcc1db63802aaa"
+ARG HELM_SHA256="10e1fdcca263062b1d7b2cb93a924be1ef3dd6c381263d8151dd1a20a3d8c0dc"
 RUN wget ${HELM_LOCATION}/${HELM_FILENAME} && \
     echo Verifying ${HELM_FILENAME}... && \
     sha256sum ${HELM_FILENAME} | grep -q "${HELM_SHA256}" && \

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -1994,6 +1994,9 @@ func (helm *mockHelmExec) Fetch(chart string, flags ...string) error {
 func (helm *mockHelmExec) Lint(name, chart string, flags ...string) error {
 	return nil
 }
+func (helm *mockHelmExec) IsHelm3() bool {
+	return false
+}
 
 func TestTemplate_SingleStateFile(t *testing.T) {
 	files := map[string]string{

--- a/pkg/exectest/helm.go
+++ b/pkg/exectest/helm.go
@@ -157,6 +157,10 @@ func (helm *Helm) TemplateRelease(name, chart string, flags ...string) error {
 	return nil
 }
 
+func (helm *Helm) IsHelm3() bool {
+	return false
+}
+
 func (helm *Helm) sync(m *sync.Mutex, f func()) {
 	if m != nil {
 		m.Lock()

--- a/pkg/helmexec/exec_test.go
+++ b/pkg/helmexec/exec_test.go
@@ -32,10 +32,7 @@ func MockExecer(logger *zap.SugaredLogger, kubeContext string) *execer {
 
 func TestNewHelmExec(t *testing.T) {
 	buffer := bytes.NewBufferString("something")
-	logger := NewLogger(buffer, "debug")
-	helm := New("helm", logger, "dev", &ShellRunner{
-		Logger: logger,
-	})
+	helm := MockExecer(NewLogger(buffer, "debug"), "dev")
 	if helm.kubeContext != "dev" {
 		t.Error("helmexec.New() - kubeContext")
 	}
@@ -48,11 +45,7 @@ func TestNewHelmExec(t *testing.T) {
 }
 
 func Test_SetExtraArgs(t *testing.T) {
-	buffer := bytes.NewBufferString("something")
-	logger := NewLogger(buffer, "debug")
-	helm := New("helm", NewLogger(os.Stdout, "info"), "dev", &ShellRunner{
-		Logger: logger,
-	})
+	helm := MockExecer(NewLogger(os.Stdout, "info"), "dev")
 	helm.SetExtraArgs()
 	if len(helm.extra) != 0 {
 		t.Error("helmexec.SetExtraArgs() - passing no arguments should not change extra field")
@@ -68,11 +61,7 @@ func Test_SetExtraArgs(t *testing.T) {
 }
 
 func Test_SetHelmBinary(t *testing.T) {
-	buffer := bytes.NewBufferString("something")
-	logger := NewLogger(buffer, "debug")
-	helm := New("helm", NewLogger(os.Stdout, "info"), "dev", &ShellRunner{
-		Logger: logger,
-	})
+	helm := MockExecer(NewLogger(os.Stdout, "info"), "dev")
 	if helm.helmBinary != "helm" {
 		t.Error("helmexec.command - default command is not helm")
 	}

--- a/pkg/helmexec/helmexec.go
+++ b/pkg/helmexec/helmexec.go
@@ -19,8 +19,10 @@ type Interface interface {
 	TestRelease(context HelmContext, name string, flags ...string) error
 	List(context HelmContext, filter string, flags ...string) (string, error)
 	DecryptSecret(context HelmContext, name string, flags ...string) (string, error)
+	IsHelm3() bool
 }
 
 type DependencyUpdater interface {
 	UpdateDeps(chart string) error
+	IsHelm3() bool
 }

--- a/pkg/state/chart_dependency.go
+++ b/pkg/state/chart_dependency.go
@@ -280,7 +280,7 @@ func (m *chartDependencyManager) lockFileName() string {
 }
 
 func (m *chartDependencyManager) Update(shell helmexec.DependencyUpdater, wd string, unresolved *UnresolvedDependencies) (*ResolvedDependencies, error) {
-	if isHelm3() {
+	if shell.IsHelm3() {
 		return m.updateHelm3(shell, wd, unresolved)
 	}
 	return m.updateHelm2(shell, wd, unresolved)
@@ -330,7 +330,7 @@ func (m *chartDependencyManager) doUpdate(chartLockFile string, unresolved *Unre
 		return nil, err
 	}
 
-	if isHelm3() && originalLockFileContent != nil {
+	if shell.IsHelm3() && originalLockFileContent != nil {
 		if err := m.writeBytes(filepath.Join(wd, chartLockFile), originalLockFileContent); err != nil {
 			return nil, err
 		}
@@ -357,7 +357,7 @@ func (m *chartDependencyManager) doUpdate(chartLockFile string, unresolved *Unre
 	})
 
 	// Don't update lock file if no dependency updated.
-	if !isHelm3() && originalLockFileContent != nil {
+	if !shell.IsHelm3() && originalLockFileContent != nil {
 		originalLockedReqs := &ChartLockedRequirements{}
 		if err := yaml.Unmarshal(originalLockFileContent, originalLockedReqs); err != nil {
 			return nil, err

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -477,7 +477,7 @@ func (st *HelmState) DeleteReleasesForSync(affectedReleases *AffectedReleases, h
 					relErr = newReleaseError(release, err)
 				} else {
 					var args []string
-					if isHelm3() {
+					if helm.IsHelm3() {
 						args = []string{}
 						if release.Namespace != "" {
 							args = append(args, "--namespace", release.Namespace)
@@ -577,7 +577,7 @@ func (st *HelmState) SyncReleases(affectedReleases *AffectedReleases, helm helme
 						relErr = newReleaseError(release, err)
 					} else if installed {
 						var args []string
-						if isHelm3() {
+						if helm.IsHelm3() {
 							args = []string{}
 						} else {
 							args = []string{"--purge"}
@@ -646,7 +646,7 @@ func (st *HelmState) SyncReleases(affectedReleases *AffectedReleases, helm helme
 
 func (st *HelmState) listReleases(context helmexec.HelmContext, helm helmexec.Interface, release *ReleaseSpec) (string, error) {
 	flags := st.connectionFlags(release)
-	if isHelm3() && release.Namespace != "" {
+	if helm.IsHelm3() && release.Namespace != "" {
 		flags = append(flags, "--namespace", release.Namespace)
 	}
 	return helm.List(context, "^"+release.Name+"$", flags...)
@@ -1161,11 +1161,11 @@ func (st *HelmState) DeleteReleases(affectedReleases *AffectedReleases, helm hel
 		st.ApplyOverrides(&release)
 
 		flags := []string{}
-		if purge && !isHelm3() {
+		if purge && !helm.IsHelm3() {
 			flags = append(flags, "--purge")
 		}
 		flags = st.appendConnectionFlags(flags, &release)
-		if isHelm3() && release.Namespace != "" {
+		if helm.IsHelm3() && release.Namespace != "" {
 			flags = append(flags, "--namespace", release.Namespace)
 		}
 		context := st.createHelmContext(&release, workerIndex)
@@ -1192,7 +1192,7 @@ func (st *HelmState) TestReleases(helm helmexec.Interface, cleanup bool, timeout
 			flags = append(flags, "--cleanup")
 		}
 		duration := strconv.Itoa(timeout)
-		if isHelm3() {
+		if helm.IsHelm3() {
 			duration += "s"
 		}
 		flags = append(flags, "--timeout", duration)
@@ -1200,10 +1200,6 @@ func (st *HelmState) TestReleases(helm helmexec.Interface, cleanup bool, timeout
 
 		return helm.TestRelease(st.createHelmContext(&release, workerIndex), release.Name, flags...)
 	})
-}
-
-func isHelm3() bool {
-	return os.Getenv("HELMFILE_HELM3") != ""
 }
 
 // Clean will remove any generated secrets
@@ -1532,7 +1528,7 @@ func (st *HelmState) flagsForUpgrade(helm helmexec.Interface, release *ReleaseSp
 	}
 	if timeout != 0 {
 		duration := strconv.Itoa(timeout)
-		if isHelm3() {
+		if helm.IsHelm3() {
 			duration += "s"
 		}
 		flags = append(flags, "--timeout", duration)

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -145,6 +145,14 @@ func boolValue(v bool) *bool {
 	return &v
 }
 
+// Mocking the command-line runner
+
+type mockRunner struct{}
+
+func (mock *mockRunner) Execute(cmd string, args []string, env map[string]string) ([]byte, error) {
+	return []byte{}, nil
+}
+
 func TestHelmState_flagsForUpgrade(t *testing.T) {
 	enable := true
 	disable := false
@@ -524,9 +532,7 @@ func TestHelmState_flagsForUpgrade(t *testing.T) {
 				HelmDefaults:      tt.defaults,
 				valsRuntime:       valsRuntime,
 			}
-			helm := helmexec.New("helm", logger, "default", &helmexec.ShellRunner{
-				Logger: logger,
-			})
+			helm := helmexec.New("helm", logger, "default", &mockRunner{})
 			args, err := state.flagsForUpgrade(helm, tt.release, 0)
 			if err != nil {
 				t.Errorf("unexpected error flagsForUpgade: %v", err)

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -46,7 +46,7 @@ function retry() {
 set -e
 info "Using namespace: ${test_ns}"
 # helm v2
-if helm version --client 1>/dev/null 2>/dev/null; then
+if helm version --client 2>/dev/null | grep '"v2\.'; then
   info "Using Helm version: $(helm version --short --client | grep -o v.*$)"
   ${helm} init --wait --override spec.template.spec.automountServiceAccountToken=true
 # helm v3


### PR DESCRIPTION
Runs `helm version` in helmexec.New, and exposes a method on Interface to allow other packages to use the detected version. Preserves compatibility with previous HELMFILE_HELM3 mechanism.

Resolves #923