### PR TITLE
Log "could not deduce `environment:` block" message at debug level

### DIFF
--- a/pkg/app/two_pass_renderer.go
+++ b/pkg/app/two_pass_renderer.go
@@ -56,7 +56,7 @@ func (r *desiredStateLoader) renderPrestate(firstPassEnv *environment.Environmen
 	if err != nil && r.logger != nil {
 		switch err.(type) {
 		case *state.StateLoadError:
-			r.logger.Infof("could not deduce `environment:` block, configuring only .Environment.Name. error: %v", err)
+			r.logger.Debugf("could not deduce `environment:` block, configuring only .Environment.Name. error: %v", err)
 		}
 		r.logger.Debugf("error in first-pass rendering: result of \"%s\":\n%s", filename, prependLineNumbers(yamlBuf.String()))
 	}


### PR DESCRIPTION
As discussed in #937, change the log level of the message
```
could not deduce `environment:` block, configuring only .Environment.Name. error: failed to read iae.yaml.part.0: reading document at index 1: yaml: unknown anchor 'iae' referenced
```
from info to debug.