### PR TITLE
Adding the cleanup-on-fail flag to upgrade command

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ helmDefaults:
   tillerNamespace: tiller-namespace  #dedicated default key for tiller-namespace
   tillerless: false                  #dedicated default key for tillerless
   kubeContext: kube-context          #dedicated default key for kube-context (--kube-context)
+  cleanup-on-fail: false             #dedicated default key for helm flag --cleanup-on-fail
   # additional and global args passed to helm
   args:
     - "--set k=v"
@@ -157,6 +158,8 @@ releases:
     installed: true
     # restores previous state in case of failed release
     atomic: true
+    # when true, cleans up any new resources created during a failed release
+    cleanup-on-fail: false
     # name of the tiller namespace
     tillerNamespace: vault
     # if true, will use the helm-tiller plugin

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -102,7 +102,7 @@ type HelmSpec struct {
 	// Atomic, when set to true, restore previous state in case of a failed install/upgrade attempt
 	Atomic bool `yaml:"atomic"`
 	// CleanupOnFailure, when set to true, the --cleanup-on-fail helm flag is passed to the upgrade command
-	CleanupOnFail bool `yaml:"cleanup-on-fail"`
+	CleanupOnFail bool `yaml:"cleanup-on-fail,omitempty"`
 
 	TLS       bool   `yaml:"tls"`
 	TLSCACert string `yaml:"tlsCACert,omitempty"`
@@ -142,7 +142,7 @@ type ReleaseSpec struct {
 	// Atomic, when set to true, restore previous state in case of a failed install/upgrade attempt
 	Atomic *bool `yaml:"atomic,omitempty"`
 	// CleanupOnFailure, when set to true, the --cleanup-on-fail helm flag is passed to the upgrade command
-	CleanupOnFail bool `yaml:"cleanup-on-fail"`
+	CleanupOnFail bool `yaml:"cleanup-on-fail,omitempty"`
 
 	// MissingFileHandler is set to either "Error" or "Warn". "Error" instructs helmfile to fail when unable to find a values or secrets file. When "Warn", it prints the file and continues.
 	// The default value for MissingFileHandler is "Error".

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -101,6 +101,8 @@ type HelmSpec struct {
 	Force bool `yaml:"force"`
 	// Atomic, when set to true, restore previous state in case of a failed install/upgrade attempt
 	Atomic bool `yaml:"atomic"`
+	// CleanupOnFailure, when set to true, the --cleanup-on-fail helm flag is passed to the upgrade command
+	CleanupOnFail bool `yaml:"cleanup-on-fail"`
 
 	TLS       bool   `yaml:"tls"`
 	TLSCACert string `yaml:"tlsCACert,omitempty"`
@@ -139,6 +141,8 @@ type ReleaseSpec struct {
 	Installed *bool `yaml:"installed,omitempty"`
 	// Atomic, when set to true, restore previous state in case of a failed install/upgrade attempt
 	Atomic *bool `yaml:"atomic,omitempty"`
+	// CleanupOnFailure, when set to true, the --cleanup-on-fail helm flag is passed to the upgrade command
+	CleanupOnFail bool `yaml:"cleanup-on-fail"`
 
 	// MissingFileHandler is set to either "Error" or "Warn". "Error" instructs helmfile to fail when unable to find a values or secrets file. When "Warn", it prints the file and continues.
 	// The default value for MissingFileHandler is "Error".
@@ -1520,6 +1524,10 @@ func (st *HelmState) flagsForUpgrade(helm helmexec.Interface, release *ReleaseSp
 
 	if release.Wait != nil && *release.Wait || release.Wait == nil && st.HelmDefaults.Wait {
 		flags = append(flags, "--wait")
+	}
+
+	if release.CleanupOnFail || st.HelmDefaults.CleanupOnFail {
+		flags = append(flags, "--cleanup-on-fail")
 	}
 
 	timeout := st.HelmDefaults.Timeout

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -101,7 +101,7 @@ type HelmSpec struct {
 	Force bool `yaml:"force"`
 	// Atomic, when set to true, restore previous state in case of a failed install/upgrade attempt
 	Atomic bool `yaml:"atomic"`
-	// CleanupOnFailure, when set to true, the --cleanup-on-fail helm flag is passed to the upgrade command
+	// CleanupOnFail, when set to true, the --cleanup-on-fail helm flag is passed to the upgrade command
 	CleanupOnFail bool `yaml:"cleanup-on-fail,omitempty"`
 
 	TLS       bool   `yaml:"tls"`
@@ -141,8 +141,8 @@ type ReleaseSpec struct {
 	Installed *bool `yaml:"installed,omitempty"`
 	// Atomic, when set to true, restore previous state in case of a failed install/upgrade attempt
 	Atomic *bool `yaml:"atomic,omitempty"`
-	// CleanupOnFailure, when set to true, the --cleanup-on-fail helm flag is passed to the upgrade command
-	CleanupOnFail bool `yaml:"cleanup-on-fail,omitempty"`
+	// CleanupOnFail, when set to true, the --cleanup-on-fail helm flag is passed to the upgrade command
+	CleanupOnFail *bool `yaml:"cleanup-on-fail,omitempty"`
 
 	// MissingFileHandler is set to either "Error" or "Warn". "Error" instructs helmfile to fail when unable to find a values or secrets file. When "Warn", it prints the file and continues.
 	// The default value for MissingFileHandler is "Error".
@@ -1526,10 +1526,6 @@ func (st *HelmState) flagsForUpgrade(helm helmexec.Interface, release *ReleaseSp
 		flags = append(flags, "--wait")
 	}
 
-	if release.CleanupOnFail || st.HelmDefaults.CleanupOnFail {
-		flags = append(flags, "--cleanup-on-fail")
-	}
-
 	timeout := st.HelmDefaults.Timeout
 	if release.Timeout != nil {
 		timeout = *release.Timeout
@@ -1552,6 +1548,10 @@ func (st *HelmState) flagsForUpgrade(helm helmexec.Interface, release *ReleaseSp
 
 	if release.Atomic != nil && *release.Atomic || release.Atomic == nil && st.HelmDefaults.Atomic {
 		flags = append(flags, "--atomic")
+	}
+
+	if release.CleanupOnFail != nil && *release.CleanupOnFail || release.CleanupOnFail == nil && st.HelmDefaults.CleanupOnFail {
+		flags = append(flags, "--cleanup-on-fail")
 	}
 
 	flags = st.appendConnectionFlags(flags, release)

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -456,7 +456,7 @@ func TestHelmState_flagsForUpgrade(t *testing.T) {
 			release: &ReleaseSpec{
 				Chart:     "test/chart",
 				Version:   "0.1",
-				CleanupOnFail:    &enable,
+				CleanupOnFail:    true,
 				Name:      "test-charts",
 				Namespace: "test-namespace",
 			},
@@ -474,7 +474,7 @@ func TestHelmState_flagsForUpgrade(t *testing.T) {
 			release: &ReleaseSpec{
 				Chart:     "test/chart",
 				Version:   "0.1",
-				CleanupOnFail:    &disable,
+				CleanupOnFail:    false,
 				Name:      "test-charts",
 				Namespace: "test-namespace",
 			},

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -456,7 +456,7 @@ func TestHelmState_flagsForUpgrade(t *testing.T) {
 			release: &ReleaseSpec{
 				Chart:     "test/chart",
 				Version:   "0.1",
-				CleanupOnFail:    true,
+				CleanupOnFail:    &enable,
 				Name:      "test-charts",
 				Namespace: "test-namespace",
 			},
@@ -474,7 +474,7 @@ func TestHelmState_flagsForUpgrade(t *testing.T) {
 			release: &ReleaseSpec{
 				Chart:     "test/chart",
 				Version:   "0.1",
-				CleanupOnFail:    false,
+				CleanupOnFail:    &disable,
 				Name:      "test-charts",
 				Namespace: "test-namespace",
 			},

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -449,6 +449,58 @@ func TestHelmState_flagsForUpgrade(t *testing.T) {
 			},
 		},
 		{
+			name: "cleanup-on-fail",
+			defaults: HelmSpec{
+				CleanupOnFail: false,
+			},
+			release: &ReleaseSpec{
+				Chart:     "test/chart",
+				Version:   "0.1",
+				CleanupOnFail:    &enable,
+				Name:      "test-charts",
+				Namespace: "test-namespace",
+			},
+			want: []string{
+				"--version", "0.1",
+				"--cleanup-on-fail",
+				"--namespace", "test-namespace",
+			},
+		},
+		{
+			name: "cleanup-on-fail-override-default",
+			defaults: HelmSpec{
+				CleanupOnFail: true,
+			},
+			release: &ReleaseSpec{
+				Chart:     "test/chart",
+				Version:   "0.1",
+				CleanupOnFail:    &disable,
+				Name:      "test-charts",
+				Namespace: "test-namespace",
+			},
+			want: []string{
+				"--version", "0.1",
+				"--namespace", "test-namespace",
+			},
+		},
+		{
+			name: "cleanup-on-fail-from-default",
+			defaults: HelmSpec{
+				CleanupOnFail: true,
+			},
+			release: &ReleaseSpec{
+				Chart:     "test/chart",
+				Version:   "0.1",
+				Name:      "test-charts",
+				Namespace: "test-namespace",
+			},
+			want: []string{
+				"--version", "0.1",
+				"--cleanup-on-fail",
+				"--namespace", "test-namespace",
+			},
+		},
+		{
 			name:     "tiller",
 			defaults: HelmSpec{},
 			release: &ReleaseSpec{

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -454,11 +454,11 @@ func TestHelmState_flagsForUpgrade(t *testing.T) {
 				CleanupOnFail: false,
 			},
 			release: &ReleaseSpec{
-				Chart:     "test/chart",
-				Version:   "0.1",
-				CleanupOnFail:    &enable,
-				Name:      "test-charts",
-				Namespace: "test-namespace",
+				Chart:         "test/chart",
+				Version:       "0.1",
+				CleanupOnFail: &enable,
+				Name:          "test-charts",
+				Namespace:     "test-namespace",
 			},
 			want: []string{
 				"--version", "0.1",
@@ -472,11 +472,11 @@ func TestHelmState_flagsForUpgrade(t *testing.T) {
 				CleanupOnFail: true,
 			},
 			release: &ReleaseSpec{
-				Chart:     "test/chart",
-				Version:   "0.1",
-				CleanupOnFail:    &disable,
-				Name:      "test-charts",
-				Namespace: "test-namespace",
+				Chart:         "test/chart",
+				Version:       "0.1",
+				CleanupOnFail: &disable,
+				Name:          "test-charts",
+				Namespace:     "test-namespace",
 			},
 			want: []string{
 				"--version", "0.1",


### PR DESCRIPTION
This PR adds cleanup-on-fail flag to the release as well as helmDefaults spec.
This allows failed releases to cleanup new resources.