### PR TITLE
Fix random "expansion errors" in large values contained in `values`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/tatsushid/go-prettytable v0.0.0-20141013043238-ed2d14c29939
 	github.com/urfave/cli v1.20.0
 	github.com/variantdev/dag v0.0.0-20191028002400-bb0b3c785363
-	github.com/variantdev/vals v0.0.0-20191030045026-1fa6af1b5299
+	github.com/variantdev/vals v0.0.0-20191117001227-ba4c7a29875a
 	go.mozilla.org/sops v0.0.0-20190912205235-14a22d7a7060 // indirect
 	go.opencensus.io v0.22.1 // indirect
 	go.uber.org/multierr v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -728,6 +728,8 @@ github.com/variantdev/vals v0.0.0-20191026125821-5d18b16cf30a h1:zrV+XXPXniLy9ZV
 github.com/variantdev/vals v0.0.0-20191026125821-5d18b16cf30a/go.mod h1:8CW8eonQlIJgAjF1fLfrkaBe16fGjwGf2PX52/Vualw=
 github.com/variantdev/vals v0.0.0-20191030045026-1fa6af1b5299 h1:91g7EEeE6dHdubLkS013s9vcZScrGDk/RqZEQwSkn4w=
 github.com/variantdev/vals v0.0.0-20191030045026-1fa6af1b5299/go.mod h1:8CW8eonQlIJgAjF1fLfrkaBe16fGjwGf2PX52/Vualw=
+github.com/variantdev/vals v0.0.0-20191117001227-ba4c7a29875a h1:Ce3KCr4PAC1qdEykv5iMnDrUjhN6pWDkdSTw/Lx11ts=
+github.com/variantdev/vals v0.0.0-20191117001227-ba4c7a29875a/go.mod h1:8CW8eonQlIJgAjF1fLfrkaBe16fGjwGf2PX52/Vualw=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 go.etcd.io/bbolt v1.3.2 h1:Z/90sZLPOeCy2PwprqkFa25PdkusRzaj9P8zm/KNyvk=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -7,6 +7,8 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"path/filepath"
+	"sort"
 	"strings"
 	"syscall"
 	"text/tabwriter"
@@ -17,11 +19,7 @@ import (
 	"github.com/roboll/helmfile/pkg/remote"
 	"github.com/roboll/helmfile/pkg/state"
 	"github.com/variantdev/vals"
-
 	"go.uber.org/zap"
-
-	"path/filepath"
-	"sort"
 )
 
 const (
@@ -89,7 +87,7 @@ func Init(app *App) *App {
 	app.directoryExistsAt = directoryExistsAt
 
 	var err error
-	app.valsRuntime, err = vals.New(valsCacheSize)
+	app.valsRuntime, err = vals.New(vals.Options{CacheSize: valsCacheSize})
 	if err != nil {
 		panic(fmt.Sprintf("Failed to initialize vals runtime: %v", err))
 	}

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -2018,7 +2018,7 @@ releases:
 	var buffer bytes.Buffer
 	logger := helmexec.NewLogger(&buffer, "debug")
 
-	valsRuntime, err := vals.New(32)
+	valsRuntime, err := vals.New(vals.Options{CacheSize: 32})
 	if err != nil {
 		t.Errorf("unexpected error creating vals runtime: %v", err)
 	}
@@ -3360,7 +3360,7 @@ err: "foo" has dependency to inexistent release "bar"
 
 				logger := helmexec.NewLogger(logWriter, "debug")
 
-				valsRuntime, err := vals.New(32)
+				valsRuntime, err := vals.New(vals.Options{CacheSize: 32})
 				if err != nil {
 					t.Errorf("unexpected error creating vals runtime: %v", err)
 				}

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 var logger = helmexec.NewLogger(os.Stdout, "warn")
-var valsRuntime, _ = vals.New(32)
+var valsRuntime, _ = vals.New(vals.Options{CacheSize: 32})
 
 func injectFs(st *HelmState, fs *testhelper.TestFs) *HelmState {
 	st.glob = fs.Glob


### PR DESCRIPTION
Those are not actually random but would have looked like so. We use an external go pkg `variantdev/vals` to expand urls like `ref+vault://foo/bar` contained in release values into their respective secret values.

There was a bug in `vals` that it tries to expand unintended types of strings which resulted in confusing errors like reported in #973.

`vals` fixed the issue in https://github.com/variantdev/vals/commit/ba4c7a29875ab5fea5df80d7c25b5d6ccdce07c0. This commit upgrades `vals` to accomodate that.

Fixes #973