### PR TITLE
Sending basePath to yamls renderer

### DIFF
--- a/pkg/tmpl/context_funcs.go
+++ b/pkg/tmpl/context_funcs.go
@@ -25,6 +25,7 @@ func (c *Context) createFuncMap() template.FuncMap {
 		"get":            get,
 		"getOrNil":       getOrNil,
 		"tpl":            c.Tpl,
+		"basePath":       func() string { return c.basePath },
 	}
 	if c.preRender {
 		// disable potential side-effect template calls


### PR DESCRIPTION
Hi,

I would like to propose this change because we faced a problem when we have app X that depends on app Y and we wanted to put Y in X dependencies:
```
helmfiles:
  - path: git::https://github/anih/Y.git@helmfile/helmfile.yaml?ref=master
```

But in Y we have 
```
helmfiles:
  - path: git::https://github/anih/generic-app.git@helmfile/helmfile.yaml?ref=master
    values:
      - extraValuesTemplates:
        - {{ requiredEnv "PWD" }}/values/values-file.yaml.gotmpl
```
unfortunately after removing `{{ requiredEnv "PWD" }}` i was getting error like 
```
values file matching "/project/.helmfile/cache/https_gihub_generic-app_git.ref=master/generic-api/values/values-file.yaml.gotmpl" does not exist in "/project/.helmfile/cache/https_gihub_generic-app_git.ref=master/generic-api"
```
With this patch all is working correctly.