### PR TITLE
Fix capitalization of cleanup-on-fail config key

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ helmDefaults:
   tillerNamespace: tiller-namespace  #dedicated default key for tiller-namespace
   tillerless: false                  #dedicated default key for tillerless
   kubeContext: kube-context          #dedicated default key for kube-context (--kube-context)
-  cleanup-on-fail: false             #dedicated default key for helm flag --cleanup-on-fail
+  cleanupOnFail: false             #dedicated default key for helm flag --cleanup-on-fail
   # additional and global args passed to helm
   args:
     - "--set k=v"
@@ -159,7 +159,7 @@ releases:
     # restores previous state in case of failed release
     atomic: true
     # when true, cleans up any new resources created during a failed release
-    cleanup-on-fail: false
+    cleanupOnFail: false
     # name of the tiller namespace
     tillerNamespace: vault
     # if true, will use the helm-tiller plugin

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -102,7 +102,7 @@ type HelmSpec struct {
 	// Atomic, when set to true, restore previous state in case of a failed install/upgrade attempt
 	Atomic bool `yaml:"atomic"`
 	// CleanupOnFail, when set to true, the --cleanup-on-fail helm flag is passed to the upgrade command
-	CleanupOnFail bool `yaml:"cleanup-on-fail,omitempty"`
+	CleanupOnFail bool `yaml:"cleanupOnFail,omitempty"`
 
 	TLS       bool   `yaml:"tls"`
 	TLSCACert string `yaml:"tlsCACert,omitempty"`
@@ -142,7 +142,7 @@ type ReleaseSpec struct {
 	// Atomic, when set to true, restore previous state in case of a failed install/upgrade attempt
 	Atomic *bool `yaml:"atomic,omitempty"`
 	// CleanupOnFail, when set to true, the --cleanup-on-fail helm flag is passed to the upgrade command
-	CleanupOnFail *bool `yaml:"cleanup-on-fail,omitempty"`
+	CleanupOnFail *bool `yaml:"cleanupOnFail,omitempty"`
 
 	// MissingFileHandler is set to either "Error" or "Warn". "Error" instructs helmfile to fail when unable to find a values or secrets file. When "Warn", it prints the file and continues.
 	// The default value for MissingFileHandler is "Error".


### PR DESCRIPTION
It is how `cleanupOnFail` to be consistent with other keys.

Ref #969