### PR TITLE
Fix Helm test having run subcommand with helm3

### DIFF
--- a/pkg/helmexec/exec.go
+++ b/pkg/helmexec/exec.go
@@ -302,12 +302,7 @@ func (helm *execer) TestRelease(context HelmContext, name string, flags ...strin
 	helm.logger.Infof("Testing %v", name)
 	preArgs := context.GetTillerlessArgs(helm)
 	env := context.getTillerlessEnv()
-	var args []string
-	if helm.IsHelm3() {
-		args = []string{"test", "run", name}
-	} else {
-		args = []string{"test", name}
-	}
+	args := []string{"test", name}
 	out, err := helm.exec(append(append(preArgs, args...), flags...), env)
 	helm.write(out)
 	return err


### PR DESCRIPTION
It looks like during the beta phase the testing functionality was tweaked / changed back during the beta phase but has since been returned back to how it worked originally.

RE: https://github.com/helm/helm/commit/a6f4bc1bc0fc721aa501f7b8667928b2ec4f0016
Signed-off-by: Jake Hill <jake@naphta.uk>