### PR TITLE
feat: Option to pass apiVersions to `helm diff` and `helm template`

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ helmDefaults:
   tlsKey: "path/to/key.pem"
   # limit the maximum number of revisions saved per release. Use 0 for no limit (default 10)
   historyMax: 10
+  # list of api versions to pass to `helm diff` and `helm template` via the --api-versions flag
+  apiVersions:
+  - example/v1
 
 
 # The desired states of Helm releases.

--- a/README.md
+++ b/README.md
@@ -94,10 +94,6 @@ helmDefaults:
   tlsKey: "path/to/key.pem"
   # limit the maximum number of revisions saved per release. Use 0 for no limit (default 10)
   historyMax: 10
-  # list of api versions to pass to `helm diff` and `helm template` via the --api-versions flag
-  apiVersions:
-  - example/v1
-
 
 # The desired states of Helm releases.
 #
@@ -270,6 +266,18 @@ bases:
 - environments.yaml
 - defaults.yaml
 - templates.yaml
+
+#
+# Advanced Configuration: API Capabilities
+#
+# Some helmfile tasks render releases locally without querying an actual cluster (diff, apply, template),
+# and in this case `.Capabilities.APIVersions` cannot be populated.
+# When a chart queries for a specific CRD, this can lead to unexpected results.
+# 
+# Configure a fixed list of api versions to pass to helm via the --api-versions flag:
+apiVersions:
+- example/v1
+
 ```
 
 ## Templating

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -2095,10 +2095,9 @@ releases:
 func TestTemplate_ApiVersions(t *testing.T) {
 	files := map[string]string{
 		"/path/to/helmfile.yaml": `
-helmDefaults:
-  apiVersions:
-  - helmfile.test/v1
-  - helmfile.test/v2
+apiVersions:
+- helmfile.test/v1
+- helmfile.test/v2
 releases:
 - name: myrelease1
   chart: mychart1
@@ -3415,9 +3414,8 @@ err: "foo" has dependency to inexistent release "bar"
 			loc:  location(),
 			files: map[string]string{
 				"/path/to/helmfile.yaml": `
-helmDefaults:
-  apiVersions:
-  - xxx/v1
+apiVersions:
+- xxx/v1
 releases:
 - name: foo
   chart: mychart1

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -110,6 +110,8 @@ type HelmSpec struct {
 	TLSCACert string `yaml:"tlsCACert,omitempty"`
 	TLSKey    string `yaml:"tlsKey,omitempty"`
 	TLSCert   string `yaml:"tlsCert,omitempty"`
+
+	ApiVersions []string `yaml:"apiVersions,omitempty"`
 }
 
 // RepositorySpec that defines values for a helm repo
@@ -1590,6 +1592,8 @@ func (st *HelmState) flagsForTemplate(helm helmexec.Interface, release *ReleaseS
 		return nil, err
 	}
 
+	flags = st.appendApiVersionsFlags(flags)
+
 	common, err := st.namespaceAndValuesFlags(helm, release, workerIndex)
 	if err != nil {
 		return nil, err
@@ -1615,11 +1619,23 @@ func (st *HelmState) flagsForDiff(helm helmexec.Interface, release *ReleaseSpec,
 		return nil, err
 	}
 
+	flags = st.appendApiVersionsFlags(flags)
+
 	common, err := st.namespaceAndValuesFlags(helm, release, workerIndex)
 	if err != nil {
 		return nil, err
 	}
 	return append(flags, common...), nil
+}
+
+func (st *HelmState) appendApiVersionsFlags(flags []string) []string {
+	if len(st.HelmDefaults.ApiVersions) == 0 {
+		return flags
+	}
+	for _, a := range st.HelmDefaults.ApiVersions {
+		flags = append(flags, "--api-versions", a)
+	}
+	return flags
 }
 
 func (st *HelmState) isDevelopment(release *ReleaseSpec) bool {

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -47,6 +47,7 @@ type HelmState struct {
 	Repositories       []RepositorySpec  `yaml:"repositories,omitempty"`
 	Releases           []ReleaseSpec     `yaml:"releases,omitempty"`
 	Selectors          []string          `yaml:"-"`
+	ApiVersions        []string          `yaml:"apiVersions,omitempty"`
 
 	Templates map[string]TemplateSpec `yaml:"templates"`
 
@@ -110,8 +111,6 @@ type HelmSpec struct {
 	TLSCACert string `yaml:"tlsCACert,omitempty"`
 	TLSKey    string `yaml:"tlsKey,omitempty"`
 	TLSCert   string `yaml:"tlsCert,omitempty"`
-
-	ApiVersions []string `yaml:"apiVersions,omitempty"`
 }
 
 // RepositorySpec that defines values for a helm repo
@@ -1629,10 +1628,7 @@ func (st *HelmState) flagsForDiff(helm helmexec.Interface, release *ReleaseSpec,
 }
 
 func (st *HelmState) appendApiVersionsFlags(flags []string) []string {
-	if len(st.HelmDefaults.ApiVersions) == 0 {
-		return flags
-	}
-	for _, a := range st.HelmDefaults.ApiVersions {
+	for _, a := range st.ApiVersions {
 		flags = append(flags, "--api-versions", a)
 	}
 	return flags


### PR DESCRIPTION
resolves #1014

This makes it possible to pass the API Capabilities to helmfile when executing a task that does not render against an actual cluster (diff, template, apply).

The list of api versions are currently passed via `helmDefaults`. Maybe it would also make sense to override in specific `environments`, but this is not implemented.

This is my first contribution to a golang project, any feedback will be appreciated :)