### PR TITLE
do not pass --api-versions to "helm diff"

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,11 +270,11 @@ bases:
 #
 # Advanced Configuration: API Capabilities
 #
-# Some helmfile tasks render releases locally without querying an actual cluster (diff, apply, template),
+# 'helmfile template' renders releases locally without querying an actual cluster,
 # and in this case `.Capabilities.APIVersions` cannot be populated.
 # When a chart queries for a specific CRD, this can lead to unexpected results.
 # 
-# Configure a fixed list of api versions to pass to helm via the --api-versions flag:
+# Configure a fixed list of api versions to pass to 'helm template' via the --api-versions flag:
 apiVersions:
 - example/v1
 

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -3409,25 +3409,6 @@ Affected releases are:
 err: "foo" has dependency to inexistent release "bar"
 `,
 		},
-		{
-			name: "pass apiVersions to helm diff",
-			loc:  location(),
-			files: map[string]string{
-				"/path/to/helmfile.yaml": `
-apiVersions:
-- xxx/v1
-releases:
-- name: foo
-  chart: mychart1
-`,
-			},
-			diffs: map[exectest.DiffKey]error{
-				exectest.DiffKey{Name: "foo", Chart: "mychart1", Flags: "--kube-contextdefault--api-versionsxxx/v1--detailed-exitcode"}: helmexec.ExitError{Code: 2},
-			},
-			upgraded: []exectest.Release{
-				{Name: "foo", Flags: []string{"--kube-context", "default"}},
-			},
-		},
 	}
 
 	for i := range testcases {

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1619,8 +1619,6 @@ func (st *HelmState) flagsForDiff(helm helmexec.Interface, release *ReleaseSpec,
 		return nil, err
 	}
 
-	flags = st.appendApiVersionsFlags(flags)
-
 	common, err := st.namespaceAndValuesFlags(helm, release, workerIndex)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
https://github.com/roboll/helmfile/pull/1046 introduced the `apiVersions` configuration option in helmfile.yaml. The api versions were passed via `--api-versions` to `helm template` and `helm diff`. 

However `helm diff` does not implement the `--api-versions` parameter, and does not plan to do so (see https://github.com/databus23/helm-diff/pull/175). Instead, with helm 3.1.0 `helm diff` will render templates against the actual cluster, removing the need to specify api versions manually.

This PR removes passing API versions to `helm diff` (which caused helm diff to fail, if `apiVersions` was specified in helmfile). The API versions are still used when running `helmfile template`, which may make sense for some use cases.