### PR TITLE
fix: `helmfile -n ns status` should set ns for helm 3

### DIFF
--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1166,6 +1166,8 @@ func (st *HelmState) ReleaseStatuses(helm helmexec.Interface, workerLimit int) [
 			return nil
 		}
 
+		st.ApplyOverrides(&release)
+
 		flags := []string{}
 		if helm.IsHelm3() && release.Namespace != "" {
 			flags = append(flags, "--namespace", release.Namespace)


### PR DESCRIPTION
This fixes the issue reported in Slack https://sweetops.slack.com/archives/CE5NGCB9Q/p1582088381195000