### PR TITLE
feat: `helmfile --log-level=debug apply --retain-values-files`

### DIFF
--- a/main.go
+++ b/main.go
@@ -339,6 +339,10 @@ func main() {
 					Usage: "pass args to helm exec",
 				},
 				cli.BoolFlag{
+					Name:  "retain-values-files",
+					Usage: "Stop cleaning up values files passed to Helm. Together with --log-level=debug, you can manually rerun helm commands as Helmfile did for debugging purpose",
+				},
+				cli.BoolFlag{
 					Name:  "suppress-secrets",
 					Usage: "suppress secrets in the diff output. highly recommended to specify on CI/CD use-cases",
 				},
@@ -540,6 +544,10 @@ func (c configImpl) SkipDeps() bool {
 
 func (c configImpl) DetailedExitcode() bool {
 	return c.c.Bool("detailed-exitcode")
+}
+
+func (c configImpl) RetainValuesFiles() bool {
+	return c.c.Bool("retain-values-files")
 }
 
 func (c configImpl) SuppressSecrets() bool {

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -1890,18 +1890,19 @@ func (c configImpl) Concurrency() int {
 }
 
 type applyConfig struct {
-	args             string
-	values           []string
-	set              []string
-	skipDeps         bool
-	suppressSecrets  bool
-	suppressDiff     bool
-	noColor          bool
-	context          int
-	concurrency      int
-	detailedExitcode bool
-	interactive      bool
-	logger           *zap.SugaredLogger
+	args              string
+	values            []string
+	retainValuesFiles bool
+	set               []string
+	skipDeps          bool
+	suppressSecrets   bool
+	suppressDiff      bool
+	noColor           bool
+	context           int
+	concurrency       int
+	detailedExitcode  bool
+	interactive       bool
+	logger            *zap.SugaredLogger
 }
 
 func (a applyConfig) Args() string {
@@ -1950,6 +1951,10 @@ func (a applyConfig) Interactive() bool {
 
 func (a applyConfig) Logger() *zap.SugaredLogger {
 	return a.logger
+}
+
+func (a applyConfig) RetainValuesFiles() bool {
+	return a.retainValuesFiles
 }
 
 // Mocking the command-line runner

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -48,6 +48,8 @@ type ApplyConfigProvider interface {
 	NoColor() bool
 	Context() int
 
+	RetainValuesFiles() bool
+
 	concurrencyConfig
 	interactive
 	loggingConfig

--- a/pkg/app/load_opts.go
+++ b/pkg/app/load_opts.go
@@ -9,6 +9,8 @@ type LoadOpts struct {
 	Selectors   []string
 	Environment state.SubhelmfileEnvironmentSpec
 
+	RetainValuesFiles bool
+
 	// CalleePath is the absolute path to the file being loaded
 	CalleePath string
 }


### PR DESCRIPTION
`--retain-values-files` prevents temporary values files that were passed to Helm commands run by Helmfile for debugging purpose.

With that, you can manually rerun helm commands that were logged when `--log-level=debug` is enabled.

Resolves ##1117