### PR TITLE
Added validation for empty repository names

### DIFF
--- a/pkg/helmexec/exec.go
+++ b/pkg/helmexec/exec.go
@@ -84,6 +84,10 @@ func (helm *execer) SetHelmBinary(bin string) {
 
 func (helm *execer) AddRepo(name, repository, cafile, certfile, keyfile, username, password string) error {
 	var args []string
+	if name == "" && repository != "" {
+		helm.logger.Infof("empty field name\n")
+		return fmt.Errorf("empty field name")
+	}
 	args = append(args, "repo", "add", name, repository)
 	if certfile != "" && keyfile != "" {
 		args = append(args, "--cert-file", certfile, "--key-file", keyfile)

--- a/pkg/helmexec/exec_test.go
+++ b/pkg/helmexec/exec_test.go
@@ -113,6 +113,15 @@ exec: helm repo add myRepo https://repo.example.com/ --username example_user --p
 	if buffer.String() != expected {
 		t.Errorf("helmexec.AddRepo()\nactual = %v\nexpect = %v", buffer.String(), expected)
 	}
+
+	buffer.Reset()
+	helm.AddRepo("", "https://repo.example.com/", "", "", "", "", "")
+	expected = `empty field name
+
+`
+	if buffer.String() != expected {
+		t.Errorf("helmexec.AddRepo()\nactual = %v\nexpect = %v", buffer.String(), expected)
+	}
 }
 
 func Test_UpdateRepo(t *testing.T) {


### PR DESCRIPTION
This adds validation for when a helmfile declares a repository URL but not a repository name.

Resolves #1112.
