### PR TITLE
WIP: (#1125) ask question

### DIFF
--- a/Dockerfile.helm3
+++ b/Dockerfile.helm3
@@ -2,6 +2,8 @@ FROM golang:1.13.7-alpine3.11 as builder
 
 RUN apk add --no-cache make git
 WORKDIR /workspace/helmfile
+COPY go.mod go.sum ./
+RUN go mod download
 COPY . /workspace/helmfile
 RUN make static-linux
 

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ cross:
 .PHONY: cross
 
 static-linux:
-	env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GOFLAGS=-mod=vendor go build -o "dist/helmfile_linux_amd64" -ldflags '-X github.com/roboll/helmfile/pkg/app/version.Version=${TAG}' ${TARGETS}
+	env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o "dist/helmfile_linux_amd64" -ldflags '-X github.com/roboll/helmfile/pkg/app/version.Version=${TAG}' ${TARGETS}
 .PHONY: static-linux
 
 install:


### PR DESCRIPTION
I have question about issue with docker build failed. 
Is the are a reason to use `go mod vendor` instead off `go mod download`? 
I can advise as follow.