### PR TITLE
feat: add helmfile template --validate

### DIFF
--- a/main.go
+++ b/main.go
@@ -237,6 +237,10 @@ func main() {
 					Usage: "maximum number of concurrent downloads of release charts",
 				},
 				cli.BoolFlag{
+					Name:  "validate",
+					Usage: "validate your manifests against the Kubernetes cluster you are currently pointing at",
+				},
+				cli.BoolFlag{
 					Name:  "skip-deps",
 					Usage: "skip running `helm repo update` and `helm dependency build`",
 				},
@@ -526,6 +530,10 @@ func (c configImpl) Args() string {
 
 func (c configImpl) OutputDir() string {
 	return c.c.String("output-dir")
+}
+
+func (c configImpl) Validate() bool {
+	return c.c.Bool("validate")
 }
 
 func (c configImpl) Concurrency() int {

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1114,7 +1114,7 @@ func (a *App) template(r *Run, c TemplateConfigProvider) (bool, []error) {
 			opts := &state.TemplateOpts{
 				Set: c.Set(),
 			}
-			return subst.TemplateReleases(helm, c.OutputDir(), c.Values(), args, c.Concurrency(), opts)
+			return subst.TemplateReleases(helm, c.OutputDir(), c.Values(), args, c.Concurrency(), c.Validate(), opts)
 		}))
 
 		if templateErrs != nil && len(templateErrs) > 0 {

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -1877,6 +1877,10 @@ func (c configImpl) Args() string {
 	return "some args"
 }
 
+func (c configImpl) Validate() bool {
+	return true
+}
+
 func (c configImpl) SkipDeps() bool {
 	return true
 }
@@ -1894,6 +1898,7 @@ type applyConfig struct {
 	values            []string
 	retainValuesFiles bool
 	set               []string
+	validate          bool
 	skipDeps          bool
 	suppressSecrets   bool
 	suppressDiff      bool
@@ -1915,6 +1920,10 @@ func (a applyConfig) Values() []string {
 
 func (a applyConfig) Set() []string {
 	return a.set
+}
+
+func (a applyConfig) Validate() bool {
+	return a.validate
 }
 
 func (a applyConfig) SkipDeps() bool {

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -125,6 +125,7 @@ type TemplateConfigProvider interface {
 
 	Values() []string
 	Set() []string
+	Validate() bool
 	SkipDeps() bool
 	OutputDir() string
 

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -760,7 +760,7 @@ func (o *TemplateOpts) Apply(opts *TemplateOpts) {
 }
 
 // TemplateReleases wrapper for executing helm template on the releases
-func (st *HelmState) TemplateReleases(helm helmexec.Interface, outputDir string, additionalValues []string, args []string, workerLimit int, opt ...TemplateOpt) []error {
+func (st *HelmState) TemplateReleases(helm helmexec.Interface, outputDir string, additionalValues []string, args []string, workerLimit int, validate bool, opt ...TemplateOpt) []error {
 	opts := &TemplateOpts{}
 	for _, o := range opt {
 		o.Apply(opts)
@@ -830,6 +830,10 @@ func (st *HelmState) TemplateReleases(helm helmexec.Interface, outputDir string,
 			flags = append(flags, "--output-dir", releaseOutputDir)
 			st.logger.Debugf("Generating templates to : %s\n", releaseOutputDir)
 			os.Mkdir(releaseOutputDir, 0755)
+		}
+
+		if validate {
+			flags = append(flags, "--validate")
 		}
 
 		if len(errs) == 0 {


### PR DESCRIPTION
This adds ability for helmfile to call helm template --validate introduced in helm 3.

Note: what about helm 2 support? Should we forbid this flag when using helm 2?

Fixes https://github.com/roboll/helmfile/issues/1105