### PR TITLE
fix: empty map merge was not working after mergo bump

### DIFF
--- a/pkg/state/envvals_loader.go
+++ b/pkg/state/envvals_loader.go
@@ -73,7 +73,7 @@ func (ld *EnvironmentValuesLoader) LoadEnvironmentValues(missingFileHandler *str
 			if err != nil {
 				return nil, err
 			}
-			if err := mergo.Merge(&result, &vals, mergo.WithOverride); err != nil {
+			if err := mergo.Merge(&result, &vals, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue); err != nil {
 				return nil, fmt.Errorf("failed to merge %v: %v", m, err)
 			}
 		}


### PR DESCRIPTION
Since mergo had been bumped to 0.3.9 in https://github.com/roboll/helmfile/commit/6643a41ea3bb2e8f87a860d562cfdb6b9ca72d1b an environment value like:
```yaml
affinity: {}
```
Was not merged properly (not merged) instead it threw an error
that it cannot find the key "affinity" in the environment values even
though it was outputted in debug output as read in properly.
Error message:
```
err: failed to render values files "values.yaml.gotmpl": failed to render [values.yaml.gotmpl], because of template: stringTemplate:2:23: executing "stringTemplate" at <.Environment.Values.affinity>: map has no entry for key "affinity"
in ./helmfile.yaml: failed to render values files "values.yaml.gotmpl": failed to render [values.yaml.gotmpl], because of template: stringTemplate:2:23: executing "stringTemplate" at <.Environment.Values.affinity>: map has no entry for key "affinity"
```

debug output:
```
...
envvals_loader: loaded empty.yaml:map[affinity:map[]]
...
merged environment: &{empty map[] map[]}
```

steps to reporduce:
helmfile:
```yaml
releases:
- name: "test"
  chart: "./testchart" # dummy local test chart created via "helm create"
  version: "0.1.0"
  namespace: "test"
  installed: true
  values:
  - "values.yaml.gotmpl"

environments:
  empty:
    values:
    - empty.yaml
    missingFileHandler: Error

  nonempty:
    values:
    - nonempty.yaml
    missingFileHandler: Error

```
values.yaml.gotmpl
```yaml
affinity:
{{- toYaml .Environment.Values.affinity | nindent 2 }}
```
empty.yaml:
```yaml
affinity: {}
```
nonempty.yaml:
```yaml
affinity:
  test: "test
```

and `helmfile --log-level debug --environment empty template` will fail
and `helmfile --log-level debug --environment nonempty template` will pass

After this change both cases pass properly.