### PR TITLE
feat: Emit clear error message instead of panic on empty chart name

### DIFF
--- a/pkg/app/desired_state_file_loader.go
+++ b/pkg/app/desired_state_file_loader.go
@@ -207,6 +207,12 @@ func (ld *desiredStateLoader) renderAndLoad(env, overrodeEnv *environment.Enviro
 			return nil, err
 		}
 
+		for i, r := range currentState.Releases {
+			if r.Chart == "" {
+				return nil, fmt.Errorf("error during %s parsing: encountered empty chart while reading release %q at index %d", id, r.Name, i)
+			}
+		}
+
 		if finalState == nil {
 			finalState = currentState
 		} else {


### PR DESCRIPTION
Instead of panic, Helmfile will now kindly emit a clear error message like this:

```
# helmfile.emptychart.yaml
releases:
- name: foo
```

```
$ ./helmfile -f helmfile.emptychart.yaml  build
in ./helmfile.emptychart.yaml: error during helmfile.emptychart.yaml.part.0 parsing: encountered empty chart while reading release "foo" at index 0
```

Resolves #999