### PR TITLE
Fix misleading `helmfile diff` output

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -148,7 +148,13 @@ func (a *App) Diff(c DiffConfigProvider) error {
 	if len(deferredErrs) > 0 {
 		// We take the first release error w/ exit status 2 (although all the defered errs should have exit status 2)
 		// to just let helmfile itself to exit with 2
-		return deferredErrs[0]
+		// See https://github.com/roboll/helmfile/issues/749
+		code := 2
+		e := &Error{
+			msg:  "Identified at least on change",
+			code: &code,
+		}
+		return e
 	}
 
 	return nil
@@ -1299,7 +1305,7 @@ func (e *Error) Code() int {
 	panic(fmt.Sprintf("[bug] assertion error: unexpected state: unable to handle errors: %v", e.Errors))
 }
 
-func appError(msg string, err error) error {
+func appError(msg string, err error) *Error {
 	return &Error{msg: msg, Errors: []error{err}}
 }
 

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -86,6 +86,7 @@ func (r *Run) Diff(c DiffConfigProvider) []error {
 		Set:     c.Set(),
 	}
 	_, errs := st.DiffReleases(helm, c.Values(), c.Concurrency(), c.DetailedExitcode(), c.SuppressSecrets(), c.SuppressDiff(), true, opts)
+
 	return errs
 }
 

--- a/pkg/state/release_error.go
+++ b/pkg/state/release_error.go
@@ -13,9 +13,19 @@ type ReleaseError struct {
 }
 
 func (e *ReleaseError) Error() string {
-	return fmt.Sprintf("failed processing release %s: %v", e.Name, e.err.Error())
+	return e.err.Error()
 }
 
-func newReleaseError(release *ReleaseSpec, err error) *ReleaseError {
-	return &ReleaseError{release, err, ReleaseErrorCodeFailure}
+func NewReleaseError(release *ReleaseSpec, err error, code int) *ReleaseError {
+	return &ReleaseError{
+		ReleaseSpec: release,
+		err:         err,
+		Code:        code,
+	}
+}
+
+func newReleaseFailedError(release *ReleaseSpec, err error) *ReleaseError {
+	wrappedErr := fmt.Errorf("failed processing release %s: %v", release.Name, err.Error())
+
+	return NewReleaseError(release, wrappedErr, ReleaseErrorCodeFailure)
 }


### PR DESCRIPTION
It's now as simple as:

```
********************

	Release was not present in Helm.  Diff will show entire contents as new.

********************
default, mysecret, Secret (v1) has been added:
-
+ # Source: raw/templates/resources.yaml
+ apiVersion: v1
+ kind: Secret
+ metadata:
+   labels:
+     app: raw
+     chart: raw-0.2.3
+     heritage: Helm
+     release: raw
+   name: mysecret
+ stringData:
+   foo: bar

Identified at least on change
```

```
$ echo $?
2
```

Fixes #749
