### PR TITLE
put tiller on path for use in helm-tiller plugin.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN wget ${HELM_LOCATION}/${HELM_FILENAME} && \
     sha256sum ${HELM_FILENAME} | grep -q "${HELM_SHA256}" && \
     echo Extracting ${HELM_FILENAME}... && \
     tar zxvf ${HELM_FILENAME} && mv /linux-amd64/helm /usr/local/bin/ && \
+    mv /linux-amd64/tiller /usr/local/bin/ && \
     rm ${HELM_FILENAME} && rm -r /linux-amd64
 
 # using the install documentation found at https://kubernetes.io/docs/tasks/tools/install-kubectl/


### PR DESCRIPTION
Put tiller binary on the path in helm v2.X container image so that helm-tiller plugin will use it instead of duplicating the download of helm tarball and performing version check.