### PR TITLE
fix: helmDefaults.timeout and releases[].timeout not working for `helmfile test`

### DIFF
--- a/main.go
+++ b/main.go
@@ -591,6 +591,9 @@ func (c configImpl) Cleanup() bool {
 }
 
 func (c configImpl) Timeout() int {
+	if !c.c.IsSet("timeout") {
+		return state.EmptyTimeout
+	}
 	return c.c.Int("timeout")
 }
 


### PR DESCRIPTION
Fixes #1191