### PR TITLE
Upgrade helm to v3.2.0

### DIFF
--- a/Dockerfile.helm3
+++ b/Dockerfile.helm3
@@ -11,7 +11,7 @@ FROM alpine:3.11
 
 RUN apk add --no-cache ca-certificates git bash curl jq
 
-ARG HELM_VERSION=v3.1.0
+ARG HELM_VERSION=v3.2.0
 ARG HELM_LOCATION="https://get.helm.sh"
 ARG HELM_FILENAME="helm-${HELM_VERSION}-linux-amd64.tar.gz"
 ARG HELM_SHA256="f0fd9fe2b0e09dc9ed190239fce892a468cbb0a2a8fffb9fe846f893c8fd09de"

--- a/Dockerfile.helm3
+++ b/Dockerfile.helm3
@@ -14,7 +14,7 @@ RUN apk add --no-cache ca-certificates git bash curl jq
 ARG HELM_VERSION=v3.2.0
 ARG HELM_LOCATION="https://get.helm.sh"
 ARG HELM_FILENAME="helm-${HELM_VERSION}-linux-amd64.tar.gz"
-ARG HELM_SHA256="f0fd9fe2b0e09dc9ed190239fce892a468cbb0a2a8fffb9fe846f893c8fd09de"
+ARG HELM_SHA256="4c3fd562e64005786ac8f18e7334054a24da34ec04bbd769c206b03b8ed6e457"
 RUN wget ${HELM_LOCATION}/${HELM_FILENAME} && \
     echo Verifying ${HELM_FILENAME}... && \
     sha256sum ${HELM_FILENAME} | grep -q "${HELM_SHA256}" && \


### PR DESCRIPTION
As helmfile v0.114.0 has a new `createNamespace` option, it would be good to have it in the Docker image by default.