### PR TITLE
Allow skipping chart-related operations when `installed: false`

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1142,6 +1142,9 @@ func (a *App) template(r *Run, c TemplateConfigProvider) (bool, []error) {
 	releasesToRender := map[string]state.ReleaseSpec{}
 	for _, r := range toRender {
 		id := state.ReleaseToID(&r)
+		if r.Installed != nil && !*r.Installed {
+			continue
+		}
 		releasesToRender[id] = r
 	}
 

--- a/pkg/app/context.go
+++ b/pkg/app/context.go
@@ -17,6 +17,15 @@ func NewContext() Context {
 func (ctx Context) SyncReposOnce(st *state.HelmState, helm state.RepoUpdater) []error {
 	var errs []error
 
+	hasInstalled := false
+	for _, release := range st.Releases {
+		hasInstalled = hasInstalled && (release.Installed == nil || *release.Installed)
+	}
+
+	if !hasInstalled {
+		return errs
+	}
+
 	allUpdated := true
 	for _, r := range st.Repositories {
 		_, exists := ctx.updatedRepos[r.Name]

--- a/pkg/app/context.go
+++ b/pkg/app/context.go
@@ -19,7 +19,7 @@ func (ctx Context) SyncReposOnce(st *state.HelmState, helm state.RepoUpdater) []
 
 	hasInstalled := false
 	for _, release := range st.Releases {
-		hasInstalled = hasInstalled && (release.Installed == nil || *release.Installed)
+		hasInstalled = hasInstalled || release.Installed == nil || *release.Installed
 	}
 
 	if !hasInstalled {

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -975,6 +975,9 @@ func (st *HelmState) prepareDiffReleases(helm helmexec.Interface, additionalValu
 		if !st.Releases[i].Desired() {
 			continue
 		}
+		if st.Releases[i].Installed != nil && !*(st.Releases[i].Installed) {
+			continue
+		}
 		releases = append(releases, &st.Releases[i])
 	}
 
@@ -1388,6 +1391,10 @@ func (st *HelmState) PrepareReleases(helm helmexec.Interface, helmfileCommand st
 	for i := range st.Releases {
 		release := st.Releases[i]
 
+		if release.Installed != nil && !*release.Installed {
+			continue
+		}
+
 		if _, err := st.triggerPrepareEvent(&release, helmfileCommand); err != nil {
 			errs = append(errs, newReleaseFailedError(&release, err))
 			continue
@@ -1481,6 +1488,10 @@ func (st *HelmState) BuildDeps(helm helmexec.Interface) []error {
 	for _, release := range st.Releases {
 		if len(release.Chart) == 0 {
 			errs = append(errs, errors.New("chart is required for: "+release.Name))
+			continue
+		}
+
+		if release.Installed != nil && !*release.Installed {
 			continue
 		}
 


### PR DESCRIPTION
When install is false, we do not need to update the repositories and get
the chart.

Fix #1232 