### PR TITLE
Use namespace for release unicity with helm3 (#1213)

### DIFF
--- a/pkg/app/mocks_test.go
+++ b/pkg/app/mocks_test.go
@@ -5,6 +5,15 @@ import "github.com/roboll/helmfile/pkg/helmexec"
 type noCallHelmExec struct {
 }
 
+type versionOnlyHelmExec struct {
+	*noCallHelmExec
+	isHelm3 bool
+}
+
+func (helm *versionOnlyHelmExec) IsHelm3() bool {
+	return helm.isHelm3
+}
+
 func (helm *noCallHelmExec) doPanic() {
 	panic("unexpected call to helm")
 }


### PR DESCRIPTION
This is for #1213 so that the releases are considered scoped to their namespace and not to tiller namespace.

Note the open question here: https://github.com/roboll/helmfile/issues/1213#issuecomment-621402678