### PR TITLE
feat: Add global `--debug` flag for passing `--debug` to helm

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,7 +13,6 @@ import (
 	"github.com/roboll/helmfile/pkg/state"
 	"github.com/urfave/cli"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 var logger *zap.SugaredLogger
@@ -22,13 +21,10 @@ func configureLogging(c *cli.Context) error {
 	// Valid levels:
 	// https://github.com/uber-go/zap/blob/7e7e266a8dbce911a49554b945538c5b950196b8/zapcore/level.go#L126
 	logLevel := c.GlobalString("log-level")
-	if c.GlobalBool("quiet") {
+	if c.GlobalBool("debug") {
+		logLevel = "debug"
+	} else if c.GlobalBool("quiet") {
 		logLevel = "warn"
-	}
-	var level zapcore.Level
-	err := level.Set(logLevel)
-	if err != nil {
-		return err
 	}
 	logger = helmexec.NewLogger(os.Stderr, logLevel)
 	if c.App.Metadata == nil {
@@ -75,6 +71,10 @@ func main() {
 		cli.StringFlag{
 			Name:  "kube-context",
 			Usage: "Set kubectl context. Uses current context by default",
+		},
+		cli.BoolFlag{
+			Name:  "debug",
+			Usage: "Enable verbose output for Helm and set log-level to debug, this disables --quiet/-q effect",
 		},
 		cli.BoolFlag{
 			Name:  "no-color",
@@ -539,7 +539,13 @@ func (c configImpl) Values() []string {
 }
 
 func (c configImpl) Args() string {
-	return c.c.String("args")
+	args := c.c.String("args")
+	enableHelmDebug := c.c.GlobalBool("debug")
+
+	if enableHelmDebug {
+		args = fmt.Sprintf("%s %s", args, "--debug")
+	}
+	return args
 }
 
 func (c configImpl) OutputDir() string {


### PR DESCRIPTION
Added a global flag `—debug`  that sets the logging level to debug and passes the global flag `—debug` to Helm through subcommands’ `—args`. See: https://github.com/roboll/helmfile/issues/1104

- Helm accepts the redundancy of the global flag `--debug`
- argparser.GetArgs gets rid of the redundancy which seems to be used to parse all —args
- what do you think about adding an Args field to `state.ReleaseSpec` ?
- what about adding a `Debug` (as we do for `—atomic` and `—wait` e.g.) into `state.HelmSpec` `state.ReleaseSpec` for more granularity ?
- sth still prevents the debug output from being displayed into stdout
- tests
