### PR TITLE
Error when subhelmfiles do not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,9 @@ helmfiles:
   # The nested-state file is locally checked-out along with the remote directory containing it.
   # Therefore all the local paths in the file are resolved relative to the file
   path: git::https://github.com/cloudposse/helmfiles.git@releases/kiam.yaml?ref=0.40.0
+# If set to "Error", return an error when a subhelmfile points to a
+# non-existent path. The default behavior is to print a warning and continue.
+missingFileHandler: Error
 
 #
 # Advanced Configuration: Environments

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -73,6 +73,11 @@ type HelmState struct {
 
 	runner      helmexec.Runner
 	valsRuntime vals.Evaluator
+
+	// If set to "Error", return an error when a subhelmfile points to a
+	// non-existent path. The default behavior is to print a warning. Note the
+	// differing default compared to other MissingFileHandlers.
+	MissingFileHandler string `yaml:"missingFileHandler"`
 }
 
 // SubHelmfileSpec defines the subhelmfile path and options
@@ -1790,6 +1795,11 @@ func (st *HelmState) ExpandedHelmfiles() ([]SubHelmfileSpec, error) {
 			return nil, err
 		}
 		if len(matches) == 0 {
+			err := fmt.Errorf("no matches for path: %s", hf.Path)
+			if st.MissingFileHandler == "Error" {
+				return nil, err
+			}
+			fmt.Println(err)
 			continue
 		}
 		for _, match := range matches {


### PR DESCRIPTION
This prevents typos in sub-helmfile paths from silently preventing operations from running.