### PR TITLE
README: Add note about environment variable types

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,10 @@ releases:
         value: {{ env "SCHEME" | default "https" }}
 ```
 
+### Note
+
+If you wish to treat your enviroment variables as strings always, even if they are boolean or numeric values you can use `{{ env "ENV_NAME" | quote }}` or `"{{ env "ENV_NAME" }}"`. These approaches also work with `requiredEnv`.
+
 ## installation
 
 - download one of [releases](https://github.com/roboll/helmfile/releases) or


### PR DESCRIPTION
Fixes https://github.com/roboll/helmfile/issues/1248

This can bite you if you have values that are dynamic, in my case a git sha, where sometimes the templating losses information that a string would preserve. I could see this being a mistake that other people fall into so I wanted to add this note to the docs.