### PR TITLE
Fixed part splitting for CRLF separated files

### DIFF
--- a/pkg/app/desired_state_file_loader.go
+++ b/pkg/app/desired_state_file_loader.go
@@ -173,7 +173,9 @@ func (a *desiredStateLoader) load(yaml []byte, baseDir, file string, evaluateBas
 }
 
 func (ld *desiredStateLoader) renderAndLoad(env, overrodeEnv *environment.Environment, baseDir, filename string, content []byte, evaluateBases bool) (*state.HelmState, error) {
-	parts := bytes.Split(content, []byte("\n---\n"))
+	// Allows part-splitting to work with CLRF-ed content
+	normalizedContent := bytes.ReplaceAll(content, []byte("\r\n"), []byte("\n"))
+	parts := bytes.Split(normalizedContent, []byte("\n---\n"))
 
 	var finalState *state.HelmState
 


### PR DESCRIPTION
Fixes https://github.com/roboll/helmfile/issues/1142

desired_state_file_loader.go
- Will now normalize the content before splitting it to parts

context:
Me & and a fellow dev have tried to figure out why helmfile didn't fill in certain values on his machine; 
turns out, he'd mistakenly checked out our project w/ CRLF line endings, which had caused part splitting to not work (as it's hard coded to look for '\n').

The following was acted on as a single part, causing values from the bases not to be available in the next yaml part:

```
bases:\r\n
  - base.yaml\r\n
---\r\n

releases:
  - name: external-secrets-crd
    ... some templated yaml ...
```

I've thought about regex-ing it out instead of replace-all, but benchmarks had shown that a plain replace is faster.

I've also considered splitting by "\n---" instead of "\n---", but that would break if the dashes were to continue with some other text.