### PR TITLE
fix: Follow-up fixes for #1172

### DIFF
--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -89,3 +89,49 @@ At this point, Helmfile can generate a complete kustomization from the base kust
 which can be included in the temporary chart.
 
 After all, Helmfile just installs the temporary chart like standard charts, which allows you to manage everything with Helmfile regardless of each app is declared using a Helm chart or a kustomization.
+
+Please also see [test/advanced/helmfile.yaml](https://github.com/roboll/helmfile/tree/master/test/advanced/helmfile.yaml) for an example of kustomization support and more.
+
+## Adhoc Customization of Helm charts
+
+You can add/update any Kubernetes resource field rendered from a Helm chart by specifying `releases[].strategicMergePatches`:
+
+```
+repositories:
+- name: incubator
+  url: https://kubernetes-charts-incubator.storage.googleapis.com
+
+releases:
+- name: raw1
+  chart: incubator/raw
+  values:
+  - resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: raw1
+        namespace: default
+      data:
+        foo: FOO
+  strategicMergePatches:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: raw1
+        namespace: default
+      data:
+        bar: BAR
+```
+
+Running `helmfile template` on the above example results in a ConfigMap called `raw` whose `data` is:
+
+```yaml
+foo: FOO
+bar: BAR
+```
+
+Please note that the second `data` field `bar` is coming from the strategic-merge patch defined in the above helmfile.yaml.
+
+There's also `releases[].jsonPatches` that works similarly to `strategicMergePatches` but has additional capability to remove fields.
+
+Please also see [test/advanced/helmfile.yaml](https://github.com/roboll/helmfile/tree/master/test/advanced/helmfile.yaml) for an example of patching support and more.

--- a/pkg/state/helmx.go
+++ b/pkg/state/helmx.go
@@ -3,6 +3,8 @@ package state
 import (
 	"github.com/roboll/helmfile/pkg/helmexec"
 	"github.com/variantdev/chartify"
+	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -28,6 +30,13 @@ func (st *HelmState) PrepareChartify(helm helmexec.Interface, release *ReleaseSp
 	opts.EnableKustomizeAlphaPlugins = true
 
 	opts.ChartVersion = release.Version
+
+	dir := filepath.Join(st.basePath, release.Chart)
+	if stat, _ := os.Stat(dir); stat != nil && stat.IsDir() {
+		if exists, err := st.fileExists(filepath.Join(dir, "Chart.yaml")); err == nil && !exists {
+			shouldRun = true
+		}
+	}
 
 	for _, d := range release.Dependencies {
 		var dep string

--- a/test/advanced/helmfile.yaml
+++ b/test/advanced/helmfile.yaml
@@ -1,0 +1,49 @@
+repositories:
+- name: incubator
+  url: https://kubernetes-charts-incubator.storage.googleapis.com
+
+releases:
+- name: kustomapp
+  chart: ./kustomapp
+  values:
+  - namePrefix: kustomapp-
+- name: raw1
+  chart: incubator/raw
+  values:
+  - resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: raw1
+        namespace: default
+      data:
+        foo: FOO
+  strategicMergePatches:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: raw1
+        namespace: default
+      data:
+        bar: BAR
+- name: raw2
+  chart: incubator/raw
+  values:
+  - resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: raw2
+        namespace: default
+      data:
+        foo: FOO
+  jsonPatches:
+  - target:
+      version: v1
+      kind: ConfigMap
+      name: raw2
+      namespace: default
+    patch:
+      - op: replace
+        path: /data/baz
+        value: "BAZ"

--- a/test/advanced/kustomapp/all.yaml
+++ b/test/advanced/kustomapp/all.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kustomapp
+  namespace: default
+data:
+  kustomappfoo: FOO

--- a/test/advanced/kustomapp/kustomization.yaml
+++ b/test/advanced/kustomapp/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- all.yaml

--- a/test/advanced/kustomapp2/all.yaml
+++ b/test/advanced/kustomapp2/all.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kustomapp2
+  namespace: default
+data:
+  kustomappfoo: FOO

--- a/test/advanced/kustomapp2/kustomization.yaml
+++ b/test/advanced/kustomapp2/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- all.yaml


### PR DESCRIPTION
Fixes:

- Do not skip passing values files when releases[].adhocDependencies/jsonPatches/jsonPatches exist
- Fix the bug that resulted in any such release to ignore the chart version number specified in helmfile.yaml
- Fix the issue that kustomization has not been properly chartified when a kustomization is specified on `releases[].chart` but there were no `releases[].strategicMergePatches` and `jsonPatches` specified

This is a follow-up PR for #1172