### PR TITLE
Fix missing resources in `hemlfile template` with jsonPatches

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/r3labs/diff v0.0.0-20190801153147-a71de73c46ad
 	github.com/tatsushid/go-prettytable v0.0.0-20141013043238-ed2d14c29939
 	github.com/urfave/cli v1.20.0
-	github.com/variantdev/chartify v0.3.3
+	github.com/variantdev/chartify v0.3.7
 	github.com/variantdev/dag v0.0.0-20191028002400-bb0b3c785363
 	github.com/variantdev/vals v0.4.1-0.20200501114609-9cebe482281c
 	go.mozilla.org/sops v0.0.0-20190912205235-14a22d7a7060 // indirect

--- a/go.sum
+++ b/go.sum
@@ -801,6 +801,14 @@ github.com/variantdev/chartify v0.3.2 h1:EjwlY/ArgkOhsvbMG+xyeBnsWRV6eaxfHfJj9st
 github.com/variantdev/chartify v0.3.2/go.mod h1:0tw+4doFHsNnhttYx7I9Pv/dsZ82BD4UuTV9saBOcfw=
 github.com/variantdev/chartify v0.3.3 h1:qKi5Rw4A9TfZ2oedQIop4rcHfiToraakWIdn1rZJyLo=
 github.com/variantdev/chartify v0.3.3/go.mod h1:0tw+4doFHsNnhttYx7I9Pv/dsZ82BD4UuTV9saBOcfw=
+github.com/variantdev/chartify v0.3.4 h1:1KAUAtK4AZ1/N+Hy3YNN2w+6Yl/BoDSdyYTGuODhNz0=
+github.com/variantdev/chartify v0.3.4/go.mod h1:0tw+4doFHsNnhttYx7I9Pv/dsZ82BD4UuTV9saBOcfw=
+github.com/variantdev/chartify v0.3.5 h1:5lH6eJXlhfWT7vQ+OGtRlocgRwZriIrge5OAGFMKs4M=
+github.com/variantdev/chartify v0.3.5/go.mod h1:0tw+4doFHsNnhttYx7I9Pv/dsZ82BD4UuTV9saBOcfw=
+github.com/variantdev/chartify v0.3.6 h1:FQOcc0ikcf2yni+75STkKu68Qz2zoyqJSxDDc6xH1X4=
+github.com/variantdev/chartify v0.3.6/go.mod h1:0tw+4doFHsNnhttYx7I9Pv/dsZ82BD4UuTV9saBOcfw=
+github.com/variantdev/chartify v0.3.7 h1:4bnmhnnjqkGAbUAn2ZZkyz+LJfQLbWv2YGmpt/4NfK0=
+github.com/variantdev/chartify v0.3.7/go.mod h1:0tw+4doFHsNnhttYx7I9Pv/dsZ82BD4UuTV9saBOcfw=
 github.com/variantdev/dag v0.0.0-20191028002400-bb0b3c785363 h1:KrfQBEUn+wEOQ/6UIfoqRDvn+Q/wZridQ7t0G1vQqKE=
 github.com/variantdev/dag v0.0.0-20191028002400-bb0b3c785363/go.mod h1:pH1TQsNSLj2uxMo9NNl9zdGy01Wtn+/2MT96BrKmVyE=
 github.com/variantdev/vals v0.4.0 h1:O1O7/sWhlvozcY2DjZBzlE1notxwVo6UBT1+w7HsO/k=

--- a/pkg/state/helmx.go
+++ b/pkg/state/helmx.go
@@ -25,6 +25,8 @@ func (st *HelmState) appendHelmXFlags(flags []string, release *ReleaseSpec) ([]s
 func (st *HelmState) PrepareChartify(helm helmexec.Interface, release *ReleaseSpec, workerIndex int) (bool, *chartify.ChartifyOpts, error) {
 	var opts chartify.ChartifyOpts
 
+	opts.WorkaroundOutputDirIssue = true
+
 	var shouldRun bool
 
 	opts.EnableKustomizeAlphaPlugins = true


### PR DESCRIPTION
Probably this has been affecting strategicMergePatches and dependencies as well, as the source of the problem is the underlying common feature called helm-x that previsouly used `helm template --output-dir`, which turned out to be not working as intended.

Ref #1279