### PR TITLE
fix: Do not include stderr content in result of `{{ exec }}`

### DIFF
--- a/pkg/helmexec/exit_error.go
+++ b/pkg/helmexec/exit_error.go
@@ -5,19 +5,55 @@ import (
 	"strings"
 )
 
-func newExitError(helmCmdPath string, exitStatus int, errorMessage string) ExitError {
+func newExitError(path string, args []string, exitStatus int, err error, stderr, combined string) ExitError {
+	var out string
+
+	out += fmt.Sprintf("PATH:\n%s", Indent(path, "  "))
+
+	out += "\n\nARGS:"
+	for i, a := range args {
+		out += fmt.Sprintf("\n%s", Indent(fmt.Sprintf("%d: %s (%d bytes)", i, a, len(a)), "  "))
+	}
+
+	out += fmt.Sprintf("\n\nERROR:\n%s", Indent(err.Error(), "  "))
+
+	out += fmt.Sprintf("\n\nEXIT STATUS\n%s", Indent(fmt.Sprintf("%d", exitStatus), "  "))
+
+	if len(stderr) > 0 {
+		out += fmt.Sprintf("\n\nSTDERR:\n%s", Indent(stderr, "  "))
+	}
+
+	if len(combined) > 0 {
+		out += fmt.Sprintf("\n\nCOMBINED OUTPUT:\n%s", Indent(combined, "  "))
+	}
+
 	return ExitError{
-		Message: fmt.Sprintf("the following cmd exited with status %d:\n%s\n\n%s", exitStatus, indent(strings.TrimSpace(helmCmdPath)), indent(strings.TrimSpace(errorMessage))),
+		Message: fmt.Sprintf("command %q exited with non-zero status:\n\n%s", path, out),
 		Code:    exitStatus,
 	}
 }
 
-func indent(text string) string {
+// indents a block of text with an indent string
+func Indent(text, indent string) string {
+	var b strings.Builder
+
+	b.Grow(len(text) * 2)
+
 	lines := strings.Split(text, "\n")
-	for i := range lines {
-		lines[i] = "  " + lines[i]
+
+	last := len(lines) - 1
+
+	for i, j := range lines {
+		if i > 0 && i < last && j != "" {
+			b.WriteString("\n")
+		}
+
+		if j != "" {
+			b.WriteString(indent + j)
+		}
 	}
-	return strings.Join(lines, "\n")
+
+	return b.String()
 }
 
 // ExitError is created whenever your shell command exits with a non-zero exit status

--- a/pkg/tmpl/context_funcs.go
+++ b/pkg/tmpl/context_funcs.go
@@ -2,6 +2,7 @@ package tmpl
 
 import (
 	"fmt"
+	"github.com/roboll/helmfile/pkg/helmexec"
 	"golang.org/x/sync/errgroup"
 	"gopkg.in/yaml.v2"
 	"io"
@@ -97,25 +98,9 @@ func (c *Context) Exec(command string, args []interface{}, inputs ...string) (st
 	g.Go(func() error {
 		// We use CombinedOutput to produce helpful error messages
 		// See https://github.com/roboll/helmfile/issues/1158
-		bs, err := cmd.CombinedOutput()
+		bs, err := helmexec.Output(cmd)
 		if err != nil {
-			args := strings.Join(strArgs, ", ")
-			shownCmd := []string{command}
-			if len(args) > 0 {
-				shownCmd = append(shownCmd, args)
-			}
-
-			var out string
-
-			out += fmt.Sprintf("\n\nCOMMAND:\n%s", Indent(strings.Join(shownCmd, " "), "  "))
-
-			out += fmt.Sprintf("\n\nERROR:\n%s", Indent(err.Error(), "  "))
-
-			if len(bs) > 0 {
-				out += fmt.Sprintf("\n\nCOMBINED OUTPUT:\n%s", Indent(string(bs), "  "))
-			}
-
-			return fmt.Errorf("%v%s", err, out)
+			return err
 		}
 
 		bytes = bs
@@ -128,29 +113,6 @@ func (c *Context) Exec(command string, args []interface{}, inputs ...string) (st
 	}
 
 	return string(bytes), nil
-}
-
-// indents a block of text with an indent string
-func Indent(text, indent string) string {
-	var b strings.Builder
-
-	b.Grow(len(text) * 2)
-
-	lines := strings.Split(text, "\n")
-
-	last := len(lines) - 1
-
-	for i, j := range lines {
-		if i > 0 && i < last && j != "" {
-			b.WriteString("\n")
-		}
-
-		if j != "" {
-			b.WriteString(indent + j)
-		}
-	}
-
-	return b.String()
 }
 
 func (c *Context) ReadFile(filename string) (string, error) {


### PR DESCRIPTION
Seems like this was a regression since https://github.com/roboll/helmfile/commit/f676c6142520364553c6a574fb976eeb0c31a456 and #1159
Fixes #1258