### PR TITLE
Bump variantdev/vals to 0.6.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/urfave/cli v1.20.0
 	github.com/variantdev/chartify v0.3.7
 	github.com/variantdev/dag v0.0.0-20191028002400-bb0b3c785363
-	github.com/variantdev/vals v0.4.1-0.20200501114609-9cebe482281c
+	github.com/variantdev/vals v0.6.0
 	go.mozilla.org/sops v0.0.0-20190912205235-14a22d7a7060 // indirect
 	go.uber.org/multierr v1.1.0
 	go.uber.org/zap v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -817,6 +817,8 @@ github.com/variantdev/vals v0.4.0 h1:O1O7/sWhlvozcY2DjZBzlE1notxwVo6UBT1+w7HsO/k
 github.com/variantdev/vals v0.4.0/go.mod h1:28iJwAamsfHevGLXO7QKmVWmwa79xM06sRjw8eGY73U=
 github.com/variantdev/vals v0.4.1-0.20200501114609-9cebe482281c h1:ODJGhYOTMQJ1s+aeVzFsoJc/2MnseLhMdgB+/mykXe0=
 github.com/variantdev/vals v0.4.1-0.20200501114609-9cebe482281c/go.mod h1:IfLBErvsyYBQU0Jobuzfmft46K0MG0sLO6xz9o9KZdY=
+github.com/variantdev/vals v0.6.0 h1:PcAK0n+tQ7Xu4EorKcgf8B2Xo3PjGm4Ryfv3sikQsy8=
+github.com/variantdev/vals v0.6.0/go.mod h1:28iJwAamsfHevGLXO7QKmVWmwa79xM06sRjw8eGY73U=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.etcd.io/bbolt v1.3.2 h1:Z/90sZLPOeCy2PwprqkFa25PdkusRzaj9P8zm/KNyvk=


### PR DESCRIPTION
- Add `version` parameter for Vault provider
- Add `profile` parameter for AWS SSM/SecretsManager provider
= Add `version` parameter for AWS SSM Parameter Store provider
- Add support for app-role authentication when using Vault provider