### PR TITLE
Fix kubeContext per release override

### DIFF
--- a/pkg/helmexec/exec.go
+++ b/pkg/helmexec/exec.go
@@ -365,7 +365,7 @@ func (helm *execer) exec(args []string, env map[string]string) ([]byte, error) {
 		cmdargs = append(cmdargs, helm.extra...)
 	}
 	if helm.kubeContext != "" {
-		cmdargs = append(cmdargs, "--kube-context", helm.kubeContext)
+		cmdargs = append([]string{"--kube-context", helm.kubeContext}, cmdargs...)
 	}
 	cmd := fmt.Sprintf("exec: %s %s", helm.helmBinary, strings.Join(cmdargs, " "))
 	helm.logger.Debug(cmd)

--- a/pkg/helmexec/exec_test.go
+++ b/pkg/helmexec/exec_test.go
@@ -77,8 +77,8 @@ func Test_AddRepo(t *testing.T) {
 	helm := MockExecer(logger, "dev")
 	helm.AddRepo("myRepo", "https://repo.example.com/", "", "cert.pem", "key.pem", "", "")
 	expected := `Adding repo myRepo https://repo.example.com/
-exec: helm repo add myRepo https://repo.example.com/ --cert-file cert.pem --key-file key.pem --kube-context dev
-exec: helm repo add myRepo https://repo.example.com/ --cert-file cert.pem --key-file key.pem --kube-context dev: 
+exec: helm --kube-context dev repo add myRepo https://repo.example.com/ --cert-file cert.pem --key-file key.pem
+exec: helm --kube-context dev repo add myRepo https://repo.example.com/ --cert-file cert.pem --key-file key.pem: 
 `
 	if buffer.String() != expected {
 		t.Errorf("helmexec.AddRepo()\nactual = %v\nexpect = %v", buffer.String(), expected)
@@ -87,8 +87,8 @@ exec: helm repo add myRepo https://repo.example.com/ --cert-file cert.pem --key-
 	buffer.Reset()
 	helm.AddRepo("myRepo", "https://repo.example.com/", "ca.crt", "", "", "", "")
 	expected = `Adding repo myRepo https://repo.example.com/
-exec: helm repo add myRepo https://repo.example.com/ --ca-file ca.crt --kube-context dev
-exec: helm repo add myRepo https://repo.example.com/ --ca-file ca.crt --kube-context dev: 
+exec: helm --kube-context dev repo add myRepo https://repo.example.com/ --ca-file ca.crt
+exec: helm --kube-context dev repo add myRepo https://repo.example.com/ --ca-file ca.crt: 
 `
 	if buffer.String() != expected {
 		t.Errorf("helmexec.AddRepo()\nactual = %v\nexpect = %v", buffer.String(), expected)
@@ -97,8 +97,8 @@ exec: helm repo add myRepo https://repo.example.com/ --ca-file ca.crt --kube-con
 	buffer.Reset()
 	helm.AddRepo("myRepo", "https://repo.example.com/", "", "", "", "", "")
 	expected = `Adding repo myRepo https://repo.example.com/
-exec: helm repo add myRepo https://repo.example.com/ --kube-context dev
-exec: helm repo add myRepo https://repo.example.com/ --kube-context dev: 
+exec: helm --kube-context dev repo add myRepo https://repo.example.com/
+exec: helm --kube-context dev repo add myRepo https://repo.example.com/: 
 `
 	if buffer.String() != expected {
 		t.Errorf("helmexec.AddRepo()\nactual = %v\nexpect = %v", buffer.String(), expected)
@@ -107,8 +107,8 @@ exec: helm repo add myRepo https://repo.example.com/ --kube-context dev:
 	buffer.Reset()
 	helm.AddRepo("myRepo", "https://repo.example.com/", "", "", "", "example_user", "example_password")
 	expected = `Adding repo myRepo https://repo.example.com/
-exec: helm repo add myRepo https://repo.example.com/ --username example_user --password example_password --kube-context dev
-exec: helm repo add myRepo https://repo.example.com/ --username example_user --password example_password --kube-context dev: 
+exec: helm --kube-context dev repo add myRepo https://repo.example.com/ --username example_user --password example_password
+exec: helm --kube-context dev repo add myRepo https://repo.example.com/ --username example_user --password example_password: 
 `
 	if buffer.String() != expected {
 		t.Errorf("helmexec.AddRepo()\nactual = %v\nexpect = %v", buffer.String(), expected)
@@ -130,8 +130,8 @@ func Test_UpdateRepo(t *testing.T) {
 	helm := MockExecer(logger, "dev")
 	helm.UpdateRepo()
 	expected := `Updating repo
-exec: helm repo update --kube-context dev
-exec: helm repo update --kube-context dev: 
+exec: helm --kube-context dev repo update
+exec: helm --kube-context dev repo update: 
 `
 	if buffer.String() != expected {
 		t.Errorf("helmexec.UpdateRepo()\nactual = %v\nexpect = %v", buffer.String(), expected)
@@ -144,8 +144,8 @@ func Test_SyncRelease(t *testing.T) {
 	helm := MockExecer(logger, "dev")
 	helm.SyncRelease(HelmContext{}, "release", "chart", "--timeout 10", "--wait")
 	expected := `Upgrading release=release, chart=chart
-exec: helm upgrade --install --reset-values release chart --timeout 10 --wait --kube-context dev
-exec: helm upgrade --install --reset-values release chart --timeout 10 --wait --kube-context dev: 
+exec: helm --kube-context dev upgrade --install --reset-values release chart --timeout 10 --wait
+exec: helm --kube-context dev upgrade --install --reset-values release chart --timeout 10 --wait: 
 `
 	if buffer.String() != expected {
 		t.Errorf("helmexec.SyncRelease()\nactual = %v\nexpect = %v", buffer.String(), expected)
@@ -154,8 +154,8 @@ exec: helm upgrade --install --reset-values release chart --timeout 10 --wait --
 	buffer.Reset()
 	helm.SyncRelease(HelmContext{}, "release", "chart")
 	expected = `Upgrading release=release, chart=chart
-exec: helm upgrade --install --reset-values release chart --kube-context dev
-exec: helm upgrade --install --reset-values release chart --kube-context dev: 
+exec: helm --kube-context dev upgrade --install --reset-values release chart
+exec: helm --kube-context dev upgrade --install --reset-values release chart: 
 `
 	if buffer.String() != expected {
 		t.Errorf("helmexec.SyncRelease()\nactual = %v\nexpect = %v", buffer.String(), expected)
@@ -169,8 +169,8 @@ func Test_SyncReleaseTillerless(t *testing.T) {
 	helm.SyncRelease(HelmContext{Tillerless: true, TillerNamespace: "foo"}, "release", "chart",
 		"--timeout 10", "--wait")
 	expected := `Upgrading release=release, chart=chart
-exec: helm tiller run foo -- helm upgrade --install --reset-values release chart --timeout 10 --wait --kube-context dev
-exec: helm tiller run foo -- helm upgrade --install --reset-values release chart --timeout 10 --wait --kube-context dev: 
+exec: helm --kube-context dev tiller run foo -- helm upgrade --install --reset-values release chart --timeout 10 --wait
+exec: helm --kube-context dev tiller run foo -- helm upgrade --install --reset-values release chart --timeout 10 --wait: 
 `
 	if buffer.String() != expected {
 		t.Errorf("helmexec.SyncRelease()\nactual = %v\nexpect = %v", buffer.String(), expected)
@@ -183,8 +183,8 @@ func Test_UpdateDeps(t *testing.T) {
 	helm := MockExecer(logger, "dev")
 	helm.UpdateDeps("./chart/foo")
 	expected := `Updating dependency ./chart/foo
-exec: helm dependency update ./chart/foo --kube-context dev
-exec: helm dependency update ./chart/foo --kube-context dev: 
+exec: helm --kube-context dev dependency update ./chart/foo
+exec: helm --kube-context dev dependency update ./chart/foo: 
 `
 	if buffer.String() != expected {
 		t.Errorf("helmexec.UpdateDeps()\nactual = %v\nexpect = %v", buffer.String(), expected)
@@ -194,8 +194,8 @@ exec: helm dependency update ./chart/foo --kube-context dev:
 	helm.SetExtraArgs("--verify")
 	helm.UpdateDeps("./chart/foo")
 	expected = `Updating dependency ./chart/foo
-exec: helm dependency update ./chart/foo --verify --kube-context dev
-exec: helm dependency update ./chart/foo --verify --kube-context dev: 
+exec: helm --kube-context dev dependency update ./chart/foo --verify
+exec: helm --kube-context dev dependency update ./chart/foo --verify: 
 `
 	if buffer.String() != expected {
 		t.Errorf("helmexec.AddRepo()\nactual = %v\nexpect = %v", buffer.String(), expected)
@@ -208,8 +208,8 @@ func Test_BuildDeps(t *testing.T) {
 	helm := MockExecer(logger, "dev")
 	helm.BuildDeps("foo", "./chart/foo")
 	expected := `Building dependency release=foo, chart=./chart/foo
-exec: helm dependency build ./chart/foo --kube-context dev
-exec: helm dependency build ./chart/foo --kube-context dev: 
+exec: helm --kube-context dev dependency build ./chart/foo
+exec: helm --kube-context dev dependency build ./chart/foo: 
 `
 	if buffer.String() != expected {
 		t.Errorf("helmexec.BuildDeps()\nactual = %v\nexpect = %v", buffer.String(), expected)
@@ -219,8 +219,8 @@ exec: helm dependency build ./chart/foo --kube-context dev:
 	helm.SetExtraArgs("--verify")
 	helm.BuildDeps("foo", "./chart/foo")
 	expected = `Building dependency release=foo, chart=./chart/foo
-exec: helm dependency build ./chart/foo --verify --kube-context dev
-exec: helm dependency build ./chart/foo --verify --kube-context dev: 
+exec: helm --kube-context dev dependency build ./chart/foo --verify
+exec: helm --kube-context dev dependency build ./chart/foo --verify: 
 `
 	if buffer.String() != expected {
 		t.Errorf("helmexec.BuildDeps()\nactual = %v\nexpect = %v", buffer.String(), expected)
@@ -241,8 +241,8 @@ func Test_DecryptSecret(t *testing.T) {
 
 	expected := fmt.Sprintf(`Preparing to decrypt secret %v/secretName
 Decrypting secret %s/secretName
-exec: helm secrets dec %s/secretName --kube-context dev
-exec: helm secrets dec %s/secretName --kube-context dev: 
+exec: helm --kube-context dev secrets dec %s/secretName
+exec: helm --kube-context dev secrets dec %s/secretName: 
 Preparing to decrypt secret %s/secretName
 Found secret in cache %s/secretName
 `, cwd, cwd, cwd, cwd, cwd, cwd)
@@ -257,8 +257,8 @@ func Test_DiffRelease(t *testing.T) {
 	helm := MockExecer(logger, "dev")
 	helm.DiffRelease(HelmContext{}, "release", "chart", false, "--timeout 10", "--wait")
 	expected := `Comparing release=release, chart=chart
-exec: helm diff upgrade --reset-values --allow-unreleased release chart --timeout 10 --wait --kube-context dev
-exec: helm diff upgrade --reset-values --allow-unreleased release chart --timeout 10 --wait --kube-context dev: 
+exec: helm --kube-context dev diff upgrade --reset-values --allow-unreleased release chart --timeout 10 --wait
+exec: helm --kube-context dev diff upgrade --reset-values --allow-unreleased release chart --timeout 10 --wait: 
 `
 	if buffer.String() != expected {
 		t.Errorf("helmexec.DiffRelease()\nactual = %v\nexpect = %v", buffer.String(), expected)
@@ -267,8 +267,8 @@ exec: helm diff upgrade --reset-values --allow-unreleased release chart --timeou
 	buffer.Reset()
 	helm.DiffRelease(HelmContext{}, "release", "chart", false)
 	expected = `Comparing release=release, chart=chart
-exec: helm diff upgrade --reset-values --allow-unreleased release chart --kube-context dev
-exec: helm diff upgrade --reset-values --allow-unreleased release chart --kube-context dev: 
+exec: helm --kube-context dev diff upgrade --reset-values --allow-unreleased release chart
+exec: helm --kube-context dev diff upgrade --reset-values --allow-unreleased release chart: 
 `
 	if buffer.String() != expected {
 		t.Errorf("helmexec.DiffRelease()\nactual = %v\nexpect = %v", buffer.String(), expected)
@@ -281,8 +281,8 @@ func Test_DiffReleaseTillerless(t *testing.T) {
 	helm := MockExecer(logger, "dev")
 	helm.DiffRelease(HelmContext{Tillerless: true}, "release", "chart", false, "--timeout 10", "--wait")
 	expected := `Comparing release=release, chart=chart
-exec: helm tiller run -- helm diff upgrade --reset-values --allow-unreleased release chart --timeout 10 --wait --kube-context dev
-exec: helm tiller run -- helm diff upgrade --reset-values --allow-unreleased release chart --timeout 10 --wait --kube-context dev: 
+exec: helm --kube-context dev tiller run -- helm diff upgrade --reset-values --allow-unreleased release chart --timeout 10 --wait
+exec: helm --kube-context dev tiller run -- helm diff upgrade --reset-values --allow-unreleased release chart --timeout 10 --wait: 
 `
 	if buffer.String() != expected {
 		t.Errorf("helmexec.DiffRelease()\nactual = %v\nexpect = %v", buffer.String(), expected)
@@ -295,8 +295,8 @@ func Test_DeleteRelease(t *testing.T) {
 	helm := MockExecer(logger, "dev")
 	helm.DeleteRelease(HelmContext{}, "release")
 	expected := `Deleting release
-exec: helm delete release --kube-context dev
-exec: helm delete release --kube-context dev: 
+exec: helm --kube-context dev delete release
+exec: helm --kube-context dev delete release: 
 `
 	if buffer.String() != expected {
 		t.Errorf("helmexec.DeleteRelease()\nactual = %v\nexpect = %v", buffer.String(), expected)
@@ -308,8 +308,8 @@ func Test_DeleteRelease_Flags(t *testing.T) {
 	helm := MockExecer(logger, "dev")
 	helm.DeleteRelease(HelmContext{}, "release", "--purge")
 	expected := `Deleting release
-exec: helm delete release --purge --kube-context dev
-exec: helm delete release --purge --kube-context dev: 
+exec: helm --kube-context dev delete release --purge
+exec: helm --kube-context dev delete release --purge: 
 `
 	if buffer.String() != expected {
 		t.Errorf("helmexec.DeleteRelease()\nactual = %v\nexpect = %v", buffer.String(), expected)
@@ -322,8 +322,8 @@ func Test_TestRelease(t *testing.T) {
 	helm := MockExecer(logger, "dev")
 	helm.TestRelease(HelmContext{}, "release")
 	expected := `Testing release
-exec: helm test release --kube-context dev
-exec: helm test release --kube-context dev: 
+exec: helm --kube-context dev test release
+exec: helm --kube-context dev test release: 
 `
 	if buffer.String() != expected {
 		t.Errorf("helmexec.TestRelease()\nactual = %v\nexpect = %v", buffer.String(), expected)
@@ -335,8 +335,8 @@ func Test_TestRelease_Flags(t *testing.T) {
 	helm := MockExecer(logger, "dev")
 	helm.TestRelease(HelmContext{}, "release", "--cleanup", "--timeout", "60")
 	expected := `Testing release
-exec: helm test release --cleanup --timeout 60 --kube-context dev
-exec: helm test release --cleanup --timeout 60 --kube-context dev: 
+exec: helm --kube-context dev test release --cleanup --timeout 60
+exec: helm --kube-context dev test release --cleanup --timeout 60: 
 `
 	if buffer.String() != expected {
 		t.Errorf("helmexec.TestRelease()\nactual = %v\nexpect = %v", buffer.String(), expected)
@@ -349,8 +349,8 @@ func Test_ReleaseStatus(t *testing.T) {
 	helm := MockExecer(logger, "dev")
 	helm.ReleaseStatus(HelmContext{}, "myRelease")
 	expected := `Getting status myRelease
-exec: helm status myRelease --kube-context dev
-exec: helm status myRelease --kube-context dev: 
+exec: helm --kube-context dev status myRelease
+exec: helm --kube-context dev status myRelease: 
 `
 	if buffer.String() != expected {
 		t.Errorf("helmexec.ReleaseStatus()\nactual = %v\nexpect = %v", buffer.String(), expected)
@@ -379,8 +379,8 @@ exec: helm version:
 	buffer.Reset()
 	helm = MockExecer(logger, "dev")
 	helm.exec([]string{"diff", "release", "chart", "--timeout 10", "--wait"}, env)
-	expected = `exec: helm diff release chart --timeout 10 --wait --kube-context dev
-exec: helm diff release chart --timeout 10 --wait --kube-context dev: 
+	expected = `exec: helm --kube-context dev diff release chart --timeout 10 --wait
+exec: helm --kube-context dev diff release chart --timeout 10 --wait: 
 `
 	if buffer.String() != expected {
 		t.Errorf("helmexec.exec()\nactual = %v\nexpect = %v", buffer.String(), expected)
@@ -388,8 +388,8 @@ exec: helm diff release chart --timeout 10 --wait --kube-context dev:
 
 	buffer.Reset()
 	helm.exec([]string{"version"}, env)
-	expected = `exec: helm version --kube-context dev
-exec: helm version --kube-context dev: 
+	expected = `exec: helm --kube-context dev version
+exec: helm --kube-context dev version: 
 `
 	if buffer.String() != expected {
 		t.Errorf("helmexec.exec()\nactual = %v\nexpect = %v", buffer.String(), expected)
@@ -398,8 +398,8 @@ exec: helm version --kube-context dev:
 	buffer.Reset()
 	helm.SetExtraArgs("foo")
 	helm.exec([]string{"version"}, env)
-	expected = `exec: helm version foo --kube-context dev
-exec: helm version foo --kube-context dev: 
+	expected = `exec: helm --kube-context dev version foo
+exec: helm --kube-context dev version foo: 
 `
 	if buffer.String() != expected {
 		t.Errorf("helmexec.exec()\nactual = %v\nexpect = %v", buffer.String(), expected)
@@ -423,8 +423,8 @@ func Test_Lint(t *testing.T) {
 	helm := MockExecer(logger, "dev")
 	helm.Lint("release", "path/to/chart", "--values", "file.yml")
 	expected := `Linting release=release, chart=path/to/chart
-exec: helm lint path/to/chart --values file.yml --kube-context dev
-exec: helm lint path/to/chart --values file.yml --kube-context dev: 
+exec: helm --kube-context dev lint path/to/chart --values file.yml
+exec: helm --kube-context dev lint path/to/chart --values file.yml: 
 `
 	if buffer.String() != expected {
 		t.Errorf("helmexec.Lint()\nactual = %v\nexpect = %v", buffer.String(), expected)
@@ -437,8 +437,8 @@ func Test_Fetch(t *testing.T) {
 	helm := MockExecer(logger, "dev")
 	helm.Fetch("chart", "--version", "1.2.3", "--untar", "--untardir", "/tmp/dir")
 	expected := `Fetching chart
-exec: helm fetch chart --version 1.2.3 --untar --untardir /tmp/dir --kube-context dev
-exec: helm fetch chart --version 1.2.3 --untar --untardir /tmp/dir --kube-context dev: 
+exec: helm --kube-context dev fetch chart --version 1.2.3 --untar --untardir /tmp/dir
+exec: helm --kube-context dev fetch chart --version 1.2.3 --untar --untardir /tmp/dir: 
 `
 	if buffer.String() != expected {
 		t.Errorf("helmexec.Lint()\nactual = %v\nexpect = %v", buffer.String(), expected)
@@ -508,8 +508,8 @@ func Test_Template(t *testing.T) {
 	helm := MockExecer(logger, "dev")
 	helm.TemplateRelease("release", "path/to/chart", "--values", "file.yml")
 	expected := `Templating release=release, chart=path/to/chart
-exec: helm template path/to/chart --name release --values file.yml --kube-context dev
-exec: helm template path/to/chart --name release --values file.yml --kube-context dev: 
+exec: helm --kube-context dev template path/to/chart --name release --values file.yml
+exec: helm --kube-context dev template path/to/chart --name release --values file.yml: 
 `
 	if buffer.String() != expected {
 		t.Errorf("helmexec.Template()\nactual = %v\nexpect = %v", buffer.String(), expected)


### PR DESCRIPTION
This PR allows per-release `kubeContext` to override `kubeContext` from `helmDefaults` by moving `helmDefaults`'s context to the first helm arg and lowering it's priority ( last `--kube-context` wins).
Fixes #1244 