### PR TITLE
feat: `helmfile template --output-dir-template` for customizing output dirs

### DIFF
--- a/main.go
+++ b/main.go
@@ -235,6 +235,10 @@ func main() {
 					Name:  "output-dir",
 					Usage: "output directory to pass to helm template (helm template --output-dir)",
 				},
+				cli.StringFlag{
+					Name:  "output-dir-template",
+					Usage: "go text template for generating the output directory. Default: {{ .OutputDir }}/{{ .State.BaseName }}-{{ .State.AbsPathSHA1 }}-{{ .Release.Name}}",
+				},
 				cli.IntFlag{
 					Name:  "concurrency",
 					Value: 0,
@@ -550,6 +554,10 @@ func (c configImpl) Args() string {
 
 func (c configImpl) OutputDir() string {
 	return c.c.String("output-dir")
+}
+
+func (c configImpl) OutputDirTemplate() string {
+	return c.c.String("output-dir-template")
 }
 
 func (c configImpl) Validate() bool {

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1282,7 +1282,8 @@ func (a *App) template(r *Run, c TemplateConfigProvider) (bool, []error) {
 
 			args := argparser.GetArgs(c.Args(), st)
 			opts := &state.TemplateOpts{
-				Set: c.Set(),
+				Set:               c.Set(),
+				OutputDirTemplate: c.OutputDirTemplate(),
 			}
 			return subst.TemplateReleases(helm, c.OutputDir(), c.Values(), args, c.Concurrency(), c.Validate(), opts)
 		}))

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -2178,6 +2178,10 @@ func (c configImpl) OutputDir() string {
 	return "output/subdir"
 }
 
+func (c configImpl) OutputDirTemplate() string {
+	return ""
+}
+
 func (c configImpl) Concurrency() int {
 	return 1
 }

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -129,6 +129,7 @@ type TemplateConfigProvider interface {
 
 	Values() []string
 	Set() []string
+	OutputDirTemplate() string
 	Validate() bool
 	SkipDeps() bool
 	OutputDir() string


### PR DESCRIPTION
This is useful for e.g. removing state file names and their hash values out of output dirs so that it can be used easily in a gitops setup. For example, `--output-dir-template mybasedir/{{.Release.Name}}` produces `mybasedir/RELEASE/CHART/templates/*.yaml` for each release in your helmfile.yaml.