### PR TITLE
Add pre/postuninstall hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -957,6 +957,8 @@ Currently supported `events` are:
 
 - `prepare`
 - `presync`
+- `preuninstall`
+- `postuninstall`
 - `postsync`
 - `cleanup`
 
@@ -964,9 +966,15 @@ Hooks associated to `prepare` events are triggered after each release in your he
 
 Hooks associated to `cleanup` events are triggered after each release is processed.
 
-Hooks associated to `presync` events are triggered before each release is applied to the remote cluster. This is the ideal event to execute any commands that may mutate the cluster state as it will not be run for read-only operations like `lint`, `diff` or `template`.
+Hooks associated to `presync` events are triggered before each release is applied to the remote cluster.
+This is the ideal event to execute any commands that may mutate the cluster state as it will not be run for read-only operations like `lint`, `diff` or `template`.
 
-Hooks associated to `postsync` events are triggered after each release is applied to the remote cluster. This is the ideal event to execute any commands that may mutate the cluster state as it will not be run for read-only operations like `lint`, `diff` or `template`.
+`preuninstall` hooks are triggered immediately before a release is uninstalled as part of `helmfile apply`, `helmfile sync`, `helmfile delete`, and `helmfile destroy`.
+
+Hooks associated to `postsync` events are triggered after each release is applied to the remote cluster.
+This is the ideal event to execute any commands that may mutate the cluster state as it will not be run for read-only operations like `lint`, `diff` or `template`.
+
+`postuninstall` hooks are triggered immediately after successful uninstall of a release while running `helmfile apply`, `helmfile sync`, `helmfile delete`, `helmfile destroy`.
 
 The following is an example hook that just prints the contextual information provided to hook:
 


### PR DESCRIPTION
Exmple:

```
releases:
- name: test2
  chart: stable/mysql
  installed: false
  hooks:
  - events:
    - prepare
    - preuninstall
    - postuninstall
    - cleanup
    showlogs: true
    command: "echo"
    args:
    - "event name = {{` {{ .Event.Name `}} }}"
```

Output:

```
helmfile apply
Listing releases matching ^test2$
test2   default         1               2020-07-23 00:51:44.975478 +0900 JST    deployed        mysql-1.6.6     5.7.30

helmfile.yaml: basePath=.

hook[preuninstall] logs | event name =  preuninstall
hook[preuninstall] logs |
Deleting test2
release "test2" uninstalled

helmfile.yaml: basePath=.

hook[postuninstall] logs | event name =  postuninstall
hook[postuninstall] logs |
helmfile.yaml: basePath=.

hook[cleanup] logs | event name =  cleanup
hook[cleanup] logs |

DELETED RELEASES:
NAME
test2
```

Resolves #802