### PR TITLE
 Fix and enhancement to repository update

### DIFF
--- a/pkg/app/load_opts.go
+++ b/pkg/app/load_opts.go
@@ -15,6 +15,8 @@ type LoadOpts struct {
 	CalleePath string
 
 	Reverse bool
+
+	Filter bool
 }
 
 func (o LoadOpts) DeepCopy() LoadOpts {

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -923,7 +923,7 @@ func TestHelmState_SyncRepos(t *testing.T) {
 			state := &HelmState{
 				Repositories: tt.repos,
 			}
-			if _ = state.SyncRepos(tt.helm); !reflect.DeepEqual(tt.helm.Repo, tt.want) {
+			if _, _ = state.SyncRepos(tt.helm, map[string]bool{}); !reflect.DeepEqual(tt.helm.Repo, tt.want) {
 				t.Errorf("HelmState.SyncRepos() for [%s] = %v, want %v", tt.name, tt.helm.Repo, tt.want)
 			}
 		})


### PR DESCRIPTION
Changes:

- Prevent Helmfile from unnecessarily running `helm repo add` and `helm repo up` against repositories for unused repositories(repositories of releases filtered out by selector)
- Fixes #1330
