### PR TITLE
Fix regression on template failing due to duplicate fetch target

### DIFF
--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -890,7 +890,7 @@ func (st *HelmState) PrepareCharts(helm helmexec.Interface, dir string, concurre
 						fetchFlags = append(fetchFlags, "--version", release.Version)
 					}
 
-					pathElems = append(pathElems, chartVersion, release.Chart)
+					pathElems = append(pathElems, release.Name, release.Chart, chartVersion)
 
 					chartPath = path.Join(pathElems...)
 


### PR DESCRIPTION
This fixes a regression introduced in #1388
Fixes #1394