### PR TITLE
Fix various issues in chart preparation

### DIFF
--- a/pkg/state/chart_dependency.go
+++ b/pkg/state/chart_dependency.go
@@ -254,7 +254,7 @@ func updateDependencies(st *HelmState, shell helmexec.DependencyUpdater, unresol
 
 	_, err := depMan.Update(shell, wd, unresolved)
 	if err != nil {
-		return nil, fmt.Errorf("unable to resolve %d deps: %v", len(unresolved.deps), err)
+		return nil, fmt.Errorf("unable to update %d deps: %v", len(unresolved.deps), err)
 	}
 
 	return resolveDependencies(st, depMan, unresolved)

--- a/pkg/testhelper/testfs.go
+++ b/pkg/testhelper/testfs.go
@@ -70,7 +70,7 @@ func (f *TestFs) ReadFile(filename string) ([]byte, error) {
 		str, ok = f.files[filepath.Join(f.Cwd, filename)]
 	}
 	if !ok {
-		return []byte(nil), fmt.Errorf("no registered file found: %s", filename)
+		return []byte(nil), os.ErrNotExist
 	}
 
 	f.fileReaderCalls += 1


### PR DESCRIPTION
In #1172, we accidentally changed the meaning of prepare hook that is intended to be called BEFORE the pathExists check. It broke the scenario where one used a prepare hook for generating the local chart dynamically. This fixes Helmfile not to fetch local chart generated by prepare hook.

In addition to that, this patch results in the following fixes:

- Fix an issue that `helmfile template` without `--skip-deps` fails while trying to run `helm dep build` on `helm fetch`ed chart, when the remote chart has outdated dependencies in the Chart.lock file. It should be up to the chart maintainer to update Chart.lock and the user should not be blocked due to that. So, after this patch `helm dep build` is run only on the local chart, not on fetched remote chart.
- Skip fetching chart on `helmfile template` when using Helm v3. `helm template` in helm v3 does support rendering remote charts so we do not need to fetch beforehand.

Fixes #1328
May relate to #1341