### PR TITLE
Add test case

### DIFF
--- a/pkg/state/create_test.go
+++ b/pkg/state/create_test.go
@@ -250,6 +250,8 @@ func TestReadFromYaml_FilterNegatives(t *testing.T) {
 			[]bool{false, true, false}},
 		{LabelFilter{negativeLabels: [][]string{[]string{"stage", "pre"}, []string{"stage", "post"}}},
 			[]bool{false, false, true}},
+		{LabelFilter{negativeLabels: [][]string{[]string{"foo", "bar"}}},
+			[]bool{false, true, true}},
 	}
 	state, err := createFromYaml(yamlContent, yamlFile, DefaultEnv, logger)
 	if err != nil {


### PR DESCRIPTION
To ensure that `helmfile -l foo!=bar` does match against release without the label at all.