### PR TITLE
Revert filtering on repositories to be updated

### DIFF
--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -2490,6 +2490,7 @@ releases:
 
 	var wantRepos = []mockRepo{
 		{Name: "stable"},
+		{Name: "stable2"},
 	}
 
 	var buffer bytes.Buffer

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -330,15 +330,10 @@ func (st *HelmState) getRepositoriesToSync() (map[string]bool, error) {
 }
 
 func (st *HelmState) SyncRepos(helm RepoUpdater, shouldSkip map[string]bool) ([]string, error) {
-	shouldUpdate, err := st.getRepositoriesToSync()
-	if err != nil {
-		return nil, err
-	}
-
 	var updated []string
 
 	for _, repo := range st.Repositories {
-		if !shouldUpdate[repo.Name] || shouldSkip[repo.Name] {
+		if shouldSkip[repo.Name] {
 			continue
 		}
 


### PR DESCRIPTION
This reverts a part of #1383 so that repository updates are done in the pre-0.125.0 way, which tries to update any repositories only once regardless of they are referenced by selected releases or not.

Ref #1404