### PR TITLE
feat: common labels for all releases in a helmfile

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -391,6 +391,12 @@ func (a *App) ListReleases(c ListConfigProvider) error {
 			//var releases m
 			for _, r := range run.state.Releases {
 				labels := ""
+				if r.Labels == nil {
+					r.Labels = map[string]string{}
+				}
+				for k, v := range run.state.CommonLabels {
+					r.Labels[k] = v
+				}
 				for k, v := range r.Labels {
 					labels = fmt.Sprintf("%s,%s:%s", labels, k, v)
 				}

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -4098,7 +4098,7 @@ releases:
 	})
 
 	expected := `NAME      	NAMESPACE	ENABLED	LABELS                    
-myrelease1	         	false  	id:myrelease1,common:label
+myrelease1	         	false  	common:label,id:myrelease1
 myrelease2	         	true   	common:label              
 myrelease3	         	true   	                          
 myrelease4	         	true   	id:myrelease1             

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -4,8 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/roboll/helmfile/pkg/remote"
 	"io"
 	"log"
 	"os"
@@ -16,6 +14,9 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/roboll/helmfile/pkg/remote"
 
 	"github.com/roboll/helmfile/pkg/exectest"
 	"gotest.tools/v3/assert"
@@ -4051,6 +4052,8 @@ releases:
 func TestList(t *testing.T) {
 	files := map[string]string{
 		"/path/to/helmfile.d/first.yaml": `
+commonLabels:
+  common: label
 releases:
 - name: myrelease1
   chart: mychart1
@@ -4094,11 +4097,11 @@ releases:
 		assert.NilError(t, err)
 	})
 
-	expected := `NAME      	NAMESPACE	ENABLED	LABELS       
-myrelease1	         	false  	id:myrelease1
-myrelease2	         	true   	             
-myrelease3	         	true   	             
-myrelease4	         	true   	id:myrelease1
+	expected := `NAME      	NAMESPACE	ENABLED	LABELS                    
+myrelease1	         	false  	id:myrelease1,common:label
+myrelease2	         	true   	common:label              
+myrelease3	         	true   	                          
+myrelease4	         	true   	id:myrelease1             
 `
 	assert.Equal(t, expected, out)
 }

--- a/pkg/state/state_exec_tmpl.go
+++ b/pkg/state/state_exec_tmpl.go
@@ -86,6 +86,12 @@ func (st *HelmState) ExecuteTemplates() (*HelmState, error) {
 	}
 
 	for i, rt := range st.Releases {
+		if rt.Labels == nil {
+			rt.Labels = map[string]string{}
+		}
+		for k, v := range st.CommonLabels {
+			rt.Labels[k] = v
+		}
 		successFlag := false
 		for it, prev := 0, &rt; it < 6; it++ {
 			tmplData := releaseTemplateData{


### PR DESCRIPTION
This adds `comonLabels` option to helmfile by:

- Adding `CommonLabels` to HelmState
- Changing `markExcludedReleases` and `ListReleases` functions to merge common labels into release labels

Resolves #1266