### PR TITLE
feat: Allow .Release.Name to be used in gotmpl values templates

### DIFF
--- a/pkg/state/create_test.go
+++ b/pkg/state/create_test.go
@@ -126,7 +126,11 @@ releaseName: myrelease`
 		t.Errorf("unexpected environment values: expected=%v, actual=%v", expected, actual)
 	}
 
-	actualValuesData, err := state.RenderValuesFileToBytes(valuesFile)
+	var release = ReleaseSpec{
+		Name: "myrelease",
+	}
+
+	actualValuesData, err := state.RenderValuesFileToBytes(&release, valuesFile)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/pkg/state/create_test.go
+++ b/pkg/state/create_test.go
@@ -100,9 +100,11 @@ bar: {{ readFile "bar.txt" }}
 	}
 
 	valuesFile := "/example/path/to/values.yaml.gotmpl"
-	valuesContent := []byte(`env: {{ .Environment.Name }}`)
+	valuesContent := []byte(`env: {{ .Environment.Name }}
+releaseName: {{ .Release.Name }}`)
 
-	expectedValues := `env: production`
+	expectedValues := `env: production
+releaseName: myrelease`
 
 	testFs := testhelper.NewTestFs(map[string]string{
 		fooYamlFile: string(fooYamlContent),

--- a/pkg/state/create_test.go
+++ b/pkg/state/create_test.go
@@ -130,7 +130,7 @@ releaseName: myrelease`
 		Name: "myrelease",
 	}
 
-	actualValuesData, err := state.RenderValuesFileToBytes(&release, valuesFile)
+	actualValuesData, err := state.RenderReleaseValuesFileToBytes(&release, valuesFile)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/pkg/state/envvals_loader.go
+++ b/pkg/state/envvals_loader.go
@@ -54,7 +54,7 @@ func (ld *EnvironmentValuesLoader) LoadEnvironmentValues(missingFileHandler *str
 			}
 
 			for _, f := range files {
-				tmplData := EnvironmentTemplateData{environment.EmptyEnvironment, "", map[string]interface{}{}}
+				tmplData := EnvironmentTemplateData{environment.EmptyEnvironment, "", map[string]interface{}{}, ReleaseSpec{}}
 				r := tmpl.NewFileRenderer(ld.readFile, filepath.Dir(f), tmplData)
 				bytes, err := r.RenderToBytes(f)
 				if err != nil {

--- a/pkg/state/envvals_loader.go
+++ b/pkg/state/envvals_loader.go
@@ -54,7 +54,7 @@ func (ld *EnvironmentValuesLoader) LoadEnvironmentValues(missingFileHandler *str
 			}
 
 			for _, f := range files {
-				tmplData := EnvironmentTemplateData{environment.EmptyEnvironment, "", map[string]interface{}{}, ReleaseSpec{}}
+				tmplData := EnvironmentTemplateData{environment.EmptyEnvironment, "", map[string]interface{}{}}
 				r := tmpl.NewFileRenderer(ld.readFile, filepath.Dir(f), tmplData)
 				bytes, err := r.RenderToBytes(f)
 				if err != nil {

--- a/pkg/state/helmx.go
+++ b/pkg/state/helmx.go
@@ -114,7 +114,7 @@ func (st *HelmState) PrepareChartify(helm helmexec.Interface, release *ReleaseSp
 
 	jsonPatches := release.JSONPatches
 	if len(jsonPatches) > 0 {
-		generatedFiles, err := st.generateTemporaryValuesFiles(jsonPatches, release.MissingFileHandler)
+		generatedFiles, err := st.generateTemporaryValuesFiles(release, jsonPatches, release.MissingFileHandler)
 		if err != nil {
 			return nil, clean, err
 		}
@@ -130,7 +130,7 @@ func (st *HelmState) PrepareChartify(helm helmexec.Interface, release *ReleaseSp
 
 	strategicMergePatches := release.StrategicMergePatches
 	if len(strategicMergePatches) > 0 {
-		generatedFiles, err := st.generateTemporaryValuesFiles(strategicMergePatches, release.MissingFileHandler)
+		generatedFiles, err := st.generateTemporaryValuesFiles(release, strategicMergePatches, release.MissingFileHandler)
 		if err != nil {
 			return nil, clean, err
 		}

--- a/pkg/state/helmx.go
+++ b/pkg/state/helmx.go
@@ -114,7 +114,7 @@ func (st *HelmState) PrepareChartify(helm helmexec.Interface, release *ReleaseSp
 
 	jsonPatches := release.JSONPatches
 	if len(jsonPatches) > 0 {
-		generatedFiles, err := st.generateTemporaryValuesFiles(release, jsonPatches, release.MissingFileHandler)
+		generatedFiles, err := st.generateTemporaryReleaseValuesFiles(release, jsonPatches, release.MissingFileHandler)
 		if err != nil {
 			return nil, clean, err
 		}
@@ -130,7 +130,7 @@ func (st *HelmState) PrepareChartify(helm helmexec.Interface, release *ReleaseSp
 
 	strategicMergePatches := release.StrategicMergePatches
 	if len(strategicMergePatches) > 0 {
-		generatedFiles, err := st.generateTemporaryValuesFiles(release, strategicMergePatches, release.MissingFileHandler)
+		generatedFiles, err := st.generateTemporaryReleaseValuesFiles(release, strategicMergePatches, release.MissingFileHandler)
 		if err != nil {
 			return nil, clean, err
 		}

--- a/pkg/state/state_exec_tmpl.go
+++ b/pkg/state/state_exec_tmpl.go
@@ -20,11 +20,12 @@ func (st *HelmState) mustLoadVals() map[string]interface{} {
 	return vals
 }
 
-func (st *HelmState) valuesFileTemplateData() EnvironmentTemplateData {
+func (st *HelmState) valuesFileTemplateData(release *ReleaseSpec) EnvironmentTemplateData {
 	return EnvironmentTemplateData{
 		Environment: st.Env,
 		Namespace:   st.OverrideNamespace,
 		Values:      st.mustLoadVals(),
+		Release:     *release,
 	}
 }
 

--- a/pkg/state/state_exec_tmpl.go
+++ b/pkg/state/state_exec_tmpl.go
@@ -12,20 +12,16 @@ func (st *HelmState) Values() (map[string]interface{}, error) {
 	return st.Env.GetMergedValues()
 }
 
-func (st *HelmState) mustLoadVals() map[string]interface{} {
-	vals, err := st.Values()
-	if err != nil {
-		panic(err)
-	}
-	return vals
-}
-
-func (st *HelmState) valuesFileTemplateData(release *ReleaseSpec) EnvironmentTemplateData {
-	return EnvironmentTemplateData{
+func (st *HelmState) createReleaseTemplateData(release *ReleaseSpec, vals map[string]interface{}) releaseTemplateData {
+	return releaseTemplateData{
 		Environment: st.Env,
-		Namespace:   st.OverrideNamespace,
-		Values:      st.mustLoadVals(),
-		Release:     *release,
+		Values:      vals,
+		Release: releaseTemplateDataRelease{
+			Name:      release.Name,
+			Chart:     release.Chart,
+			Namespace: release.Namespace,
+			Labels:    release.Labels,
+		},
 	}
 }
 
@@ -89,11 +85,7 @@ func (st *HelmState) ExecuteTemplates() (*HelmState, error) {
 	for i, rt := range st.Releases {
 		successFlag := false
 		for it, prev := 0, &rt; it < 6; it++ {
-			tmplData := releaseTemplateData{
-				Environment: st.Env,
-				Release:     *prev,
-				Values:      vals,
-			}
+			tmplData := st.createReleaseTemplateData(prev, vals)
 			renderer := tmpl.NewFileRenderer(st.readFile, st.basePath, tmplData)
 			r, err := rt.ExecuteTemplateExpressions(renderer)
 			if err != nil {

--- a/pkg/state/types.go
+++ b/pkg/state/types.go
@@ -17,6 +17,8 @@ type EnvironmentTemplateData struct {
 	Namespace string
 	// Values is accessible as `.Values` and it contains default state values overrode by environment values and override values.
 	Values map[string]interface{}
+	// Release is accessible as `.Release` from any template expression executed by the renderer
+	Release ReleaseSpec
 }
 
 // releaseTemplateData provides variables accessible while executing golang text/template expressions in releases of a helmfile YAML file

--- a/pkg/state/types.go
+++ b/pkg/state/types.go
@@ -17,16 +17,30 @@ type EnvironmentTemplateData struct {
 	Namespace string
 	// Values is accessible as `.Values` and it contains default state values overrode by environment values and override values.
 	Values map[string]interface{}
-	// Release is accessible as `.Release` from any template expression executed by the renderer
-	Release ReleaseSpec
 }
 
-// releaseTemplateData provides variables accessible while executing golang text/template expressions in releases of a helmfile YAML file
+// releaseTemplateData provides variables accessible while executing golang text/template expressions in release templates
+// and release values templates within a Helmfile YAML file.
 type releaseTemplateData struct {
 	// Environment is accessible as `.Environment` from any template expression executed by the renderer
 	Environment environment.Environment
-	// Release is accessible as `.Release` from any template expression executed by the renderer
-	Release ReleaseSpec
+	// Release is accessible as `.Release` from any template expression executed by the renderer.
+	// It contains a subset of ReleaseSpec that is known to be useful to dynamically render values.
+	Release releaseTemplateDataRelease
 	// Values is accessible as `.Values` and it contains default state values overrode by environment values and override values.
 	Values map[string]interface{}
+}
+
+type releaseTemplateDataRelease struct {
+	// Name is basically ReleaseSpec.Name exposed to the template
+	Name string
+
+	// Namespace is HelmState.OverrideNamespace, or if it's empty, ReleaseSpec.Namespace.
+	Namespace string
+
+	// Labels is ReleaseSpec.Labels
+	Labels map[string]string
+
+	// Chart is ReleaseSpec.Chart
+	Chart string
 }


### PR DESCRIPTION
This adds the ability to utilize `.Release` inside of gotmpl files as discussed [here](https://github.com/roboll/helmfile/issues/760).

Resolves: https://github.com/roboll/helmfile/issues/760

Added a simple test that passed once implemented and all tests are running green.