### PR TITLE
HELMFILE_ENVIRONMENT variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,9 @@ GLOBAL OPTIONS:
    --interactive, -i                       Request confirmation before attempting to modify clusters
    --help, -h                              show help
    --version, -v                           print the version
+
+Environment variables:
+  HELMFILE_ENVIRONMENT                     specify the environment name, the command line option '-e' have precedence
 ```
 
 ### sync

--- a/main.go
+++ b/main.go
@@ -681,7 +681,10 @@ func (c configImpl) Logger() *zap.SugaredLogger {
 func (c configImpl) Env() string {
 	env := c.c.GlobalString("environment")
 	if env == "" {
-		env = state.DefaultEnv
+		env = os.Getenv("HELMFILE_ENVIRONMENT")
+		if env == "" {
+			env = state.DefaultEnv
+		}
 	}
 	return env
 }


### PR DESCRIPTION
A simple change to allow the 'environment name' to be set by an environment variable. Precedence have command line option.