### PR TITLE
Allow helm versions without patch semver part (#1427)

### DIFF
--- a/pkg/helmexec/exec_test.go
+++ b/pkg/helmexec/exec_test.go
@@ -570,3 +570,50 @@ func Test_IsVersionAtLeast(t *testing.T) {
 	}
 
 }
+
+func Test_parseHelmVersion(t *testing.T) {
+	tests := []struct {
+		ver     string
+		want    Version
+		wantErr bool
+	}{
+		{
+			ver: "v1.2.3",
+			want: Version{
+				Major: 1,
+				Minor: 2,
+				Patch: 3,
+			},
+			wantErr: false,
+		},
+		{
+			ver: "v1.2",
+			want: Version{
+				Major: 1,
+				Minor: 2,
+				Patch: 0,
+			},
+			wantErr: false,
+		},
+		{
+			ver:     "v1",
+			wantErr: true,
+		},
+		{
+			ver:     "1.1.1",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.ver, func(t *testing.T) {
+			got, err := parseHelmVersion(tt.ver)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseHelmVersion() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseHelmVersion() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #1427

Helm binary distribution (in archlinux, at least) does not have patch part it it's `helm version` output. This should be supported by helmfile because patch part is actually never used by any meaningful checks.

I thought that it would be nice to use existing `semver` package of Masterminds or coreos to parse semver instead of regex, but this doesn't make sense since we now support non-semver `v3.3`

Also I noticed that errors are not handled properly, so I refactored `getHelmVersion` just a little bit. Next time when it panics user will get a better idea of what's happening. Not ideal though