### PR TITLE
feat: `helmfile build --embed-values` to embed release values and secrets into the output

### DIFF
--- a/main.go
+++ b/main.go
@@ -467,7 +467,12 @@ func main() {
 		{
 			Name:  "build",
 			Usage: "output compiled helmfile state(s) as YAML",
-			Flags: []cli.Flag{},
+			Flags: []cli.Flag{
+				cli.BoolFlag{
+					Name:  "embed-values",
+					Usage: "Read all the values files for every release and embed into the output helmfile.yaml",
+				},
+			},
 			Action: action(func(run *app.App, c configImpl) error {
 				return run.PrintState(c)
 			}),
@@ -672,6 +677,10 @@ func (c configImpl) NoColor() bool {
 
 func (c configImpl) Context() int {
 	return c.c.Int("context")
+}
+
+func (c configImpl) EmbedValues() bool {
+	return c.c.Bool("embed-values")
 }
 
 func (c configImpl) Logger() *zap.SugaredLogger {

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -2271,6 +2271,10 @@ func (c configImpl) Concurrency() int {
 	return 1
 }
 
+func (c configImpl) EmbedValues() bool {
+	return false
+}
+
 func (c configImpl) Output() string {
 	return c.output
 }

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -144,6 +144,7 @@ type StatusesConfigProvider interface {
 }
 
 type StateConfigProvider interface {
+	EmbedValues() bool
 }
 
 type concurrencyConfig interface {

--- a/pkg/state/release.go
+++ b/pkg/state/release.go
@@ -133,12 +133,15 @@ func (r ReleaseSpec) ExecuteTemplateExpressions(renderer *tmpl.FileRenderer) (*R
 		}
 	}
 
-	for i, ts := range result.Secrets {
-		s, err := renderer.RenderTemplateContentToBuffer([]byte(ts))
-		if err != nil {
-			return nil, fmt.Errorf("failed executing template expressions in release \"%s\".secrets[%d] = \"%s\": %v", r.Name, i, ts, err)
+	for i, t := range result.Secrets {
+		switch ts := t.(type) {
+		case string:
+			s, err := renderer.RenderTemplateContentToBuffer([]byte(ts))
+			if err != nil {
+				return nil, fmt.Errorf("failed executing template expressions in release \"%s\".secrets[%d] = \"%s\": %v", r.Name, i, ts, err)
+			}
+			result.Secrets[i] = s.String()
 		}
-		result.Secrets[i] = s.String()
 	}
 
 	if len(result.SetValuesTemplate) > 0 {

--- a/pkg/state/state_exec_tmpl_test.go
+++ b/pkg/state/state_exec_tmpl_test.go
@@ -36,7 +36,7 @@ func TestHelmState_executeTemplates(t *testing.T) {
 				Name:           "test-app",
 				Namespace:      "test-namespace-{{ .Release.Name }}",
 				ValuesTemplate: []interface{}{"config/{{ .Environment.Name }}/{{ .Release.Name }}/values.yaml"},
-				Secrets:        []string{"config/{{ .Environment.Name }}/{{ .Release.Name }}/secrets.yaml"},
+				Secrets:        []interface{}{"config/{{ .Environment.Name }}/{{ .Release.Name }}/secrets.yaml"},
 				Labels:         map[string]string{"id": "{{ .Release.Name }}"},
 			},
 			want: ReleaseSpec{
@@ -45,7 +45,7 @@ func TestHelmState_executeTemplates(t *testing.T) {
 				Name:      "test-app",
 				Namespace: "test-namespace-test-app",
 				Values:    []interface{}{"config/test_env/test-app/values.yaml"},
-				Secrets:   []string{"config/test_env/test-app/secrets.yaml"},
+				Secrets:   []interface{}{"config/test_env/test-app/secrets.yaml"},
 				Labels:    map[string]string{"id": "test-app"},
 			},
 		},


### PR DESCRIPTION
This is handy when debugging complex `helmfile.yaml` and `values.yaml.gotmpl` as the resulting `helmfile.yaml` contains all the rendered values and sops-encrypted secrets in its embedded form.

It's gonna be used to resolve a terraform-provider-helmfile issue that requires a unique hash of the desired state: https://github.com/mumoshu/terraform-provider-helmfile/issues/28

Environment values and secrets are not yet supported. They are output as-is. But it should be fine as the resulting helm release won't change as long as release values/secrets are unchanged.