### PR TITLE
Add experimental "forceNamespace" in helmfile.yaml

### DIFF
--- a/pkg/state/helmx.go
+++ b/pkg/state/helmx.go
@@ -144,6 +144,10 @@ func (st *HelmState) PrepareChartify(helm helmexec.Interface, release *ReleaseSp
 		shouldRun = true
 	}
 
+	if release.ForceNamespace != "" {
+		chartify.Opts.OverrideNamespace = release.ForceNamespace
+	}
+
 	if shouldRun {
 		generatedFiles, err := st.generateValuesFiles(helm, release, workerIndex)
 		if err != nil {

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -253,6 +253,13 @@ type ReleaseSpec struct {
 	// Without this, any error in url parsing result in silently falling-back to normal process of treating `chart:` as the regular
 	// helm chart name.
 	ForceGoGetter bool `yaml:"forceGoGetter,omitempty"`
+
+	// ForceNamespace is an experimental feature to set metadata.namespace in every K8s resource rendered by the chart,
+	// regardless of the template, even when it doesn't have `namespace: {{ .Namespace | quote }}`.
+	// This is only needed when you can't FIX your chart to have `namespace: {{ .Namespace }}` AND you're using `helmfile template`.
+	// In standard use-cases, `Namespace` should be sufficient.
+	// Use this only when you know what you want to do!
+	ForceNamespace string `yaml:"forceNamespace"`
 }
 
 type Release struct {


### PR DESCRIPTION
This is an experimental feature to support a potential use-case that you need to set namespaces in manifests rendered by `helmfile template`, WHEN the chart is unconventional hence does not have `namespace: {{ .Namespace }}`.
Rather than using this, you should usually fork/maintain or update/pull-request the chart to have `namespace: {{ .Namespace }}`.
Use this only when you CAN NOT do so, but still need to use `helmfile template`.