### PR TITLE
Re-add Release.Namespace in release values.yaml templates

### DIFF
--- a/pkg/state/create_test.go
+++ b/pkg/state/create_test.go
@@ -101,10 +101,14 @@ bar: {{ readFile "bar.txt" }}
 
 	valuesFile := "/example/path/to/values.yaml.gotmpl"
 	valuesContent := []byte(`env: {{ .Environment.Name }}
-releaseName: {{ .Release.Name }}`)
+releaseName: {{ .Release.Name }}
+releaseNamespace: {{ .Release.Namespace }}
+`)
 
 	expectedValues := `env: production
-releaseName: myrelease`
+releaseName: myrelease
+releaseNamespace: mynamespace
+`
 
 	testFs := testhelper.NewTestFs(map[string]string{
 		fooYamlFile: string(fooYamlContent),
@@ -126,9 +130,96 @@ releaseName: myrelease`
 		t.Errorf("unexpected environment values: expected=%v, actual=%v", expected, actual)
 	}
 
-	var release = ReleaseSpec{
-		Name: "myrelease",
+	release := state.Releases[0]
+
+	state.ApplyOverrides(&release)
+
+	actualValuesData, err := state.RenderReleaseValuesFileToBytes(&release, valuesFile)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
 	}
+	actualValues := string(actualValuesData)
+
+	if !reflect.DeepEqual(expectedValues, actualValues) {
+		t.Errorf("unexpected values: expected=%v, actual=%v", expectedValues, actualValues)
+	}
+}
+
+func TestReadFromYaml_OverrideNamespace(t *testing.T) {
+	yamlFile := "/example/path/to/helmfile.yaml"
+	yamlContent := []byte(`environments:
+  production:
+    values:
+    - foo.yaml
+    - bar.yaml.gotmpl
+
+# A.k.a helmfile apply --namespace myns
+namespace: myns
+
+releases:
+- name: myrelease
+  namespace: mynamespace
+  chart: mychart
+  values:
+  - values.yaml.gotmpl
+`)
+
+	fooYamlFile := "/example/path/to/foo.yaml"
+	fooYamlContent := []byte(`foo: foo
+# As this file doesn't have an file extension ".gotmpl", this template expression should not be evaluated
+baz: "{{ readFile \"baz.txt\" }}"`)
+
+	barYamlFile := "/example/path/to/bar.yaml.gotmpl"
+	barYamlContent := []byte(`foo: FOO
+bar: {{ readFile "bar.txt" }}
+`)
+
+	barTextFile := "/example/path/to/bar.txt"
+	barTextContent := []byte("BAR")
+
+	expected := map[string]interface{}{
+		"foo": "FOO",
+		"bar": "BAR",
+		// As the file doesn't have an file extension ".gotmpl", this template expression should not be evaluated
+		"baz": "{{ readFile \"baz.txt\" }}",
+	}
+
+	valuesFile := "/example/path/to/values.yaml.gotmpl"
+	valuesContent := []byte(`env: {{ .Environment.Name }}
+releaseName: {{ .Release.Name }}
+releaseNamespace: {{ .Release.Namespace }}
+overrideNamespace: {{ .Namespace }}
+`)
+
+	expectedValues := `env: production
+releaseName: myrelease
+releaseNamespace: myns
+overrideNamespace: myns
+`
+
+	testFs := testhelper.NewTestFs(map[string]string{
+		fooYamlFile: string(fooYamlContent),
+		barYamlFile: string(barYamlContent),
+		barTextFile: string(barTextContent),
+		valuesFile:  string(valuesContent),
+	})
+	testFs.Cwd = "/example/path/to"
+
+	r := remote.NewRemote(logger, testFs.Cwd, testFs.ReadFile, testFs.DirectoryExistsAt, testFs.FileExistsAt)
+	state, err := NewCreator(logger, testFs.ReadFile, testFs.FileExists, testFs.Abs, testFs.Glob, nil, nil, "", r).
+		ParseAndLoad(yamlContent, filepath.Dir(yamlFile), yamlFile, "production", true, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	actual := state.Env.Values
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("unexpected environment values: expected=%v, actual=%v", expected, actual)
+	}
+
+	release := state.Releases[0]
+
+	state.ApplyOverrides(&release)
 
 	actualValuesData, err := state.RenderReleaseValuesFileToBytes(&release, valuesFile)
 	if err != nil {

--- a/pkg/state/state_exec_tmpl.go
+++ b/pkg/state/state_exec_tmpl.go
@@ -15,6 +15,7 @@ func (st *HelmState) Values() (map[string]interface{}, error) {
 func (st *HelmState) createReleaseTemplateData(release *ReleaseSpec, vals map[string]interface{}) releaseTemplateData {
 	return releaseTemplateData{
 		Environment: st.Env,
+		Namespace:   st.OverrideNamespace,
 		Values:      vals,
 		Release: releaseTemplateDataRelease{
 			Name:      release.Name,

--- a/pkg/state/types.go
+++ b/pkg/state/types.go
@@ -29,6 +29,10 @@ type releaseTemplateData struct {
 	Release releaseTemplateDataRelease
 	// Values is accessible as `.Values` and it contains default state values overrode by environment values and override values.
 	Values map[string]interface{}
+	// Namespace is HelmState.OverrideNamespace.
+	// You should better use Release.Namespace as it might work as you'd expect even if OverrideNamespace is not set.
+	// See releaseTemplateDataRelease.Namespace for more information.
+	Namespace string
 }
 
 type releaseTemplateDataRelease struct {


### PR DESCRIPTION
It was accidentally removed in #1424, and had been unexpectedly unavailable between v0.126.0 and v0.128.1.

Fixes #1464