### PR TITLE
Update README.md - small change to Global Hooks example  

### DIFF
--- a/README.md
+++ b/README.md
@@ -1079,7 +1079,7 @@ hooks:
 - events: ["prepare", "cleanup"]
   showlogs: true
   command: "echo"
-  args: ["{{`{{.Environment.Name}}`}}", "{{`{{.Release.Name}}`}}", "{{`{{.HelmfileCommand}}`}}\
+  args: ["{{`{{.Environment.Name}}`}}", "{{`{{.HelmfileCommand}}`}}\
 "]
 ```
 


### PR DESCRIPTION
I've made a small change to Global Hooks example in order to remove release name reference - this was probably copy/pasted from Hooks section. As I understand release name can't be referenced in Global Hooks section.
I am not sure if there is any open issue that might be relevant to this PR.