### PR TITLE
fix: Do treat selector with multiple conditions an AND for negation on a missing label

### DIFF
--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -747,6 +747,8 @@ func runFilterSubHelmFilesTests(testcases []struct {
 	expectErr        bool
 	errMsg           string
 }, files map[string]string, t *testing.T, testName string) {
+	t.Helper()
+
 	for _, testcase := range testcases {
 		actual := []string{}
 

--- a/pkg/state/release_filters.go
+++ b/pkg/state/release_filters.go
@@ -38,7 +38,7 @@ func (l LabelFilter) Match(r ReleaseSpec) bool {
 			k := element[0]
 			v := element[1]
 			if rVal, ok := r.Labels[k]; !ok {
-				return true
+
 			} else if rVal == v {
 				return false
 			}

--- a/pkg/state/selector_test.go
+++ b/pkg/state/selector_test.go
@@ -1,0 +1,97 @@
+package state
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"gopkg.in/yaml.v2"
+	"testing"
+)
+
+func TestSelectReleasesWithOverrides(t *testing.T) {
+	type testcase struct {
+		subject  string
+		selector []string
+		want     []string
+	}
+
+	testcases := []testcase{
+		{
+			subject:  "multiple OR selectors (nillable label first)",
+			selector: []string{"type=bar", "name=nolabel2", "name=nolabel1"},
+			want:     []string{"nolabel1", "nolabel2", "foo"},
+		},
+		{
+			subject:  "multiple OR selectors (non-nillable label first)",
+			selector: []string{"name=foo", "type!=bar"},
+			want:     []string{"nolabel1", "nolabel2", "foo"},
+		},
+		{
+			subject:  "multiple AND conditions (nillable label first)",
+			selector: []string{"type!=bar,name!=nolabel2"},
+			want:     []string{"nolabel1"},
+		},
+		{
+			subject:  "multiple AND conditions (non-nillable label first)",
+			selector: []string{"name!=nolabel2,type!=bar"},
+			want:     []string{"nolabel1"},
+		},
+		{
+			subject:  "inequality on nillable label",
+			selector: []string{"type!=bar"},
+			want:     []string{"nolabel1", "nolabel2"},
+		},
+		{
+			subject:  "equality on nillable label",
+			selector: []string{"type=bar"},
+			want:     []string{"foo"},
+		},
+		{
+			subject:  "inequality on non-nillable label",
+			selector: []string{"name!=nolabel1"},
+			want:     []string{"nolabel2", "foo"},
+		},
+		{
+			subject:  "equality on non-nillable label",
+			selector: []string{"name=nolabel1"},
+			want:     []string{"nolabel1"},
+		},
+	}
+
+	example := []byte(`releases:
+- name: nolabel1
+  namespace: kube-system
+  chart: stable/nolabel
+- name: nolabel2
+  namespace: default
+  chart: stable/nolabel
+- name: foo
+  namespace: kube-system
+  chart: stable/foo
+  labels:
+    type: bar
+`)
+
+	var state HelmState
+
+	if err := yaml.Unmarshal(example, &state); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range testcases {
+		state.Selectors = tc.selector
+
+		rs, err := state.GetSelectedReleasesWithOverrides()
+		if err != nil {
+			t.Fatalf("%s %s: %v", tc.selector, tc.subject, err)
+		}
+
+		var got []string
+
+		for _, r := range rs {
+			got = append(got, r.Name)
+		}
+
+		if d := cmp.Diff(tc.want, got); d != "" {
+			t.Errorf("%s %s: %s", tc.selector, tc.subject, d)
+		}
+	}
+}


### PR DESCRIPTION
Helmfile is defined to treat multiple `-l` as OR and multiple conditions in a single `-l` as AND. But there was a bug that a selector with multiple negations matches on first negation that encountered a missing label, which means it's unexpectedly treated as an OR sometimes. It should iterate over all the negations, not only the first on, regardless of the existence of the label, to be an AND.

Since this change, we can treat all the multi-conditions case AND.

Fixes #1477