### PR TITLE
Fix helm version checking

### DIFF
--- a/pkg/exectest/helm.go
+++ b/pkg/exectest/helm.go
@@ -175,7 +175,21 @@ func (helm *Helm) IsVersionAtLeast(major int, minor int, patch int) bool {
 		return false
 	}
 
-	return helm.Version.Major >= major && minor >= helm.Version.Minor && patch >= helm.Version.Patch
+	if helm.Version.Major > major {
+		return true
+	}
+	if helm.Version.Major < major {
+		return false
+	}
+
+	if helm.Version.Minor > minor {
+		return true
+	}
+	if helm.Version.Minor < minor {
+		return false
+	}
+
+	return helm.Version.Patch >= patch
 }
 
 func (helm *Helm) sync(m *sync.Mutex, f func()) {


### PR DESCRIPTION
Noticed this incorrect algorithm while browsing the changelog.  Should really use the built in semver package, but my golang-fu wasn't up to making that big a change...