### PR TITLE
feat: Upgrade kubectl, upgrade helm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,12 @@ FROM alpine:3.11
 
 RUN apk add --no-cache ca-certificates git bash curl jq
 
-ARG HELM_VERSION=v2.16.12
+ARG HELM_VERSION="v2.16.12"
 ARG HELM_LOCATION="https://kubernetes-helm.storage.googleapis.com"
 ARG HELM_FILENAME="helm-${HELM_VERSION}-linux-amd64.tar.gz"
 ARG HELM_SHA256="756ab375314329b66b452c0f9d569f74b0760141670217c07b79890ad314c214"
-RUN wget ${HELM_LOCATION}/${HELM_FILENAME} && \
+RUN set -x && \
+    wget ${HELM_LOCATION}/${HELM_FILENAME} && \
     echo Verifying ${HELM_FILENAME}... && \
     sha256sum ${HELM_FILENAME} | grep -q "${HELM_SHA256}" && \
     echo Extracting ${HELM_FILENAME}... && \
@@ -26,9 +27,12 @@ RUN wget ${HELM_LOCATION}/${HELM_FILENAME} && \
 # using the install documentation found at https://kubernetes.io/docs/tasks/tools/install-kubectl/
 # for now but in a future version of alpine (in the testing version at the time of writing)
 # we should be able to install using apk add.
-ENV KUBECTL_VERSION="v1.14.5"
-ENV KUBECTL_SHA256="26681319de56820a8467c9407e9203d5b15fb010ffc75ac5b99c9945ad0bd28c"
-RUN curl --retry 3 --retry-connrefused -LO "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
+# the sha256 sum can be found at https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256
+# maybe a good idea to automate in the future?
+ENV KUBECTL_VERSION="v1.18.9"
+ENV KUBECTL_SHA256="6a68756a2d3d04b4d0f52b00de6493ba2c1fcb28b32f3e4a0e99b3d9f6c4e8ed"
+RUN set -x & \
+    curl --retry 5 --retry-connrefused -LO "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
     sha256sum kubectl | grep ${KUBECTL_SHA256} && \
     chmod +x kubectl && \
     mv kubectl /usr/local/bin/kubectl

--- a/Dockerfile.helm3
+++ b/Dockerfile.helm3
@@ -11,11 +11,12 @@ FROM alpine:3.11
 
 RUN apk add --no-cache ca-certificates git bash curl jq
 
-ARG HELM_VERSION=v3.3.3
+ARG HELM_VERSION="v3.3.4"
 ARG HELM_LOCATION="https://get.helm.sh"
 ARG HELM_FILENAME="helm-${HELM_VERSION}-linux-amd64.tar.gz"
-ARG HELM_SHA256="246d58b6b353e63ae8627415a7340089015e3eb542ff7b5ce124b0b1409369cc"
-RUN wget ${HELM_LOCATION}/${HELM_FILENAME} && \
+ARG HELM_SHA256="b664632683c36446deeb85c406871590d879491e3de18978b426769e43a1e82c"
+RUN set -x && \
+    wget ${HELM_LOCATION}/${HELM_FILENAME} && \
     echo Verifying ${HELM_FILENAME}... && \
     sha256sum ${HELM_FILENAME} | grep -q "${HELM_SHA256}" && \
     echo Extracting ${HELM_FILENAME}... && \
@@ -25,9 +26,12 @@ RUN wget ${HELM_LOCATION}/${HELM_FILENAME} && \
 # using the install documentation found at https://kubernetes.io/docs/tasks/tools/install-kubectl/
 # for now but in a future version of alpine (in the testing version at the time of writing)
 # we should be able to install using apk add.
-ENV KUBECTL_VERSION="v1.14.5"
-ENV KUBECTL_SHA256="26681319de56820a8467c9407e9203d5b15fb010ffc75ac5b99c9945ad0bd28c"
-RUN curl --retry 3 --retry-connrefused -LO "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
+# the sha256 sum can be found at https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256
+# maybe a good idea to automate in the future?
+ENV KUBECTL_VERSION="v1.18.9"
+ENV KUBECTL_SHA256="6a68756a2d3d04b4d0f52b00de6493ba2c1fcb28b32f3e4a0e99b3d9f6c4e8ed"
+RUN set -x && \
+    curl --retry 5 --retry-connrefused -LO "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
     sha256sum kubectl | grep ${KUBECTL_SHA256} && \
     chmod +x kubectl && \
     mv kubectl /usr/local/bin/kubectl


### PR DESCRIPTION
As per the [version skew of kubectl](https://kubernetes.io/docs/setup/release/version-skew-policy/#kubectl) I picked v1.18.9 as to support both the latest stable and as many older versions as possible.

I upgraded Helm because using the latest release I was getting strange issues with helm-diff being unable to unmarshal YAML which I couldn't replicate locally (on the same versions of helmfile, helm, and plugins), but could within the Docker release. Upgrading Helm to the latest patch fixed it for me.

Changes:

* Bump helm to v3.3.4.
* Bump kubectl to v1.18.9
* Update Dockerfile to be a little more verbose to help understand which command in a chain failed.

Signed-off-by: Jake Hill <jake@naphta.uk>