### PR TITLE
Clarify namespace prefix in needs

### DIFF
--- a/README.md
+++ b/README.md
@@ -848,6 +848,8 @@ releases:
   - [TILLER_NAMESPACE/][NAMESPACE/]anotherelease
 ```
 
+Be aware that you have to specify the namespace name if you configured one for the release(s).
+
 All the releases listed under `needs` are installed before(or deleted after) the release itself.
 
 For the following example, `helmfile [sync|apply]` installs releases in this order:


### PR DESCRIPTION
Before this, the documentation didn't mention that the release needs to
be prefixed with the namespace if the release had a namespace configured.