### PR TITLE
Fix: forceNamespace needs shouldRun is true

### DIFF
--- a/pkg/state/helmx.go
+++ b/pkg/state/helmx.go
@@ -146,6 +146,8 @@ func (st *HelmState) PrepareChartify(helm helmexec.Interface, release *ReleaseSp
 
 	if release.ForceNamespace != "" {
 		chartify.Opts.OverrideNamespace = release.ForceNamespace
+
+		shouldRun = true
 	}
 
 	if shouldRun {


### PR DESCRIPTION
Hi,

I found `releases[].forceNamespace` doesn't work okay, so tried to fix it.

## how it works

```sh
$ cat <<EOF > sample-helmfile.yaml
releases:
- name: scaler
  forceNamespace: this-is-forced-namespace
  chart: stable/cluster-autoscaler
EOF

$ helmfile -f sample-helmfile.yaml template
```
It's gonna insert `metadata.namespace` with value `forceNamespace` if a chart has some manifest templates which doesn't have `metadata.namespace`.

cc @mumoshu 