### PR TITLE
Support for azure acr helm repositories

### DIFF
--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -2418,7 +2418,7 @@ func (helm *mockHelmExec) SetExtraArgs(args ...string) {
 func (helm *mockHelmExec) SetHelmBinary(bin string) {
 	return
 }
-func (helm *mockHelmExec) AddRepo(name, repository, cafile, certfile, keyfile, username, password string) error {
+func (helm *mockHelmExec) AddRepo(name, repository, cafile, certfile, keyfile, username, password string, managed string) error {
 	helm.repos = append(helm.repos, mockRepo{Name: name})
 	return nil
 }

--- a/pkg/app/context.go
+++ b/pkg/app/context.go
@@ -15,11 +15,6 @@ func NewContext() Context {
 }
 
 func (ctx Context) SyncReposOnce(st *state.HelmState, helm state.RepoUpdater) error {
-	for _, repo := range st.Repositories {
-		if repo.Managed != "" {
-			ctx.updatedRepos[repo.Name] = true
-		}
-	}
 	updated, err := st.SyncRepos(helm, ctx.updatedRepos)
 
 	for _, r := range updated {

--- a/pkg/app/context.go
+++ b/pkg/app/context.go
@@ -16,7 +16,7 @@ func NewContext() Context {
 
 func (ctx Context) SyncReposOnce(st *state.HelmState, helm state.RepoUpdater) error {
 	for _, repo := range st.Repositories {
-		if repo.Managed {
+		if repo.Managed != "" {
 			ctx.updatedRepos[repo.Name] = true
 		}
 	}

--- a/pkg/app/context.go
+++ b/pkg/app/context.go
@@ -15,6 +15,11 @@ func NewContext() Context {
 }
 
 func (ctx Context) SyncReposOnce(st *state.HelmState, helm state.RepoUpdater) error {
+	for _, repo := range st.Repositories {
+		if repo.Managed {
+			ctx.updatedRepos[repo.Name] = true
+		}
+	}
 	updated, err := st.SyncRepos(helm, ctx.updatedRepos)
 
 	for _, r := range updated {

--- a/pkg/app/mocks_test.go
+++ b/pkg/app/mocks_test.go
@@ -41,7 +41,7 @@ func (helm *noCallHelmExec) SetHelmBinary(bin string) {
 	helm.doPanic()
 	return
 }
-func (helm *noCallHelmExec) AddRepo(name, repository, cafile, certfile, keyfile, username, password string) error {
+func (helm *noCallHelmExec) AddRepo(name, repository, cafile, certfile, keyfile, username, password string, managed string) error {
 	helm.doPanic()
 	return nil
 }

--- a/pkg/exectest/helm.go
+++ b/pkg/exectest/helm.go
@@ -81,8 +81,8 @@ func (helm *Helm) SetExtraArgs(args ...string) {
 func (helm *Helm) SetHelmBinary(bin string) {
 	return
 }
-func (helm *Helm) AddRepo(name, repository, cafile, certfile, keyfile, username, password string) error {
-	helm.Repo = []string{name, repository, cafile, certfile, keyfile, username, password}
+func (helm *Helm) AddRepo(name, repository, cafile, certfile, keyfile, username, password string, managed string) error {
+	helm.Repo = []string{name, repository, cafile, certfile, keyfile, username, password, managed}
 	return nil
 }
 func (helm *Helm) UpdateRepo() error {

--- a/pkg/helmexec/exec.go
+++ b/pkg/helmexec/exec.go
@@ -394,9 +394,10 @@ func (helm *execer) exec(args []string, env map[string]string) ([]byte, error) {
 }
 
 func (helm *execer) azcli(name string) ([]byte, error) {
-	cmd := fmt.Sprintf("exec: az acr helm repo add --name %s", name)
+	cmdargs := append(strings.Split("acr helm repo add --name", " "), name)
+	cmd := fmt.Sprintf("exec: az %s", strings.Join(cmdargs, " "))
 	helm.logger.Debug(cmd)
-	bytes, err := helm.runner.Execute("az", append( strings.Split("acr helm repo add --name", " ") , name ), map[string]string{})
+	bytes, err := helm.runner.Execute("az", cmdargs, map[string]string{})
 	helm.logger.Debugf("%s: %s", cmd, bytes)
 	return bytes, err
 }

--- a/pkg/helmexec/exec.go
+++ b/pkg/helmexec/exec.go
@@ -123,11 +123,15 @@ func (helm *execer) SetHelmBinary(bin string) {
 	helm.helmBinary = bin
 }
 
-func (helm *execer) AddRepo(name, repository, cafile, certfile, keyfile, username, password string) error {
+func (helm *execer) AddRepo(name, repository, cafile, certfile, keyfile, username, password string, managed string) error {
 	var args []string
 	if name == "" && repository != "" {
 		helm.logger.Infof("empty field name\n")
 		return fmt.Errorf("empty field name")
+	}
+	if managed != "" {
+		helm.logger.Infof("Skipping managed repo %v (`%v`)\n", name, managed)
+		return nil
 	}
 	args = append(args, "repo", "add", name, repository)
 	if helm.IsHelm3() && helm.IsVersionAtLeast(3, 3, 2) {

--- a/pkg/helmexec/exec.go
+++ b/pkg/helmexec/exec.go
@@ -130,8 +130,10 @@ func (helm *execer) AddRepo(name, repository, cafile, certfile, keyfile, usernam
 		return fmt.Errorf("empty field name")
 	}
 	if managed != "" {
-		helm.logger.Infof("Skipping managed repo %v (`%v`)\n", name, managed)
-		return nil
+		helm.logger.Infof("Adding repo %v (acr)", name)
+		out, err := helm.azcli(name)
+		helm.info(out)
+		return err
 	}
 	args = append(args, "repo", "add", name, repository)
 	if helm.IsHelm3() && helm.IsVersionAtLeast(3, 3, 2) {
@@ -381,6 +383,14 @@ func (helm *execer) exec(args []string, env map[string]string) ([]byte, error) {
 	cmd := fmt.Sprintf("exec: %s %s", helm.helmBinary, strings.Join(cmdargs, " "))
 	helm.logger.Debug(cmd)
 	bytes, err := helm.runner.Execute(helm.helmBinary, cmdargs, env)
+	helm.logger.Debugf("%s: %s", cmd, bytes)
+	return bytes, err
+}
+
+func (helm *execer) azcli(name string) ([]byte, error) {
+	cmd := fmt.Sprintf("exec: az acr helm repo add --name %s", name)
+	helm.logger.Debug(cmd)
+	bytes, err := helm.runner.Execute("az", append( strings.Split("acr helm repo add --name", " ") , name ), map[string]string{})
 	helm.logger.Debugf("%s: %s", cmd, bytes)
 	return bytes, err
 }

--- a/pkg/helmexec/exec_test.go
+++ b/pkg/helmexec/exec_test.go
@@ -75,7 +75,7 @@ func Test_AddRepo(t *testing.T) {
 	var buffer bytes.Buffer
 	logger := NewLogger(&buffer, "debug")
 	helm := MockExecer(logger, "dev")
-	helm.AddRepo("myRepo", "https://repo.example.com/", "", "cert.pem", "key.pem", "", "")
+	helm.AddRepo("myRepo", "https://repo.example.com/", "", "cert.pem", "key.pem", "", "", "")
 	expected := `Adding repo myRepo https://repo.example.com/
 exec: helm --kube-context dev repo add myRepo https://repo.example.com/ --cert-file cert.pem --key-file key.pem
 exec: helm --kube-context dev repo add myRepo https://repo.example.com/ --cert-file cert.pem --key-file key.pem: 
@@ -85,7 +85,7 @@ exec: helm --kube-context dev repo add myRepo https://repo.example.com/ --cert-f
 	}
 
 	buffer.Reset()
-	helm.AddRepo("myRepo", "https://repo.example.com/", "ca.crt", "", "", "", "")
+	helm.AddRepo("myRepo", "https://repo.example.com/", "ca.crt", "", "", "", "", "")
 	expected = `Adding repo myRepo https://repo.example.com/
 exec: helm --kube-context dev repo add myRepo https://repo.example.com/ --ca-file ca.crt
 exec: helm --kube-context dev repo add myRepo https://repo.example.com/ --ca-file ca.crt: 
@@ -95,7 +95,7 @@ exec: helm --kube-context dev repo add myRepo https://repo.example.com/ --ca-fil
 	}
 
 	buffer.Reset()
-	helm.AddRepo("myRepo", "https://repo.example.com/", "", "", "", "", "")
+	helm.AddRepo("myRepo", "https://repo.example.com/", "", "", "", "", "", "")
 	expected = `Adding repo myRepo https://repo.example.com/
 exec: helm --kube-context dev repo add myRepo https://repo.example.com/
 exec: helm --kube-context dev repo add myRepo https://repo.example.com/: 
@@ -105,7 +105,7 @@ exec: helm --kube-context dev repo add myRepo https://repo.example.com/:
 	}
 
 	buffer.Reset()
-	helm.AddRepo("myRepo", "https://repo.example.com/", "", "", "", "example_user", "example_password")
+	helm.AddRepo("myRepo", "https://repo.example.com/", "", "", "", "example_user", "example_password", "")
 	expected = `Adding repo myRepo https://repo.example.com/
 exec: helm --kube-context dev repo add myRepo https://repo.example.com/ --username example_user --password example_password
 exec: helm --kube-context dev repo add myRepo https://repo.example.com/ --username example_user --password example_password: 
@@ -115,7 +115,7 @@ exec: helm --kube-context dev repo add myRepo https://repo.example.com/ --userna
 	}
 
 	buffer.Reset()
-	helm.AddRepo("", "https://repo.example.com/", "", "", "", "", "")
+	helm.AddRepo("", "https://repo.example.com/", "", "", "", "", "", "")
 	expected = `empty field name
 
 `
@@ -461,7 +461,7 @@ func Test_LogLevels(t *testing.T) {
 		buffer.Reset()
 		logger := NewLogger(&buffer, logLevel)
 		helm := MockExecer(logger, "")
-		helm.AddRepo("myRepo", "https://repo.example.com/", "", "", "", "example_user", "example_password")
+		helm.AddRepo("myRepo", "https://repo.example.com/", "", "", "", "example_user", "example_password", "")
 		if buffer.String() != expected {
 			t.Errorf("helmexec.AddRepo()\nactual = %v\nexpect = %v", buffer.String(), expected)
 		}

--- a/pkg/helmexec/exec_test.go
+++ b/pkg/helmexec/exec_test.go
@@ -105,6 +105,24 @@ exec: helm --kube-context dev repo add myRepo https://repo.example.com/:
 	}
 
 	buffer.Reset()
+	helm.AddRepo("acrRepo", "", "", "", "", "", "", "acr")
+	expected = `Adding repo acrRepo (acr)
+exec: az acr helm repo add --name acrRepo
+exec: az acr helm repo add --name acrRepo: 
+`
+	if buffer.String() != expected {
+		t.Errorf("helmexec.AddRepo()\nactual = %v\nexpect = %v", buffer.String(), expected)
+	}
+
+	buffer.Reset()
+	helm.AddRepo("otherRepo", "", "", "", "", "", "", "unknown")
+	expected = `ERROR: unknown type 'unknown' for repository otherRepo
+`
+	if buffer.String() != expected {
+		t.Errorf("helmexec.AddRepo()\nactual = %v\nexpect = %v", buffer.String(), expected)
+	}
+
+	buffer.Reset()
 	helm.AddRepo("myRepo", "https://repo.example.com/", "", "", "", "example_user", "example_password", "")
 	expected = `Adding repo myRepo https://repo.example.com/
 exec: helm --kube-context dev repo add myRepo https://repo.example.com/ --username example_user --password example_password

--- a/pkg/helmexec/exec_test.go
+++ b/pkg/helmexec/exec_test.go
@@ -82,7 +82,7 @@ func Test_AddRepo_Helm_3_3_2(t *testing.T) {
 		kubeContext: "dev",
 		runner:      &mockRunner{},
 	}
-	helm.AddRepo("myRepo", "https://repo.example.com/", "", "cert.pem", "key.pem", "", "")
+	helm.AddRepo("myRepo", "https://repo.example.com/", "", "cert.pem", "key.pem", "", "", "")
 	expected := `Adding repo myRepo https://repo.example.com/
 exec: helm --kube-context dev repo add myRepo https://repo.example.com/ --force-update --cert-file cert.pem --key-file key.pem
 exec: helm --kube-context dev repo add myRepo https://repo.example.com/ --force-update --cert-file cert.pem --key-file key.pem: 

--- a/pkg/helmexec/helmexec.go
+++ b/pkg/helmexec/helmexec.go
@@ -12,7 +12,7 @@ type Interface interface {
 	SetExtraArgs(args ...string)
 	SetHelmBinary(bin string)
 
-	AddRepo(name, repository, cafile, certfile, keyfile, username, password string) error
+	AddRepo(name, repository, cafile, certfile, keyfile, username, password string, managed string) error
 	UpdateRepo() error
 	BuildDeps(name, chart string) error
 	UpdateDeps(chart string) error

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -311,7 +311,7 @@ func (st *HelmState) ApplyOverrides(spec *ReleaseSpec) {
 }
 
 type RepoUpdater interface {
-	AddRepo(name, repository, cafile, certfile, keyfile, username, password string) error
+	AddRepo(name, repository, cafile, certfile, keyfile, username, password string, managed string) error
 	UpdateRepo() error
 }
 
@@ -353,7 +353,7 @@ func (st *HelmState) SyncRepos(helm RepoUpdater, shouldSkip map[string]bool) ([]
 			continue
 		}
 
-		if err := helm.AddRepo(repo.Name, repo.URL, repo.CaFile, repo.CertFile, repo.KeyFile, repo.Username, repo.Password); err != nil {
+		if err := helm.AddRepo(repo.Name, repo.URL, repo.CaFile, repo.CertFile, repo.KeyFile, repo.Username, repo.Password, repo.Managed); err != nil {
 			return nil, err
 		}
 

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -154,6 +154,7 @@ type RepositorySpec struct {
 	KeyFile  string `yaml:"keyFile,omitempty"`
 	Username string `yaml:"username,omitempty"`
 	Password string `yaml:"password,omitempty"`
+	Managed  bool   `yaml:"managed,omitempty"`
 }
 
 // ReleaseSpec defines the structure of a helm release

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -154,7 +154,7 @@ type RepositorySpec struct {
 	KeyFile  string `yaml:"keyFile,omitempty"`
 	Username string `yaml:"username,omitempty"`
 	Password string `yaml:"password,omitempty"`
-	Managed  bool   `yaml:"managed,omitempty"`
+	Managed  string `yaml:"managed,omitempty"`
 }
 
 // ReleaseSpec defines the structure of a helm release

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -876,7 +876,7 @@ func TestHelmState_SyncRepos(t *testing.T) {
 				},
 			},
 			helm: &exectest.Helm{},
-			want: []string{"name", "http://example.com/", "", "", "", "", ""},
+			want: []string{"name", "http://example.com/", "", "", "", "", "", ""},
 		},
 		{
 			name: "repository with cert and key",
@@ -891,7 +891,7 @@ func TestHelmState_SyncRepos(t *testing.T) {
 				},
 			},
 			helm: &exectest.Helm{},
-			want: []string{"name", "http://example.com/", "", "certfile", "keyfile", "", ""},
+			want: []string{"name", "http://example.com/", "", "certfile", "keyfile", "", "", ""},
 		},
 		{
 			name: "repository with ca file",
@@ -905,7 +905,7 @@ func TestHelmState_SyncRepos(t *testing.T) {
 				},
 			},
 			helm: &exectest.Helm{},
-			want: []string{"name", "http://example.com/", "cafile", "", "", "", ""},
+			want: []string{"name", "http://example.com/", "cafile", "", "", "", "", ""},
 		},
 		{
 			name: "repository with username and password",
@@ -920,7 +920,7 @@ func TestHelmState_SyncRepos(t *testing.T) {
 				},
 			},
 			helm: &exectest.Helm{},
-			want: []string{"name", "http://example.com/", "", "", "", "example_user", "example_password"},
+			want: []string{"name", "http://example.com/", "", "", "", "example_user", "example_password", ""},
 		},
 	}
 	for i := range tests {

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -879,6 +879,17 @@ func TestHelmState_SyncRepos(t *testing.T) {
 			want: []string{"name", "http://example.com/", "", "", "", "", "", ""},
 		},
 		{
+			name: "ACR hosted repository",
+			repos: []RepositorySpec{
+				{
+					Name:     "name",
+					Managed:  "acr",
+				},
+			},
+			helm: &exectest.Helm{},
+			want: []string{"name", "", "", "", "", "", "", "acr"},
+		},
+		{
 			name: "repository with cert and key",
 			repos: []RepositorySpec{
 				{

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -882,8 +882,8 @@ func TestHelmState_SyncRepos(t *testing.T) {
 			name: "ACR hosted repository",
 			repos: []RepositorySpec{
 				{
-					Name:     "name",
-					Managed:  "acr",
+					Name:    "name",
+					Managed: "acr",
 				},
 			},
 			helm: &exectest.Helm{},


### PR DESCRIPTION
This adds some basic support for helm repositories hosted on azure container registry (not OCI but [classic ones](https://docs.microsoft.com/en-us/cli/azure/acr/helm?view=azure-cli-latest). Add a new element to RepositorySpec to state that is externally managed and runs the az-cli command instead of the helm one.
