### PR TITLE
Bump chartify to 0.4.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/spf13/cobra v0.0.3
 	github.com/tatsushid/go-prettytable v0.0.0-20141013043238-ed2d14c29939
 	github.com/urfave/cli v1.20.0
-	github.com/variantdev/chartify v0.4.3
+	github.com/variantdev/chartify v0.4.4
 	github.com/variantdev/dag v0.0.0-20191028002400-bb0b3c785363
 	github.com/variantdev/vals v0.10.3
 	go.uber.org/multierr v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -853,6 +853,8 @@ github.com/variantdev/chartify v0.4.2 h1:Vw647JysxJ4kz+6vOxOmrctRoTTf5qmpleB6hTQ
 github.com/variantdev/chartify v0.4.2/go.mod h1:Fr4oPNJ4b19knlovn0wBoU2+MZxQdBacmBs30wwgAFk=
 github.com/variantdev/chartify v0.4.3 h1:CRyi9XDCXkgvvgOkNUwXp0oaIJG0BWKjbUZHN3D8xvw=
 github.com/variantdev/chartify v0.4.3/go.mod h1:Fr4oPNJ4b19knlovn0wBoU2+MZxQdBacmBs30wwgAFk=
+github.com/variantdev/chartify v0.4.4 h1:ludsoqljh2HVNpZhMjtvzo5P0ntEcFqMufu6B4SfByY=
+github.com/variantdev/chartify v0.4.4/go.mod h1:Fr4oPNJ4b19knlovn0wBoU2+MZxQdBacmBs30wwgAFk=
 github.com/variantdev/dag v0.0.0-20191028002400-bb0b3c785363 h1:KrfQBEUn+wEOQ/6UIfoqRDvn+Q/wZridQ7t0G1vQqKE=
 github.com/variantdev/dag v0.0.0-20191028002400-bb0b3c785363/go.mod h1:pH1TQsNSLj2uxMo9NNl9zdGy01Wtn+/2MT96BrKmVyE=
 github.com/variantdev/vals v0.4.0 h1:O1O7/sWhlvozcY2DjZBzlE1notxwVo6UBT1+w7HsO/k=


### PR DESCRIPTION
To incorporate the fix for unconventional chart templates like seen in the Datadog chart https://github.com/variantdev/chartify/commit/5443ca1a1db36d2626522f39130ac1157a69c3f7