### PR TITLE
Add helmDefaults.repoForceUpdate and repositories[].forceUpdate configs.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ jobs:
     - run:
         name: Install helm
         environment:
-          HELM_VERSION: v3.3.3
+          HELM_VERSION: v3.3.4
         command: |
           HELM_FILENAME="helm-${HELM_VERSION}-linux-amd64.tar.gz"
           curl -Lo ${HELM_FILENAME} "https://get.helm.sh/${HELM_FILENAME}"

--- a/Dockerfile.helm3
+++ b/Dockerfile.helm3
@@ -11,10 +11,10 @@ FROM alpine:3.11
 
 RUN apk add --no-cache ca-certificates git bash curl jq
 
-ARG HELM_VERSION=v3.3.3
+ARG HELM_VERSION=v3.3.4
 ARG HELM_LOCATION="https://get.helm.sh"
 ARG HELM_FILENAME="helm-${HELM_VERSION}-linux-amd64.tar.gz"
-ARG HELM_SHA256="246d58b6b353e63ae8627415a7340089015e3eb542ff7b5ce124b0b1409369cc"
+ARG HELM_SHA256="b664632683c36446deeb85c406871590d879491e3de18978b426769e43a1e82c"
 RUN wget ${HELM_LOCATION}/${HELM_FILENAME} && \
     echo Verifying ${HELM_FILENAME}... && \
     sha256sum ${HELM_FILENAME} | grep -q "${HELM_SHA256}" && \

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ repositories:
 # To use official "incubator" charts a.k.a https://github.com/helm/charts/tree/master/incubator
 - name: incubator
   url: https://kubernetes-charts-incubator.storage.googleapis.com
+# The flag "--force-update" will be passed to `helm repo add` if forceUpdate is true,
+# if unset, the value of helmDefaults.repoForceUpdate will be used. See
+# https://github.com/helm/helm/pull/8777 for more info.
+- name: bitnami
+  url: https://charts.bitnami.com/bitnami
+  forceUpdate: false
 # helm-git powered repository: You can treat any Git repository as a charts repository
 - name: polaris
   url: git+https://github.com/reactiveops/polaris@deploy/helm?ref=master
@@ -64,8 +70,8 @@ repositories:
 # Advanced configuration: You can use a ca bundle to use an https repo
 # with a self-signed certificate
 - name: insecure
-   url: https://charts.my-insecure-domain.com
-   caFile: optional_ca_crt
+  url: https://charts.my-insecure-domain.com
+  caFile: optional_ca_crt
 
 # context: kube-context # this directive is deprecated, please consider using helmDefaults.kubeContext
 
@@ -102,6 +108,9 @@ helmDefaults:
   historyMax: 10
   # when using helm 3.2+, automatically create release namespaces if they do not exist (default true)
   createNamespace: true
+  # when set to true (default false), "--force-update" will be passed to `helm repo add`. This value can be
+  # overridden by repositories[].forceUpdate for every individual repo.
+  repoForceUpdate: false
 
 # these labels will be applied to all releases in a Helmfile. Useful in templating if you have a helmfile per environment or customer and don't want to copy the same label to each release
 commonLabels:

--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ repositories:
 - name: incubator
   url: https://kubernetes-charts-incubator.storage.googleapis.com
 # The flag "--force-update" will be passed to `helm repo add` if forceUpdate is true,
-# if unset, the value of helmDefaults.repoForceUpdate will be used. See
-# https://github.com/helm/helm/pull/8777 for more info.
+# if unset, the value of helmDefaults.repoForceUpdate will be used. We recommend users to
+# use Helm v3.3.4 or above, otherwise this value has to be true. See
+# https://github.com/roboll/helmfile/pull/1542 for more info.
 - name: bitnami
   url: https://charts.bitnami.com/bitnami
   forceUpdate: false

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -2418,7 +2418,7 @@ func (helm *mockHelmExec) SetExtraArgs(args ...string) {
 func (helm *mockHelmExec) SetHelmBinary(bin string) {
 	return
 }
-func (helm *mockHelmExec) AddRepo(name, repository, cafile, certfile, keyfile, username, password string, managed string) error {
+func (helm *mockHelmExec) AddRepo(name, repository, cafile, certfile, keyfile, username, password, managed string, forceUpdate bool) error {
 	helm.repos = append(helm.repos, mockRepo{Name: name})
 	return nil
 }

--- a/pkg/app/mocks_test.go
+++ b/pkg/app/mocks_test.go
@@ -41,7 +41,7 @@ func (helm *noCallHelmExec) SetHelmBinary(bin string) {
 	helm.doPanic()
 	return
 }
-func (helm *noCallHelmExec) AddRepo(name, repository, cafile, certfile, keyfile, username, password string, managed string) error {
+func (helm *noCallHelmExec) AddRepo(name, repository, cafile, certfile, keyfile, username, password, managed string, forceUpdate bool) error {
 	helm.doPanic()
 	return nil
 }

--- a/pkg/exectest/helm.go
+++ b/pkg/exectest/helm.go
@@ -3,6 +3,7 @@ package exectest
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -82,8 +83,8 @@ func (helm *Helm) SetExtraArgs(args ...string) {
 func (helm *Helm) SetHelmBinary(bin string) {
 	return
 }
-func (helm *Helm) AddRepo(name, repository, cafile, certfile, keyfile, username, password string, managed string) error {
-	helm.Repo = []string{name, repository, cafile, certfile, keyfile, username, password, managed}
+func (helm *Helm) AddRepo(name, repository, cafile, certfile, keyfile, username, password, managed string, forceUpdate bool) error {
+	helm.Repo = []string{name, repository, cafile, certfile, keyfile, username, password, managed, strconv.FormatBool(forceUpdate)}
 	return nil
 }
 func (helm *Helm) UpdateRepo() error {

--- a/pkg/helmexec/exec_test.go
+++ b/pkg/helmexec/exec_test.go
@@ -9,7 +9,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/Masterminds/semver/v3"
 	"go.uber.org/zap"
 )
 
@@ -72,30 +71,11 @@ func Test_SetHelmBinary(t *testing.T) {
 	}
 }
 
-func Test_AddRepo_Helm_3_3_2(t *testing.T) {
-	var buffer bytes.Buffer
-	logger := NewLogger(&buffer, "debug")
-	helm := &execer{
-		helmBinary:  "helm",
-		version:     *semver.MustParse("3.3.2"),
-		logger:      logger,
-		kubeContext: "dev",
-		runner:      &mockRunner{},
-	}
-	helm.AddRepo("myRepo", "https://repo.example.com/", "", "cert.pem", "key.pem", "", "", "")
-	expected := `Adding repo myRepo https://repo.example.com/
-exec: helm --kube-context dev repo add myRepo https://repo.example.com/ --force-update --cert-file cert.pem --key-file key.pem
-`
-	if buffer.String() != expected {
-		t.Errorf("helmexec.AddRepo()\nactual = %v\nexpect = %v", buffer.String(), expected)
-	}
-}
-
 func Test_AddRepo(t *testing.T) {
 	var buffer bytes.Buffer
 	logger := NewLogger(&buffer, "debug")
 	helm := MockExecer(logger, "dev")
-	helm.AddRepo("myRepo", "https://repo.example.com/", "", "cert.pem", "key.pem", "", "", "")
+	helm.AddRepo("myRepo", "https://repo.example.com/", "", "cert.pem", "key.pem", "", "", "", false)
 	expected := `Adding repo myRepo https://repo.example.com/
 exec: helm --kube-context dev repo add myRepo https://repo.example.com/ --cert-file cert.pem --key-file key.pem
 `
@@ -104,7 +84,7 @@ exec: helm --kube-context dev repo add myRepo https://repo.example.com/ --cert-f
 	}
 
 	buffer.Reset()
-	helm.AddRepo("myRepo", "https://repo.example.com/", "ca.crt", "", "", "", "", "")
+	helm.AddRepo("myRepo", "https://repo.example.com/", "ca.crt", "", "", "", "", "", false)
 	expected = `Adding repo myRepo https://repo.example.com/
 exec: helm --kube-context dev repo add myRepo https://repo.example.com/ --ca-file ca.crt
 `
@@ -113,7 +93,7 @@ exec: helm --kube-context dev repo add myRepo https://repo.example.com/ --ca-fil
 	}
 
 	buffer.Reset()
-	helm.AddRepo("myRepo", "https://repo.example.com/", "", "", "", "", "", "")
+	helm.AddRepo("myRepo", "https://repo.example.com/", "", "", "", "", "", "", false)
 	expected = `Adding repo myRepo https://repo.example.com/
 exec: helm --kube-context dev repo add myRepo https://repo.example.com/
 `
@@ -122,7 +102,7 @@ exec: helm --kube-context dev repo add myRepo https://repo.example.com/
 	}
 
 	buffer.Reset()
-	helm.AddRepo("acrRepo", "", "", "", "", "", "", "acr")
+	helm.AddRepo("acrRepo", "", "", "", "", "", "", "acr", false)
 	expected = `Adding repo acrRepo (acr)
 exec: az acr helm repo add --name acrRepo
 exec: az acr helm repo add --name acrRepo: 
@@ -132,7 +112,7 @@ exec: az acr helm repo add --name acrRepo:
 	}
 
 	buffer.Reset()
-	helm.AddRepo("otherRepo", "", "", "", "", "", "", "unknown")
+	helm.AddRepo("otherRepo", "", "", "", "", "", "", "unknown", false)
 	expected = `ERROR: unknown type 'unknown' for repository otherRepo
 `
 	if buffer.String() != expected {
@@ -140,7 +120,7 @@ exec: az acr helm repo add --name acrRepo:
 	}
 
 	buffer.Reset()
-	helm.AddRepo("myRepo", "https://repo.example.com/", "", "", "", "example_user", "example_password", "")
+	helm.AddRepo("myRepo", "https://repo.example.com/", "", "", "", "example_user", "example_password", "", false)
 	expected = `Adding repo myRepo https://repo.example.com/
 exec: helm --kube-context dev repo add myRepo https://repo.example.com/ --username example_user --password example_password
 `
@@ -149,9 +129,18 @@ exec: helm --kube-context dev repo add myRepo https://repo.example.com/ --userna
 	}
 
 	buffer.Reset()
-	helm.AddRepo("", "https://repo.example.com/", "", "", "", "", "", "")
+	helm.AddRepo("", "https://repo.example.com/", "", "", "", "", "", "", false)
 	expected = `empty field name
 
+`
+	if buffer.String() != expected {
+		t.Errorf("helmexec.AddRepo()\nactual = %v\nexpect = %v", buffer.String(), expected)
+	}
+
+	buffer.Reset()
+	helm.AddRepo("myRepo", "https://repo.example.com/", "", "", "", "", "", "", true)
+	expected = `Adding repo myRepo https://repo.example.com/
+exec: helm --kube-context dev repo add myRepo https://repo.example.com/ --force-update
 `
 	if buffer.String() != expected {
 		t.Errorf("helmexec.AddRepo()\nactual = %v\nexpect = %v", buffer.String(), expected)
@@ -470,7 +459,7 @@ func Test_LogLevels(t *testing.T) {
 		buffer.Reset()
 		logger := NewLogger(&buffer, logLevel)
 		helm := MockExecer(logger, "")
-		helm.AddRepo("myRepo", "https://repo.example.com/", "", "", "", "example_user", "example_password", "")
+		helm.AddRepo("myRepo", "https://repo.example.com/", "", "", "", "example_user", "example_password", "", false)
 		if buffer.String() != expected {
 			t.Errorf("helmexec.AddRepo()\nactual = %v\nexpect = %v", buffer.String(), expected)
 		}

--- a/pkg/helmexec/helmexec.go
+++ b/pkg/helmexec/helmexec.go
@@ -12,7 +12,7 @@ type Interface interface {
 	SetExtraArgs(args ...string)
 	SetHelmBinary(bin string)
 
-	AddRepo(name, repository, cafile, certfile, keyfile, username, password string, managed string) error
+	AddRepo(name, repository, cafile, certfile, keyfile, username, password, managed string, forceUpdate bool) error
 	UpdateRepo() error
 	BuildDeps(name, chart string) error
 	UpdateDeps(chart string) error

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -140,7 +140,7 @@ type HelmSpec struct {
 	// CreateNamespace, when set to true (default), --create-namespace is passed to helm3 on install/upgrade (ignored for helm2)
 	CreateNamespace *bool `yaml:"createNamespace,omitempty"`
 	// RepoForceUpdate, when set to true, the default value of repositories[].forceUpdate will be true, default is false. See https://github.com/roboll/helmfile/pull/1494
-	RepoForceUpdate bool `yaml:"repoforceUpdate"`
+	RepoForceUpdate bool `yaml:"repoForceUpdate"`
 
 	TLS                      bool   `yaml:"tls"`
 	TLSCACert                string `yaml:"tlsCACert,omitempty"`


### PR DESCRIPTION
Add `helmDefaults.repoForceUpdate` and `repositories[].forceUpdate` in helmfile.yaml. With this PR, users can specify whether they'd like to enable `--force-update` globally, individually, or just leave it disabled (by default).

Related PRs or issues:

- <https://github.com/roboll/helmfile/pull/1494>
- <https://github.com/roboll/helmfile/issues/1489>
- <https://github.com/helm/helm/pull/8777>
