### PR TITLE
Retain `helm repo add --force-update` when Helm is v3.3.4 or above

### DIFF
--- a/pkg/helmexec/exec.go
+++ b/pkg/helmexec/exec.go
@@ -121,7 +121,7 @@ func (helm *execer) AddRepo(name, repository, cafile, certfile, keyfile, usernam
 		args = append(args, "repo", "add", name, repository)
 
 		// See https://github.com/helm/helm/pull/8777
-		if cons, err := semver.NewConstraint(">= 3.3.2, < 3.3.4"); err == nil {
+		if cons, err := semver.NewConstraint(">= 3.3.2"); err == nil {
 			if cons.Check(&helm.version) {
 				args = append(args, "--force-update")
 			}


### PR DESCRIPTION
See: https://github.com/roboll/helmfile/pull/1542#issuecomment-710082201

Please merge this PR first as currently with Helm v3.3.4, helmfile won't keep the repos updated.