### PR TITLE
fix: printing error to stdout together with templated resources

### DIFF
--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -2206,7 +2206,7 @@ func (st *HelmState) ExpandedHelmfiles() ([]SubHelmfileSpec, error) {
 			if st.MissingFileHandler == "Error" {
 				return nil, err
 			}
-			st.logger.Infof("no matches for path: %s", hf.Path)
+			st.logger.Warnf("no matches for path: %s", hf.Path)
 			continue
 		}
 		for _, match := range matches {

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -2206,7 +2206,7 @@ func (st *HelmState) ExpandedHelmfiles() ([]SubHelmfileSpec, error) {
 			if st.MissingFileHandler == "Error" {
 				return nil, err
 			}
-			fmt.Println(err)
+			st.logger.Infof("no matches for path: %s", hf.Path)
 			continue
 		}
 		for _, match := range matches {


### PR DESCRIPTION
Issue created in #1551

When `helmfile template` includes other helmfiles using glob and the directory and helmfiles do not exist, an error message is printed to stdout together with rendered k8s resources, which makes it impossible to use without manipulation with tool like `kubeval` for example.

Example piece of code in `helmfile.yaml`:

```yaml
helmfiles:
- envs/{{ .Values.Environment.Name }}/helmfile-*.yaml
```

Which may produce something like:

```
no matches for path: envs/default/helmfile-*.yaml
---
# Source: abc/templates/network-policy.yaml
kind: NetworkPolicy
apiVersion: networking.k8s.io/v1
...
```

when `helmfile template` is executed and `envs` directory is empty.