### PR TITLE
Fix `helmfile --selector x=y template` with `needs`

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -233,7 +233,7 @@ func (a *App) Template(c TemplateConfigProvider) error {
 		}
 
 		return
-	}, SetFilter(true))
+	})
 }
 
 func (a *App) WriteValues(c WriteValuesConfigProvider) error {


### PR DESCRIPTION
I had mistakenly inverted the necessary flag to turn off the legacy processing on selectors that should be used only for helmfile commands that does not support DAGs/needs.

Fixes #1552