### PR TITLE
feat: Add `helmfile template --include-crds`

### DIFF
--- a/main.go
+++ b/main.go
@@ -249,6 +249,10 @@ func main() {
 					Usage: "validate your manifests against the Kubernetes cluster you are currently pointing at",
 				},
 				cli.BoolFlag{
+					Name:  "include-crds",
+					Usage: "include CRDs in the templated output",
+				},
+				cli.BoolFlag{
 					Name:  "skip-deps",
 					Usage: "skip running `helm repo update` and `helm dependency build`",
 				},
@@ -715,6 +719,10 @@ func (c configImpl) Context() int {
 
 func (c configImpl) EmbedValues() bool {
 	return c.c.Bool("embed-values")
+}
+
+func (c configImpl) IncludeCRDs() bool {
+	return c.c.Bool("include-crds")
 }
 
 func (c configImpl) Logger() *zap.SugaredLogger {

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1433,6 +1433,7 @@ func (a *App) template(r *Run, c TemplateConfigProvider) (bool, []error) {
 
 			opts := &state.TemplateOpts{
 				Set:               c.Set(),
+				IncludeCRDs:       c.IncludeCRDs(),
 				OutputDirTemplate: c.OutputDirTemplate(),
 			}
 			return subst.TemplateReleases(helm, c.OutputDir(), c.Values(), args, c.Concurrency(), c.Validate(), opts)

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -2237,10 +2237,11 @@ services:
 }
 
 type configImpl struct {
-	selectors []string
-	set       []string
-	output    string
-	skipDeps  bool
+	selectors   []string
+	set         []string
+	output      string
+	includeCRDs bool
+	skipDeps    bool
 }
 
 func (a configImpl) Selectors() []string {
@@ -2273,6 +2274,10 @@ func (c configImpl) OutputDir() string {
 
 func (c configImpl) OutputDirTemplate() string {
 	return ""
+}
+
+func (c configImpl) IncludeCRDs() bool {
+	return c.includeCRDs
 }
 
 func (c configImpl) Concurrency() int {

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -133,6 +133,7 @@ type TemplateConfigProvider interface {
 	Validate() bool
 	SkipDeps() bool
 	OutputDir() string
+	IncludeCRDs() bool
 
 	concurrencyConfig
 }

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1125,6 +1125,7 @@ func (st *HelmState) runHelmDepBuilds(helm helmexec.Interface, concurrency int, 
 type TemplateOpts struct {
 	Set               []string
 	OutputDirTemplate string
+	IncludeCRDs       bool
 }
 
 type TemplateOpt interface{ Apply(*TemplateOpts) }
@@ -1195,6 +1196,10 @@ func (st *HelmState) TemplateReleases(helm helmexec.Interface, outputDir string,
 
 		if validate {
 			flags = append(flags, "--validate")
+		}
+
+		if opts.IncludeCRDs {
+			flags = append(flags, "--include-crds")
 		}
 
 		if len(errs) == 0 {


### PR DESCRIPTION
This allows you to use helmfile-template output as a GitOps source, when the template output contains CRDs and you use Helm 3.

Helm 3 by default removes CRDs from the template output. If you want to git-commit helmfile-template containing CRDs for GitOps and you use Helm 3 for templating, the only way is provide this newly added `--include-crds` flag.