### PR TITLE
Fix the logic of helmfile deps and add tests.

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -105,6 +105,7 @@ func (a *App) Deps(c DepsConfigProvider) error {
 	return a.ForEachState(func(run *Run) (_ bool, errs []error) {
 		prepErr := run.withPreparedCharts("deps", state.ChartPrepareOptions{
 			SkipRepos:   c.SkipRepos(),
+			SkipDeps:    true,
 			SkipResolve: true,
 		}, func() {
 			errs = run.Deps(c)
@@ -122,7 +123,10 @@ func (a *App) Repos(c ReposConfigProvider) error {
 	return a.ForEachState(func(run *Run) (_ bool, errs []error) {
 		var reposErr error
 
-		err := run.withPreparedCharts("repos", state.ChartPrepareOptions{SkipRepos: true}, func() {
+		err := run.withPreparedCharts("repos", state.ChartPrepareOptions{
+			SkipRepos: true,
+			SkipDeps:  true,
+		}, func() {
 			reposErr = run.Repos(c)
 		})
 
@@ -140,7 +144,10 @@ func (a *App) Repos(c ReposConfigProvider) error {
 
 func (a *App) DeprecatedSyncCharts(c DeprecatedChartsConfigProvider) error {
 	return a.ForEachState(func(run *Run) (_ bool, errs []error) {
-		err := run.withPreparedCharts("charts", state.ChartPrepareOptions{SkipRepos: true}, func() {
+		err := run.withPreparedCharts("charts", state.ChartPrepareOptions{
+			SkipRepos: true,
+			SkipDeps:  true,
+		}, func() {
 			errs = run.DeprecatedSyncCharts(c)
 		})
 
@@ -166,7 +173,10 @@ func (a *App) Diff(c DiffConfigProvider) error {
 
 		var errs []error
 
-		prepErr := run.withPreparedCharts("diff", state.ChartPrepareOptions{SkipRepos: c.SkipDeps()}, func() {
+		prepErr := run.withPreparedCharts("diff", state.ChartPrepareOptions{
+			SkipRepos: c.SkipDeps(),
+			SkipDeps:  c.SkipDeps(),
+		}, func() {
 			msg, matched, affected, errs = a.diff(run, c)
 		})
 
@@ -227,6 +237,7 @@ func (a *App) Template(c TemplateConfigProvider) error {
 		prepErr := run.withPreparedCharts("template", state.ChartPrepareOptions{
 			ForceDownload: !run.helm.IsHelm3(),
 			SkipRepos:     c.SkipDeps(),
+			SkipDeps:      c.SkipDeps(),
 		}, func() {
 			ok, errs = a.template(run, c)
 		})
@@ -246,6 +257,7 @@ func (a *App) WriteValues(c WriteValuesConfigProvider) error {
 		prepErr := run.withPreparedCharts("write-values", state.ChartPrepareOptions{
 			ForceDownload: !run.helm.IsHelm3(),
 			SkipRepos:     c.SkipDeps(),
+			SkipDeps:      c.SkipDeps(),
 		}, func() {
 			ok, errs = a.writeValues(run, c)
 		})
@@ -264,6 +276,7 @@ func (a *App) Lint(c LintConfigProvider) error {
 		prepErr := run.withPreparedCharts("lint", state.ChartPrepareOptions{
 			ForceDownload: true,
 			SkipRepos:     c.SkipDeps(),
+			SkipDeps:      c.SkipDeps(),
 		}, func() {
 			errs = run.Lint(c)
 		})
@@ -280,6 +293,7 @@ func (a *App) Sync(c SyncConfigProvider) error {
 	return a.ForEachState(func(run *Run) (ok bool, errs []error) {
 		prepErr := run.withPreparedCharts("sync", state.ChartPrepareOptions{
 			SkipRepos: c.SkipDeps(),
+			SkipDeps:  c.SkipDeps(),
 		}, func() {
 			ok, errs = a.sync(run, c)
 		})
@@ -304,6 +318,7 @@ func (a *App) Apply(c ApplyConfigProvider) error {
 	err := a.ForEachState(func(run *Run) (ok bool, errs []error) {
 		prepErr := run.withPreparedCharts("apply", state.ChartPrepareOptions{
 			SkipRepos: c.SkipDeps(),
+			SkipDeps:  c.SkipDeps(),
 		}, func() {
 			matched, updated, es := a.apply(run, c)
 
@@ -338,6 +353,7 @@ func (a *App) Status(c StatusesConfigProvider) error {
 	return a.ForEachState(func(run *Run) (_ bool, errs []error) {
 		err := run.withPreparedCharts("status", state.ChartPrepareOptions{
 			SkipRepos: true,
+			SkipDeps:  true,
 		}, func() {
 			errs = run.Status(c)
 		})
@@ -354,6 +370,7 @@ func (a *App) Delete(c DeleteConfigProvider) error {
 	return a.ForEachState(func(run *Run) (ok bool, errs []error) {
 		err := run.withPreparedCharts("delete", state.ChartPrepareOptions{
 			SkipRepos: true,
+			SkipDeps:  true,
 		}, func() {
 			ok, errs = a.delete(run, c.Purge(), c)
 		})
@@ -370,6 +387,7 @@ func (a *App) Destroy(c DestroyConfigProvider) error {
 	return a.ForEachState(func(run *Run) (ok bool, errs []error) {
 		err := run.withPreparedCharts("destroy", state.ChartPrepareOptions{
 			SkipRepos: true,
+			SkipDeps:  true,
 		}, func() {
 			ok, errs = a.delete(run, true, c)
 		})
@@ -392,6 +410,7 @@ func (a *App) Test(c TestConfigProvider) error {
 
 		err := run.withPreparedCharts("test", state.ChartPrepareOptions{
 			SkipRepos: true,
+			SkipDeps:  true,
 		}, func() {
 			errs = a.test(run, c)
 		})
@@ -408,6 +427,7 @@ func (a *App) PrintState(c StateConfigProvider) error {
 	return a.ForEachState(func(run *Run) (_ bool, errs []error) {
 		err := run.withPreparedCharts("build", state.ChartPrepareOptions{
 			SkipRepos: true,
+			SkipDeps:  true,
 		}, func() {
 			if c.EmbedValues() {
 				for i := range run.state.Releases {
@@ -456,6 +476,7 @@ func (a *App) ListReleases(c ListConfigProvider) error {
 	err := a.ForEachState(func(run *Run) (_ bool, errs []error) {
 		err := run.withPreparedCharts("list", state.ChartPrepareOptions{
 			SkipRepos: true,
+			SkipDeps:  true,
 		}, func() {
 
 			//var releases m
@@ -587,14 +608,15 @@ func (a *App) loadDesiredStateFromYaml(file string, opts ...LoadOpts) (*state.He
 	}
 
 	ld := &desiredStateLoader{
-		readFile:   a.readFile,
-		deleteFile: a.deleteFile,
-		fileExists: a.fileExists,
-		env:        a.Env,
-		namespace:  a.Namespace,
-		logger:     a.Logger,
-		abs:        a.abs,
-		remote:     a.remote,
+		readFile:          a.readFile,
+		deleteFile:        a.deleteFile,
+		fileExists:        a.fileExists,
+		directoryExistsAt: a.directoryExistsAt,
+		env:               a.Env,
+		namespace:         a.Namespace,
+		logger:            a.Logger,
+		abs:               a.abs,
+		remote:            a.remote,
 
 		overrideKubeContext: a.OverrideKubeContext,
 		overrideHelmBinary:  a.OverrideHelmBinary,

--- a/pkg/app/desired_state_file_loader.go
+++ b/pkg/app/desired_state_file_loader.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"path/filepath"
+
 	"github.com/imdario/mergo"
 	"github.com/roboll/helmfile/pkg/environment"
 	"github.com/roboll/helmfile/pkg/helmexec"
@@ -11,7 +13,6 @@ import (
 	"github.com/roboll/helmfile/pkg/state"
 	"github.com/variantdev/vals"
 	"go.uber.org/zap"
-	"path/filepath"
 )
 
 const (
@@ -25,12 +26,13 @@ type desiredStateLoader struct {
 	env       string
 	namespace string
 
-	readFile   func(string) ([]byte, error)
-	deleteFile func(string) error
-	fileExists func(string) (bool, error)
-	abs        func(string) (string, error)
-	glob       func(string) ([]string, error)
-	getHelm    func(*state.HelmState) helmexec.Interface
+	readFile          func(string) ([]byte, error)
+	deleteFile        func(string) error
+	fileExists        func(string) (bool, error)
+	abs               func(string) (string, error)
+	glob              func(string) ([]string, error)
+	directoryExistsAt func(string) bool
+	getHelm           func(*state.HelmState) helmexec.Interface
 
 	remote      *remote.Remote
 	logger      *zap.SugaredLogger
@@ -144,7 +146,7 @@ func (ld *desiredStateLoader) loadFileWithOverrides(inheritedEnv, overrodeEnv *e
 }
 
 func (a *desiredStateLoader) underlying() *state.StateCreator {
-	c := state.NewCreator(a.logger, a.readFile, a.fileExists, a.abs, a.glob, a.valsRuntime, a.getHelm, a.overrideHelmBinary, a.remote)
+	c := state.NewCreator(a.logger, a.readFile, a.fileExists, a.abs, a.glob, a.directoryExistsAt, a.valsRuntime, a.getHelm, a.overrideHelmBinary, a.remote)
 	c.DeleteFile = a.deleteFile
 	c.LoadFile = a.loadFile
 	return c

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -2,19 +2,20 @@ package remote
 
 import (
 	"fmt"
+	"os"
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/roboll/helmfile/pkg/helmexec"
 	"github.com/roboll/helmfile/pkg/testhelper"
-	"os"
-	"testing"
 )
 
 func TestRemote_HttpsGitHub(t *testing.T) {
 	cleanfs := map[string]string{
-		"path/to/home": "",
+		"/path/to/home": "",
 	}
 	cachefs := map[string]string{
-		"path/to/home/.helmfile/cache/https_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml": "foo: bar",
+		"/path/to/home/.helmfile/cache/https_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml": "foo: bar",
 	}
 
 	type testcase struct {
@@ -36,7 +37,7 @@ func TestRemote_HttpsGitHub(t *testing.T) {
 			hit := true
 
 			get := func(wd, src, dst string) error {
-				if wd != "path/to/home" {
+				if wd != "/path/to/home" {
 					return fmt.Errorf("unexpected wd: %s", wd)
 				}
 				if src != "git::https://github.com/cloudposse/helmfiles.git?ref=0.40.0" {
@@ -53,7 +54,7 @@ func TestRemote_HttpsGitHub(t *testing.T) {
 			}
 			remote := &Remote{
 				Logger:     helmexec.NewLogger(os.Stderr, "debug"),
-				Home:       "path/to/home",
+				Home:       "/path/to/home",
 				Getter:     getter,
 				ReadFile:   testfs.ReadFile,
 				FileExists: testfs.FileExistsAt,
@@ -72,7 +73,7 @@ func TestRemote_HttpsGitHub(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			if file != "path/to/home/.helmfile/cache/https_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml" {
+			if file != "/path/to/home/.helmfile/cache/https_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml" {
 				t.Errorf("unexpected file located: %s", file)
 			}
 
@@ -88,10 +89,10 @@ func TestRemote_HttpsGitHub(t *testing.T) {
 
 func TestRemote_SShGitHub(t *testing.T) {
 	cleanfs := map[string]string{
-		"path/to/home": "",
+		"/path/to/home": "",
 	}
 	cachefs := map[string]string{
-		"path/to/home/.helmfile/cache/ssh_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml": "foo: bar",
+		"/path/to/home/.helmfile/cache/ssh_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml": "foo: bar",
 	}
 
 	type testcase struct {
@@ -113,7 +114,7 @@ func TestRemote_SShGitHub(t *testing.T) {
 			hit := true
 
 			get := func(wd, src, dst string) error {
-				if wd != "path/to/home" {
+				if wd != "/path/to/home" {
 					return fmt.Errorf("unexpected wd: %s", wd)
 				}
 				if src != "git::ssh://git@github.com/cloudposse/helmfiles.git?ref=0.40.0" {
@@ -130,7 +131,7 @@ func TestRemote_SShGitHub(t *testing.T) {
 			}
 			remote := &Remote{
 				Logger:     helmexec.NewLogger(os.Stderr, "debug"),
-				Home:       "path/to/home",
+				Home:       "/path/to/home",
 				Getter:     getter,
 				ReadFile:   testfs.ReadFile,
 				FileExists: testfs.FileExistsAt,
@@ -143,7 +144,7 @@ func TestRemote_SShGitHub(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			if file != "path/to/home/.helmfile/cache/ssh_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml" {
+			if file != "/path/to/home/.helmfile/cache/ssh_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml" {
 				t.Errorf("unexpected file located: %s", file)
 			}
 

--- a/pkg/state/create_test.go
+++ b/pkg/state/create_test.go
@@ -1,12 +1,13 @@
 package state
 
 import (
-	"github.com/roboll/helmfile/pkg/remote"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/roboll/helmfile/pkg/remote"
 
 	"github.com/roboll/helmfile/pkg/testhelper"
 	"go.uber.org/zap"
@@ -83,7 +84,7 @@ func (testEnv stateTestEnv) MustLoadState(t *testing.T, file, envName string) *H
 	}
 
 	r := remote.NewRemote(logger, testFs.Cwd, testFs.ReadFile, testFs.DirectoryExistsAt, testFs.FileExistsAt)
-	state, err := NewCreator(logger, testFs.ReadFile, testFs.FileExists, testFs.Abs, testFs.Glob, nil, nil, "", r).
+	state, err := NewCreator(logger, testFs.ReadFile, testFs.FileExists, testFs.Abs, testFs.Glob, testFs.DirectoryExistsAt, nil, nil, "", r).
 		ParseAndLoad([]byte(yamlContent), filepath.Dir(file), file, envName, true, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -148,7 +149,7 @@ releaseNamespace: mynamespace
 	testFs.Cwd = "/example/path/to"
 
 	r := remote.NewRemote(logger, testFs.Cwd, testFs.ReadFile, testFs.DirectoryExistsAt, testFs.FileExistsAt)
-	state, err := NewCreator(logger, testFs.ReadFile, testFs.FileExists, testFs.Abs, testFs.Glob, nil, nil, "", r).
+	state, err := NewCreator(logger, testFs.ReadFile, testFs.FileExists, testFs.Abs, testFs.Glob, testFs.DirectoryExistsAt, nil, nil, "", r).
 		ParseAndLoad(yamlContent, filepath.Dir(yamlFile), yamlFile, "production", true, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -235,7 +236,7 @@ overrideNamespace: myns
 	testFs.Cwd = "/example/path/to"
 
 	r := remote.NewRemote(logger, testFs.Cwd, testFs.ReadFile, testFs.DirectoryExistsAt, testFs.FileExistsAt)
-	state, err := NewCreator(logger, testFs.ReadFile, testFs.FileExists, testFs.Abs, testFs.Glob, nil, nil, "", r).
+	state, err := NewCreator(logger, testFs.ReadFile, testFs.FileExists, testFs.Abs, testFs.Glob, testFs.DirectoryExistsAt, nil, nil, "", r).
 		ParseAndLoad(yamlContent, filepath.Dir(yamlFile), yamlFile, "production", true, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/pkg/testhelper/testfs.go
+++ b/pkg/testhelper/testfs.go
@@ -39,7 +39,7 @@ func NewTestFs(files map[string]string) *TestFs {
 
 func (f *TestFs) FileExistsAt(path string) bool {
 	var ok bool
-	if strings.Contains(path, "/") {
+	if strings.HasPrefix(path, "/") {
 		_, ok = f.files[path]
 	} else {
 		_, ok = f.files[filepath.Join(f.Cwd, path)]
@@ -53,7 +53,7 @@ func (f *TestFs) FileExists(path string) (bool, error) {
 
 func (f *TestFs) DirectoryExistsAt(path string) bool {
 	var ok bool
-	if strings.Contains(path, "/") {
+	if strings.HasPrefix(path, "/") {
 		_, ok = f.dirs[path]
 	} else {
 		_, ok = f.dirs[filepath.Join(f.Cwd, path)]
@@ -64,7 +64,7 @@ func (f *TestFs) DirectoryExistsAt(path string) bool {
 func (f *TestFs) ReadFile(filename string) ([]byte, error) {
 	var str string
 	var ok bool
-	if filename[0] == '/' {
+	if strings.HasPrefix(filename, "/") {
 		str, ok = f.files[filename]
 	} else {
 		str, ok = f.files[filepath.Join(f.Cwd, filename)]
@@ -90,7 +90,7 @@ func (f *TestFs) FileReaderCalls() int {
 
 func (f *TestFs) Glob(relPattern string) ([]string, error) {
 	var pattern string
-	if relPattern[0] == '/' {
+	if strings.HasPrefix(relPattern, "/") {
 		pattern = relPattern
 	} else {
 		pattern = filepath.Join(f.Cwd, relPattern)
@@ -116,7 +116,7 @@ func (f *TestFs) Glob(relPattern string) ([]string, error) {
 
 func (f *TestFs) Abs(path string) (string, error) {
 	var p string
-	if path[0] == '/' {
+	if strings.HasPrefix(path, "/") {
 		p = path
 	} else {
 		p = filepath.Join(f.Cwd, path)


### PR DESCRIPTION
## Context

`helmfile.yaml`:

```yaml
repositories:
  - name: bitnami
    url: https://charts.bitnami.com/bitnami/

releases:
  - name: example # this chart contains a dep
    chart: ./charts/example
```

`./charts/example/Chart.yaml`:

```yaml
apiVersion: v2
name: example
description: A Helm chart for Kubernetes

type: application
version: 0.1.0
appVersion: 1.16.0

dependencies:
  - name: redis
    version: ^10.7.0
    repository: alias:bitnami
```

When I run `helmfile deps --skip-repos` with the helmfile.yaml above, it skips updating the deps of the local chart `example`:

```
$ helmfile deps --skip-repos
There are no repositories defined in your helmfile.yaml.
This means helmfile cannot update your dependencies or create a lock file.
See https://github.com/roboll/helmfile/issues/878 for more information.
```

What I was expecting is that helmfile updates all the dependencies of the chart, like what helmfiles does without the option `--skip-repos` (but skips adding repos of course):

```
$ helmfile deps
Adding repo bitnami https://charts.bitnami.com/bitnami/
"bitnami" has been added to your repositories

Building dependency release=darwinia-bridge, chart=charts/darwinia-bridge
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "bitnami" chart repository
Update Complete. ⎈Happy Helming!⎈
Saving 1 charts
Downloading redis from repo https://charts.bitnami.com/bitnami/
Deleting outdated charts

There are no repositories defined in your helmfile.yaml.
This means helmfile cannot update your dependencies or create a lock file.
See https://github.com/roboll/helmfile/issues/878 for more information.
```

## The Problem

While I was digging into this issue, I found that the problem is not caused by `--skip-repos` itself.

In fact, logics in `UpdateDeps`:

<https://github.com/roboll/helmfile/blob/f6bf885fb76d71e4008601532aabd2841c4f3b20/pkg/state/state.go#L1928-L1937>

will never get executed, as `release.Chart` is already "normalized path", which means, it won't be considered as a local chart anymore. Here is where the chart get "normalized":

<https://github.com/roboll/helmfile/blob/f6bf885fb76d71e4008601532aabd2841c4f3b20/pkg/app/run.go#L62-L74>

`releaseToChart` contains the paths proceeded by `normalizeChart(st.basePath, chartPath)`, and `rel.Chart = chart` overrides the original chart paths in releases.

In order to fix that, I've decided not to break the current behavior of `PrepareCharts` but change the logic of determining if it's a local chart.

Firstly, I changed `if isLocalChart(release.Chart)` to `if pathExists(release.Chart)`. However, I changed it again to the func `DirectoryExistsAt` to make it mockable in unit tests. 

## Other Changes in the PR

### Add `SkipDeps` in struct `ChartPrepareOptions`

`PrepareCharts` skips executing `helm dep build` when `SkipRepos` is true:

<https://github.com/roboll/helmfile/blob/f6bf885fb76d71e4008601532aabd2841c4f3b20/pkg/state/state.go#L943-L948>

<https://github.com/roboll/helmfile/blob/f6bf885fb76d71e4008601532aabd2841c4f3b20/pkg/state/state.go#L1086-L1090>

Therefore, if I run `helmfile deps --skip-repos`:

1. PrepareCharts not executing `st.runHelmDepBuilds`. ✅
2. Then execute `UpdateDeps`. ✅

If run `helmfile deps`:

1. PrepareCharts executing `st.runHelmDepBuilds`. ❌ (Unnecessary)
2. Then execute `UpdateDeps`. ✅

PrepareCharts shouldn't use `SkipRepos` as the condition of running `helm dep build` or not. So I added another flag `SkipDeps` in struct to control whether PrepareCharts needs to build the deps.

### Helper functions in testfs

<https://github.com/roboll/helmfile/blob/f6bf885fb76d71e4008601532aabd2841c4f3b20/pkg/testhelper/testfs.go#L54-L62>

Determining absolute paths with `strings.Contains` sounds not ideal. Changed to `strings.HasPrefix(path, "/")`.

<https://github.com/roboll/helmfile/blob/f6bf885fb76d71e4008601532aabd2841c4f3b20/pkg/testhelper/testfs.go#L64-L74>

`path[0] == '/'` can lead to nil pointer error with empty string `path`. Changed to `strings.HasPrefix(path, "/")`.

### Add and fix tests

- Move several test cases from `TestHelmState_UpdateDeps` to `Test_normalizeChart`.
- Mock the fs and add test cases in `TestHelmState_UpdateDeps`.
- Add `TestDeps` in `pkg/app/app_test.go`.
- Fix tests in `pkg/remote/remote_test.go` with respect to the changes of `testfs`.
- Output logs when skipping updating deps for remote chart.