### PR TITLE
Fix selector syntax in example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -26,7 +26,7 @@ You would then start a database migration job by executing:
 
 ```console
 # Start a database migration for the prod environment
-$ RAILS_ENV=prod helmfile sync --selector job=dbmigrator
+$ RAILS_ENV=prod helmfile --selector job=dbmigrator sync
 
 # Tail log until you are satisfied
 $ kubectl logs -l job=dbmigrator


### PR DESCRIPTION
The current example in the documentation for using the selector flag doesn't work. It looks like the order matters.

`helmfile sync --selector job=dbmigrator` gives me `Incorrect Usage: flag provided but not defined: -selector`.