### PR TITLE
Stabilize helmfile-diff output

### DIFF
--- a/pkg/helmexec/context.go
+++ b/pkg/helmexec/context.go
@@ -1,6 +1,7 @@
 package helmexec
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 )
@@ -10,6 +11,7 @@ type HelmContext struct {
 	TillerNamespace string
 	HistoryMax      int
 	WorkerIndex     int
+	Writer          io.Writer
 }
 
 func (context *HelmContext) GetTillerlessArgs(helm *execer) []string {


### PR DESCRIPTION
`helmfile-diff` sorts multiple and concurrent helm-diff outputs and stabilizes writes to stdout.

It's required to use the stdout from helmfile-diff to detect if there was change(s) between 2 points in time.

For example, terraform-provider-helmfile runs a helmfile-diff on `terraform plan` and another on `terraform apply`.

`terraform`, by design, fails when helmfile-diff outputs were not equivalent, meaning that the plan is outdated and the user needs to rerun `terraform plan` against the live state.

Unstable helmfile-diff outputs results in this terraform's outdated-plan-detection to unexpectedly triggered, even if there were no changes in the helmfile.yaml/templates/manifests and the cluster's live state. Stabilizing helmfile-diff output fixes that.
