### PR TITLE
Include kustomize binary in helm3-based Docker image

### DIFF
--- a/Dockerfile.helm3
+++ b/Dockerfile.helm3
@@ -36,6 +36,15 @@ RUN set -x && \
     chmod +x kubectl && \
     mv kubectl /usr/local/bin/kubectl
 
+ENV KUSTOMIZE_VERSION="v3.8.8"
+ENV KUSTOMIZE_SHA256="175938206f23956ec18dac3da0816ea5b5b485a8493a839da278faac82e3c303"
+RUN set -x && \
+    curl --retry 5 --retry-connrefused -LO https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz && \
+    sha256sum kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz | grep ${KUSTOMIZE_SHA256} && \
+    tar zxf kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz && \
+    rm kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz && \
+    mv kustomize /usr/local/bin/kustomize
+
 RUN helm plugin install https://github.com/databus23/helm-diff --version v3.1.3 && \
     helm plugin install https://github.com/futuresimple/helm-secrets && \
     helm plugin install https://github.com/hypnoglow/helm-s3.git && \
@@ -43,4 +52,4 @@ RUN helm plugin install https://github.com/databus23/helm-diff --version v3.1.3 
 
 COPY --from=builder /workspace/helmfile/dist/helmfile_linux_amd64 /usr/local/bin/helmfile
 
-CMD ["/usr/local/bin/helmfile", "--help"]
+CMD ["/usr/local/bin/helmfile"]


### PR DESCRIPTION
In order to use the newly included Kustomize Transformers functionality (#1592), I propose to include the `kustomize` binary in the Docker image.
I understand that it will make the image size significantly larger, but is that a problem?
The alternative would be to provide another flavor of the image, e.g. `helm3-kustomize-v0.135.0`, but is it worth the hassle?