### PR TITLE
fix: dont sent RegistryLogin password via args

### DIFF
--- a/pkg/helmexec/exec.go
+++ b/pkg/helmexec/exec.go
@@ -166,8 +166,7 @@ func (helm *execer) RegistryLogin(repository string, username string, password s
 		repository,
 		"--username",
 		username,
-		"--password",
-		password,
+		"--password-stdin",
 	}
 	buffer := bytes.Buffer{}
 	buffer.Write([]byte(fmt.Sprintf("%s\n", password)))


### PR DESCRIPTION
Password is already being sent via stdin, so change the args to use password from stdin, and don't send password via args