### PR TITLE
Add ability to control skipping Deps and Repos separately

### DIFF
--- a/main.go
+++ b/main.go
@@ -186,7 +186,11 @@ func main() {
 				},
 				cli.BoolFlag{
 					Name:  "skip-deps",
-					Usage: `skip running "helm repo update" and "helm dependency build"`,
+					Usage: `skip running "helm dependency build"`,
+				},
+				cli.BoolFlag{
+					Name:  "skip-repos",
+					Usage: `skip running "helm repo update" before running "helm dependency build"`,
 				},
 				cli.BoolFlag{
 					Name:  "detailed-exitcode",
@@ -255,7 +259,11 @@ func main() {
 				},
 				cli.BoolFlag{
 					Name:  "skip-deps",
-					Usage: `skip running "helm repo update" and "helm dependency build"`,
+					Usage: `skip running "helm dependency build"`,
+				},
+				cli.BoolFlag{
+					Name:  "skip-repos",
+					Usage: `skip running "helm repo update" before running "helm dependency build"`,
 				},
 				cli.BoolFlag{
 					Name:  "skip-cleanup",
@@ -289,7 +297,11 @@ func main() {
 				},
 				cli.BoolFlag{
 					Name:  "skip-deps",
-					Usage: `skip running "helm repo update" and "helm dependency build"`,
+					Usage: `skip running "helm dependency build"`,
+				},
+				cli.BoolFlag{
+					Name:  "skip-repos",
+					Usage: `skip running "helm repo update" before running "helm dependency build"`,
 				},
 			},
 			Action: action(func(run *app.App, c configImpl) error {
@@ -320,7 +332,11 @@ func main() {
 				},
 				cli.BoolFlag{
 					Name:  "skip-deps",
-					Usage: `skip running "helm repo update" and "helm dependency build"`,
+					Usage: `skip running "helm dependency build"`,
+				},
+				cli.BoolFlag{
+					Name:  "skip-repos",
+					Usage: `skip running "helm repo update" before running "helm dependency build"`,
 				},
 			},
 			Action: action(func(run *app.App, c configImpl) error {
@@ -351,7 +367,11 @@ func main() {
 				},
 				cli.BoolFlag{
 					Name:  "skip-deps",
-					Usage: `skip running "helm repo update" and "helm dependency build"`,
+					Usage: `skip running "helm dependency build"`,
+				},
+				cli.BoolFlag{
+					Name:  "skip-repos",
+					Usage: `skip running "helm repo update" before running "helm dependency build"`,
 				},
 			},
 			Action: action(func(run *app.App, c configImpl) error {
@@ -415,7 +435,11 @@ func main() {
 				},
 				cli.BoolFlag{
 					Name:  "skip-deps",
-					Usage: `skip running "helm repo update" and "helm dependency build"`,
+					Usage: `skip running "helm dependency build"`,
+				},
+				cli.BoolFlag{
+					Name:  "skip-repos",
+					Usage: `skip running "helm repo update" before running "helm dependency build"`,
 				},
 			},
 			Action: action(func(run *app.App, c configImpl) error {

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -174,7 +174,7 @@ func (a *App) Diff(c DiffConfigProvider) error {
 		var errs []error
 
 		prepErr := run.withPreparedCharts("diff", state.ChartPrepareOptions{
-			SkipRepos: c.SkipDeps(),
+			SkipRepos: c.SkipRepos(),
 			SkipDeps:  c.SkipDeps(),
 		}, func() {
 			msg, matched, affected, errs = a.diff(run, c)
@@ -236,7 +236,7 @@ func (a *App) Template(c TemplateConfigProvider) error {
 		// So, we set forceDownload=true for helm v2 only
 		prepErr := run.withPreparedCharts("template", state.ChartPrepareOptions{
 			ForceDownload: !run.helm.IsHelm3(),
-			SkipRepos:     c.SkipDeps(),
+			SkipRepos:     c.SkipRepos(),
 			SkipDeps:      c.SkipDeps(),
 		}, func() {
 			ok, errs = a.template(run, c)
@@ -256,7 +256,7 @@ func (a *App) WriteValues(c WriteValuesConfigProvider) error {
 		// So, we set forceDownload=true for helm v2 only
 		prepErr := run.withPreparedCharts("write-values", state.ChartPrepareOptions{
 			ForceDownload: !run.helm.IsHelm3(),
-			SkipRepos:     c.SkipDeps(),
+			SkipRepos:     c.SkipRepos(),
 			SkipDeps:      c.SkipDeps(),
 		}, func() {
 			ok, errs = a.writeValues(run, c)
@@ -275,7 +275,7 @@ func (a *App) Lint(c LintConfigProvider) error {
 		// `helm lint` on helm v2 and v3 does not support remote charts, that we need to set `forceDownload=true` here
 		prepErr := run.withPreparedCharts("lint", state.ChartPrepareOptions{
 			ForceDownload: true,
-			SkipRepos:     c.SkipDeps(),
+			SkipRepos:     c.SkipRepos(),
 			SkipDeps:      c.SkipDeps(),
 		}, func() {
 			errs = run.Lint(c)
@@ -292,7 +292,7 @@ func (a *App) Lint(c LintConfigProvider) error {
 func (a *App) Sync(c SyncConfigProvider) error {
 	return a.ForEachState(func(run *Run) (ok bool, errs []error) {
 		prepErr := run.withPreparedCharts("sync", state.ChartPrepareOptions{
-			SkipRepos: c.SkipDeps(),
+			SkipRepos: c.SkipRepos(),
 			SkipDeps:  c.SkipDeps(),
 		}, func() {
 			ok, errs = a.sync(run, c)
@@ -317,7 +317,7 @@ func (a *App) Apply(c ApplyConfigProvider) error {
 
 	err := a.ForEachState(func(run *Run) (ok bool, errs []error) {
 		prepErr := run.withPreparedCharts("apply", state.ChartPrepareOptions{
-			SkipRepos: c.SkipDeps(),
+			SkipRepos: c.SkipRepos(),
 			SkipDeps:  c.SkipDeps(),
 		}, func() {
 			matched, updated, es := a.apply(run, c)

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -39,6 +39,7 @@ type ApplyConfigProvider interface {
 	Values() []string
 	Set() []string
 	SkipDeps() bool
+	SkipRepos() bool
 
 	IncludeTests() bool
 
@@ -65,6 +66,7 @@ type SyncConfigProvider interface {
 	Values() []string
 	Set() []string
 	SkipDeps() bool
+	SkipRepos() bool
 
 	concurrencyConfig
 	loggingConfig
@@ -76,6 +78,7 @@ type DiffConfigProvider interface {
 	Values() []string
 	Set() []string
 	SkipDeps() bool
+	SkipRepos() bool
 
 	IncludeTests() bool
 
@@ -123,6 +126,7 @@ type LintConfigProvider interface {
 	Values() []string
 	Set() []string
 	SkipDeps() bool
+	SkipRepos() bool
 
 	concurrencyConfig
 }
@@ -135,6 +139,7 @@ type TemplateConfigProvider interface {
 	OutputDirTemplate() string
 	Validate() bool
 	SkipDeps() bool
+	SkipRepos() bool
 	SkipCleanup() bool
 	OutputDir() string
 	IncludeCRDs() bool
@@ -147,6 +152,7 @@ type WriteValuesConfigProvider interface {
 	Set() []string
 	OutputFileTemplate() string
 	SkipDeps() bool
+	SkipRepos() bool
 }
 
 type StatusesConfigProvider interface {


### PR DESCRIPTION
Right now we have only one flag which passed to both variables, which isn't flexible as we would like to.

Main problem in our case that we are using Helmfile with envs. In each env we can have different version of remote chart. To apply that configuration in parallel we would like to split repos sync and deps build into 2 stages.

Repos sync can't be executed in parralel because it cause helm locks and `context deadline exceeded` exceptions.