### PR TITLE
fix: make --kube-context override helmDefaults

### DIFF
--- a/pkg/app/desired_state_file_loader.go
+++ b/pkg/app/desired_state_file_loader.go
@@ -72,9 +72,6 @@ func (ld *desiredStateLoader) Load(f string, opts LoadOpts) (*state.HelmState, e
 	}
 
 	if ld.overrideKubeContext != "" {
-		if st.HelmDefaults.KubeContext != "" {
-			return nil, errors.New("err: Cannot use option --kube-context and set attribute helmDefaults.kubeContext.")
-		}
 		st.HelmDefaults.KubeContext = ld.overrideKubeContext
 	}
 


### PR DESCRIPTION
This would allow cli flag `--kube-context` to override value in helmDefaults allowing to use different values in local development and CI context.