### PR TITLE
Add support for kubeContext in environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,8 @@ environments:
     # Use "Warn", "Info", or "Debug" if you want helmfile to not fail when a values file is missing, while just leaving
     # a message about the missing file at the log-level.
     missingFileHandler: Error
+    # kubeContext to use for this environment
+    kubeContext: kube-context
 
 #
 # Advanced Configuration: Layering

--- a/pkg/state/environment.go
+++ b/pkg/state/environment.go
@@ -1,8 +1,9 @@
 package state
 
 type EnvironmentSpec struct {
-	Values  []interface{} `yaml:"values,omitempty"`
-	Secrets []string      `yaml:"secrets,omitempty"`
+	Values      []interface{} `yaml:"values,omitempty"`
+	Secrets     []string      `yaml:"secrets,omitempty"`
+	KubeContext string        `yaml:"kubeContext,omitempty"`
 
 	// MissingFileHandler instructs helmfile to fail when unable to find a environment values file listed
 	// under `environments.NAME.values`.

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -2172,6 +2172,8 @@ func (st *HelmState) connectionFlags(helm helmexec.Interface, release *ReleaseSp
 
 		if release.KubeContext != "" {
 			flags = append(flags, "--kube-context", release.KubeContext)
+		} else if st.Environments[st.Env.Name].KubeContext != "" {
+			flags = append(flags, "--kube-context", st.Environments[st.Env.Name].KubeContext)
 		} else if st.HelmDefaults.KubeContext != "" {
 			flags = append(flags, "--kube-context", st.HelmDefaults.KubeContext)
 		}


### PR DESCRIPTION
This PR add the support for kubeContext in environments configuration, it resolves #898 

If a kubeContext is specified in the release this kubeContext is used instead of the one defined in the environment.