### PR TITLE
Update reference for helm-secrets to latest maintained fork

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN set -x & \
 
 RUN ["helm", "init", "--client-only", "--stable-repo-url", "https://charts.helm.sh/stable"]
 RUN helm plugin install https://github.com/databus23/helm-diff && \
-    helm plugin install https://github.com/jkroepke/helm-secrets && \
+    helm plugin install https://github.com/futuresimple/helm-secrets && \
     helm plugin install https://github.com/hypnoglow/helm-s3.git && \
     helm plugin install https://github.com/aslafy-z/helm-git.git && \
     helm plugin install https://github.com/rimusz/helm-tiller

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN set -x & \
 
 RUN ["helm", "init", "--client-only", "--stable-repo-url", "https://charts.helm.sh/stable"]
 RUN helm plugin install https://github.com/databus23/helm-diff && \
-    helm plugin install https://github.com/futuresimple/helm-secrets && \
+    helm plugin install https://github.com/jkroepke/helm-secrets && \
     helm plugin install https://github.com/hypnoglow/helm-s3.git && \
     helm plugin install https://github.com/aslafy-z/helm-git.git && \
     helm plugin install https://github.com/rimusz/helm-tiller

--- a/Dockerfile.helm3
+++ b/Dockerfile.helm3
@@ -46,7 +46,7 @@ RUN set -x && \
     mv kustomize /usr/local/bin/kustomize
 
 RUN helm plugin install https://github.com/databus23/helm-diff --version v3.1.3 && \
-    helm plugin install https://github.com/futuresimple/helm-secrets && \
+    helm plugin install https://github.com/jkroepke/helm-secrets && \
     helm plugin install https://github.com/hypnoglow/helm-s3.git && \
     helm plugin install https://github.com/aslafy-z/helm-git.git
 

--- a/README.md
+++ b/README.md
@@ -547,10 +547,10 @@ Note that `delete` doesn't purge releases. So `helmfile delete && helmfile sync`
 
 ### secrets
 
-The `secrets` parameter in a `helmfile.yaml` causes the [helm-secrets](https://github.com/futuresimple/helm-secrets) plugin to be executed to decrypt the file.
+The `secrets` parameter in a `helmfile.yaml` causes the [helm-secrets](https://github.com/jkroepke/helm-secrets) plugin to be executed to decrypt the file.
 
 To supply the secret functionality Helmfile needs the `helm secrets` plugin installed. For Helm 2.3+
-you should be able to simply execute `helm plugin install https://github.com/futuresimple/helm-secrets
+you should be able to simply execute `helm plugin install https://github.com/jkroepke/helm-secrets
 `.
 
 ### test
@@ -849,7 +849,7 @@ Environment Secrets (not to be confused with Kubernetes Secrets) are encrypted v
 You can list any number of `secrets.yaml` files created using `helm secrets` or `sops`, so that
 Helmfile could automatically decrypt and merge the secrets into the environment values.
 
-First you must have the [helm-secrets](https://github.com/futuresimple/helm-secrets) plugin installed along with a
+First you must have the [helm-secrets](https://github.com/jkroepke/helm-secrets) plugin installed along with a
 `.sops.yaml` file to configure the method of encryption (this can be in the same directory as your helmfile or
 in the sub-directory containing your secrets files).
 

--- a/docs/remote-secrets.md
+++ b/docs/remote-secrets.md
@@ -1,6 +1,6 @@
 # Secrets 
 
-helmfile can handle secrets using [helm-secrets](https://github.com/zendesk/helm-secrets) plugin or using remote secrets storage 
+helmfile can handle secrets using [helm-secrets](https://github.com/jkroepke/helm-secrets) plugin or using remote secrets storage 
 (everything that package [vals](https://github.com/variantdev/vals) can handle vault, AWS SSM etc)  
 This section will describe the second use case. 
 


### PR DESCRIPTION
Minor reference fix to the latest place to find helm-secrets.
Tested the plugin myself and works without an problems.

Resolves https://github.com/roboll/helmfile/issues/1632