### PR TITLE
Add ability to specify / override helmDefaults.wait via cli

### DIFF
--- a/main.go
+++ b/main.go
@@ -353,6 +353,10 @@ func main() {
 					Name:  "skip-deps",
 					Usage: `skip running "helm repo update" and "helm dependency build"`,
 				},
+				cli.BoolFlag{
+					Name:  "wait",
+					Usage: `Override helmDefaults.wait setting "helm upgrade --install --wait"`,
+				},
 			},
 			Action: action(func(run *app.App, c configImpl) error {
 				return run.Sync(c)
@@ -416,6 +420,10 @@ func main() {
 				cli.BoolFlag{
 					Name:  "skip-deps",
 					Usage: `skip running "helm repo update" and "helm dependency build"`,
+				},
+				cli.BoolFlag{
+					Name:  "wait",
+					Usage: `Override helmDefaults.wait setting "helm upgrade --install --wait"`,
 				},
 			},
 			Action: action(func(run *app.App, c configImpl) error {
@@ -601,6 +609,10 @@ func (c configImpl) Set() []string {
 
 func (c configImpl) SkipRepos() bool {
 	return c.c.Bool("skip-repos")
+}
+
+func (c configImpl) Wait() bool {
+	return c.c.Bool("wait")
 }
 
 func (c configImpl) Values() []string {

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -294,6 +294,7 @@ func (a *App) Sync(c SyncConfigProvider) error {
 		prepErr := run.withPreparedCharts("sync", state.ChartPrepareOptions{
 			SkipRepos: c.SkipDeps(),
 			SkipDeps:  c.SkipDeps(),
+			Wait:      c.Wait(),
 		}, func() {
 			ok, errs = a.sync(run, c)
 		})
@@ -319,6 +320,7 @@ func (a *App) Apply(c ApplyConfigProvider) error {
 		prepErr := run.withPreparedCharts("apply", state.ChartPrepareOptions{
 			SkipRepos: c.SkipDeps(),
 			SkipDeps:  c.SkipDeps(),
+			Wait:      c.Wait(),
 		}, func() {
 			matched, updated, es := a.apply(run, c)
 
@@ -1179,6 +1181,7 @@ Do you really want to apply?
 				syncOpts := state.SyncOpts{
 					Set:         c.Set(),
 					SkipCleanup: c.RetainValuesFiles() || c.SkipCleanup(),
+					Wait:        c.Wait(),
 				}
 				return subst.SyncReleases(&affectedReleases, helm, c.Values(), c.Concurrency(), &syncOpts)
 			}))
@@ -1393,7 +1396,8 @@ func (a *App) sync(r *Run, c SyncConfigProvider) (bool, []error) {
 			subst.Releases = rs
 
 			opts := &state.SyncOpts{
-				Set: c.Set(),
+				Set:  c.Set(),
+				Wait: c.Wait(),
 			}
 			return subst.SyncReleases(&affectedReleases, helm, c.Values(), c.Concurrency(), opts)
 		}))

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -2315,10 +2315,15 @@ type applyConfig struct {
 	interactive       bool
 	skipDiffOnInstall bool
 	logger            *zap.SugaredLogger
+	wait              bool
 }
 
 func (a applyConfig) Args() string {
 	return a.args
+}
+
+func (a applyConfig) Wait() bool {
+	return a.wait
 }
 
 func (a applyConfig) Values() []string {

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -39,6 +39,7 @@ type ApplyConfigProvider interface {
 	Values() []string
 	Set() []string
 	SkipDeps() bool
+	Wait() bool
 
 	IncludeTests() bool
 
@@ -65,6 +66,7 @@ type SyncConfigProvider interface {
 	Values() []string
 	Set() []string
 	SkipDeps() bool
+	Wait() bool
 
 	concurrencyConfig
 	loggingConfig

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -504,6 +504,10 @@ func (st *HelmState) prepareSyncReleases(helm helmexec.Interface, additionalValu
 					}
 				}
 
+				if opts.Wait {
+					flags = append(flags, "--wait")
+				}
+
 				if len(errs) > 0 {
 					results <- syncPrepareResult{errors: errs, files: files}
 					continue
@@ -578,6 +582,7 @@ func (st *HelmState) DetectReleasesToBeDeleted(helm helmexec.Interface, releases
 type SyncOpts struct {
 	Set         []string
 	SkipCleanup bool
+	Wait        bool
 }
 
 type SyncOpt interface{ Apply(*SyncOpts) }
@@ -876,6 +881,7 @@ type ChartPrepareOptions struct {
 	SkipRepos     bool
 	SkipDeps      bool
 	SkipResolve   bool
+	Wait          bool
 }
 
 type chartPrepareResult struct {


### PR DESCRIPTION
Fixes https://github.com/roboll/helmfile/issues/64

This PR gives the ability to append `--wait` to either `helmfile sync` or `helmfile apply`.  The setting will append `--wait` to every `helm upgrade ...` command and it will also override helmDefaults and per-release settings.