### PR TITLE
Update helm-secrets in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,11 +547,10 @@ Note that `delete` doesn't purge releases. So `helmfile delete && helmfile sync`
 
 ### secrets
 
-The `secrets` parameter in a `helmfile.yaml` causes the [helm-secrets](https://github.com/futuresimple/helm-secrets) plugin to be executed to decrypt the file.
+The `secrets` parameter in a `helmfile.yaml` causes the [helm-secrets](https://github.com/jkroepke/helm-secrets) plugin to be executed to decrypt the file.
 
 To supply the secret functionality Helmfile needs the `helm secrets` plugin installed. For Helm 2.3+
-you should be able to simply execute `helm plugin install https://github.com/futuresimple/helm-secrets
-`.
+you should be able to simply execute `helm plugin install https://github.com/jkroepke/helm-secrets --version v3.5.0`.
 
 ### test
 


### PR DESCRIPTION
- replace deprecated helm-secrets with the active helm-secrets
```plain
Deprecation Info
  Please note, this project is no longer being maintained.
  Link to active helm-secret plugin could be found in helm documentation: https://helm.sh/docs/community/related/#helm-plugins
```