### PR TITLE
fix bug #1694

### DIFF
--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -16,7 +16,7 @@ type Run struct {
 	helm  helmexec.Interface
 	ctx   Context
 
-	ReleaseToChart map[string]string
+	ReleaseToChart map[state.PrepareChartKey]string
 
 	Ask func(string) bool
 }
@@ -68,7 +68,12 @@ func (r *Run) withPreparedCharts(helmfileCommand string, opts state.ChartPrepare
 	for i := range r.state.Releases {
 		rel := &r.state.Releases[i]
 
-		if chart := releaseToChart[rel.Name]; chart != "" {
+		key := state.PrepareChartKey{
+			Name:        rel.Name,
+			Namespace:   rel.Namespace,
+			KubeContext: rel.KubeContext,
+		}
+		if chart := releaseToChart[key]; chart != "" {
 			rel.Chart = chart
 		}
 	}

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -886,6 +886,8 @@ type ChartPrepareOptions struct {
 
 type chartPrepareResult struct {
 	releaseName            string
+	releaseNamespace       string
+	releaseContext         string
 	chartName              string
 	chartPath              string
 	err                    error
@@ -907,6 +909,10 @@ func (st *HelmState) GetRepositoryAndNameFromChartName(chartName string) (*Repos
 	return nil, chartName
 }
 
+type PrepareChartKey struct {
+	Namespace, Name, KubeContext string
+}
+
 // PrepareCharts creates temporary directories of charts.
 //
 // Each resulting "chart" can be one of the followings:
@@ -921,7 +927,7 @@ func (st *HelmState) GetRepositoryAndNameFromChartName(chartName string) (*Repos
 // Otheriwse, if a chart is not a helm chart, it will call "chartify" to turn it into a chart.
 //
 // If exists, it will also patch resources by json patches, strategic-merge patches, and injectors.
-func (st *HelmState) PrepareCharts(helm helmexec.Interface, dir string, concurrency int, helmfileCommand string, opts ChartPrepareOptions) (map[string]string, []error) {
+func (st *HelmState) PrepareCharts(helm helmexec.Interface, dir string, concurrency int, helmfileCommand string, opts ChartPrepareOptions) (map[PrepareChartKey]string, []error) {
 	var selected []ReleaseSpec
 
 	if len(st.Selectors) > 0 {
@@ -939,7 +945,7 @@ func (st *HelmState) PrepareCharts(helm helmexec.Interface, dir string, concurre
 
 	releases := releasesNeedCharts(selected)
 
-	temp := make(map[string]string, len(releases))
+	temp := make(map[PrepareChartKey]string, len(releases))
 
 	errs := []error{}
 
@@ -1129,6 +1135,8 @@ func (st *HelmState) PrepareCharts(helm helmexec.Interface, dir string, concurre
 				results <- &chartPrepareResult{
 					releaseName:            release.Name,
 					chartName:              chartName,
+					releaseNamespace:       release.Namespace,
+					releaseContext:         release.KubeContext,
 					chartPath:              chartPath,
 					buildDeps:              buildDeps,
 					chartFetchedByGoGetter: chartFetchedByGoGetter,
@@ -1144,7 +1152,11 @@ func (st *HelmState) PrepareCharts(helm helmexec.Interface, dir string, concurre
 
 					return
 				}
-				temp[downloadRes.releaseName] = downloadRes.chartPath
+				temp[PrepareChartKey{
+					Namespace:   downloadRes.releaseNamespace,
+					KubeContext: downloadRes.releaseContext,
+					Name:        downloadRes.releaseName,
+				}] = downloadRes.chartPath
 
 				if downloadRes.buildDeps {
 					builds = append(builds, downloadRes)


### PR DESCRIPTION
When the same release name is used accross namespaces/kubecontexts
a bad chart name could be used

fixes #1694