### PR TITLE
Fix/secrets ordering

### DIFF
--- a/.circleci/Makefile
+++ b/.circleci/Makefile
@@ -3,11 +3,15 @@ HELM2_VERSION ?= v2.17.0
 KUSTOMIZE_VERSION ?= v3.8.8
 K8S_VERSION ?= v1.13.12
 MINIKUBE_VERSION ?= v0.30.0
+SOPS_VERSION ?= v3.6.1
 
 # ---
 CHANGE_MINIKUBE_NONE_USER ?= true
 MINIKUBE_WANTUPDATENOTIFICATION ?= false
 MINIKUBE_WANTREPORTERRORPROMPT ?= false
+
+VAULT_ADDR := http://127.0.0.1:8200
+VAULT_TOKEN := toor
 
 tmp := $(shell mktemp -d)
 HELM_FILENAME := helm-${HELM_VERSION}-linux-amd64.tar.gz
@@ -15,7 +19,7 @@ HELM2_FILENAME := helm-${HELM2_VERSION}-linux-amd64.tar.gz
 KUSTOMIZE_FILENAME := kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz
 
 
-all: helm kustomize minikube/destroy minikube
+all: vault sops helm kustomize minikube/destroy minikube
 
 helm:
 	curl -sSLo $(tmp)/${HELM_FILENAME} "https://get.helm.sh/${HELM_FILENAME}"
@@ -58,3 +62,16 @@ minikube:
 	kubectl wait node/minikube --for=condition=Ready
 .PHONY: minikube
 .EXPORT_ALL_VARIABLES: minikube
+
+vault:
+	docker kill $$(docker ps -a --filter "name=vault" -q)
+	docker run -d -p8200:8200 --rm --name vault vault:1.2.0 server -dev -dev-root-token-id=toor
+	docker run --rm --network="host" -e VAULT_ADDR=$$VAULT_ADDR -e VAULT_TOKEN=$$VAULT_TOKEN  vault:1.2.0 secrets enable -path=sops transit
+	docker run --rm --network="host" -e VAULT_ADDR=$$VAULT_ADDR -e VAULT_TOKEN=$$VAULT_TOKEN  vault:1.2.0 write sops/keys/key type=rsa-4096
+.PHONY: vault
+
+sops:
+	curl -sSLo $(tmp)/sops "https://github.com/mozilla/sops/releases/download/${SOPS_VERSION}/sops-${SOPS_VERSION}.linux"
+	chmod +x $(tmp)/sops	
+	sudo mv ${tmp}/sops /usr/local/bin/
+.PHONY: sops

--- a/.circleci/Makefile
+++ b/.circleci/Makefile
@@ -1,0 +1,51 @@
+HELM_VERSION ?= v3.5.3
+KUSTOMIZE_VERSION ?= v3.8.8
+K8S_VERSION ?= v1.13.12
+MINIKUBE_VERSION ?= v0.30.0
+
+# ---
+CHANGE_MINIKUBE_NONE_USER ?= true
+MINIKUBE_WANTUPDATENOTIFICATION ?= false
+MINIKUBE_WANTREPORTERRORPROMPT ?= false
+
+tmp := $(shell mktemp -d)
+HELM_FILENAME := helm-${HELM_VERSION}-linux-amd64.tar.gz
+KUSTOMIZE_FILENAME := kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz
+
+
+all: helm kustomize minikube/destroy minikube
+
+helm:
+	curl -sSLo $(tmp)/${HELM_FILENAME} "https://get.helm.sh/${HELM_FILENAME}"
+	tar zxf $(tmp)/${HELM_FILENAME} --directory ${tmp} linux-amd64/helm
+	chmod +x ${tmp}/linux-amd64/helm
+	sudo mv ${tmp}/linux-amd64/helm /usr/local/bin/
+.PHONY: helm
+
+kustomize:
+	curl -sSLo $(tmp)/${KUSTOMIZE_FILENAME} "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/${KUSTOMIZE_FILENAME}"
+	tar zxf $(tmp)/${KUSTOMIZE_FILENAME} --directory ${tmp} kustomize
+	chmod +x ${tmp}/kustomize
+	sudo mv ${tmp}/kustomize /usr/local/bin/
+.PHONY: kustomize
+
+minikube/destroy:
+	sudo -E minikube delete || true
+	sudo -E rm -rf /etc/kubernetes || true
+	sudo -E rm -rf $$HOME/.minikube/* || true
+.PHONY: minikube/destroy
+.EXPORT_ALL_VARIABLES: minikube/destroy
+
+minikube:
+	curl -sSLo ${tmp}/kubectl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl
+	chmod +x ${tmp}/kubectl && sudo mv ${tmp}/kubectl /usr/local/bin/
+	curl -sSLo ${tmp}/minikube https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-linux-amd64
+	chmod +x ${tmp}/minikube && sudo mv ${tmp}/minikube /usr/local/bin/
+	sudo -E minikube delete || true
+	sudo -E rm -rf /etc/kubernetes || true
+	sudo -E rm -rf $$HOME/.minikube/* || true
+	sudo -E minikube start --vm-driver=none --kubernetes-version=${K8S_VERSION}
+	sudo -E minikube update-context
+	kubectl wait node/minikube --for=condition=Ready
+.PHONY: minikube
+.EXPORT_ALL_VARIABLES: minikube

--- a/.circleci/Makefile
+++ b/.circleci/Makefile
@@ -64,7 +64,7 @@ minikube:
 .EXPORT_ALL_VARIABLES: minikube
 
 vault:
-	docker kill $$(docker ps -a --filter "name=vault" -q)
+	docker kill $$(docker ps -a --filter "name=vault" -q) || true
 	docker run -d -p8200:8200 --rm --name vault vault:1.2.0 server -dev -dev-root-token-id=toor
 	docker run --rm --network="host" -e VAULT_ADDR=$$VAULT_ADDR -e VAULT_TOKEN=$$VAULT_TOKEN  vault:1.2.0 secrets enable -path=sops transit
 	docker run --rm --network="host" -e VAULT_ADDR=$$VAULT_ADDR -e VAULT_TOKEN=$$VAULT_TOKEN  vault:1.2.0 write sops/keys/key type=rsa-4096

--- a/.circleci/Makefile
+++ b/.circleci/Makefile
@@ -1,4 +1,5 @@
 HELM_VERSION ?= v3.5.3
+HELM2_VERSION ?= v2.17.0
 KUSTOMIZE_VERSION ?= v3.8.8
 K8S_VERSION ?= v1.13.12
 MINIKUBE_VERSION ?= v0.30.0
@@ -10,6 +11,7 @@ MINIKUBE_WANTREPORTERRORPROMPT ?= false
 
 tmp := $(shell mktemp -d)
 HELM_FILENAME := helm-${HELM_VERSION}-linux-amd64.tar.gz
+HELM2_FILENAME := helm-${HELM2_VERSION}-linux-amd64.tar.gz
 KUSTOMIZE_FILENAME := kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz
 
 
@@ -21,6 +23,13 @@ helm:
 	chmod +x ${tmp}/linux-amd64/helm
 	sudo mv ${tmp}/linux-amd64/helm /usr/local/bin/
 .PHONY: helm
+
+helm2:
+	curl -sSLo $(tmp)/${HELM2_FILENAME} "https://kubernetes-helm.storage.googleapis.com/${HELM2_FILENAME}"
+	tar zxf $(tmp)/${HELM2_FILENAME} --directory ${tmp} linux-amd64/helm
+	chmod +x ${tmp}/linux-amd64/helm
+	sudo mv ${tmp}/linux-amd64/helm /usr/local/bin/
+.PHONY: helm2
 
 kustomize:
 	curl -sSLo $(tmp)/${KUSTOMIZE_FILENAME} "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/${KUSTOMIZE_FILENAME}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,22 +88,14 @@ jobs:
           command: |
             cp ~/build/helmfile ~/project/helmfile
             cp ~/build/diff-yamls ~/project/diff-yamls
-      - run:
-          name: Install helm
-          environment:
-            HELM_VERSION: v2.17.0
-          command: |
-            HELM_FILENAME="helm-${HELM_VERSION}-linux-amd64.tar.gz"
-            curl -Lo ${HELM_FILENAME} "https://kubernetes-helm.storage.googleapis.com/${HELM_FILENAME}"
-            tar zxf ${HELM_FILENAME} linux-amd64/helm
-            chmod +x linux-amd64/helm
-            sudo mv linux-amd64/helm /usr/local/bin/
+      - run: make -C .circleci helm2
       - run: make -C .circleci kustomize
       - run: make -C .circleci minikube
       - run:
           name: Execute integration tests
+          environment:
+            TERM: "xterm"
           command: |
-            export TERM=xterm
             make integration
 
   integration_tests_helm3:
@@ -123,9 +115,11 @@ jobs:
     - run: make -C .circleci minikube
     - run:
         name: Execute integration tests
+        environment:
+          HELMFILE_HELM3: "1"
+          TERM: "xterm"
         command: |
-          export TERM=xterm
-          HELMFILE_HELM3=1 make integration
+          make integration
 
 # GITHUB_TOKEN env var must be setup in circleci console
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ jobs:
     - run:
         name: Install helm
         environment:
-          HELM_VERSION: v3.4.2
+          HELM_VERSION: v3.5.3
         command: |
           HELM_FILENAME="helm-${HELM_VERSION}-linux-amd64.tar.gz"
           curl -Lo ${HELM_FILENAME} "https://get.helm.sh/${HELM_FILENAME}"
@@ -163,7 +163,7 @@ jobs:
     - run:
         name: Install kustomize
         environment:
-          KUSTOMIZE_VERSION: v3.6.1
+          KUSTOMIZE_VERSION: v3.8.8
         command: |
           KUSTOMIZE_FILENAME="kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
           curl -Lo ${KUSTOMIZE_FILENAME} "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/${KUSTOMIZE_FILENAME}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,8 @@ jobs:
           cp ~/build/helmfile ~/project/helmfile
           cp ~/build/diff-yamls ~/project/diff-yamls
     - run: make -C .circleci helm
+    - run: make -C .circleci vault
+    - run: make -C .circleci sops
     - run: make -C .circleci kustomize
     - run: make -C .circleci minikube
     - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,10 +137,10 @@ jobs:
   integration_tests_helm3:
     machine:
       image: circleci/classic:201808-01
-    environment:
-      CHANGE_MINIKUBE_NONE_USER: true
-      MINIKUBE_WANTUPDATENOTIFICATION: false
-      MINIKUBE_WANTREPORTERRORPROMPT: false
+    # environment:
+    #   CHANGE_MINIKUBE_NONE_USER: true
+    #   MINIKUBE_WANTUPDATENOTIFICATION: false
+    #   MINIKUBE_WANTREPORTERRORPROMPT: false
     steps:
     - checkout
     - run: mkdir ~/build
@@ -152,40 +152,43 @@ jobs:
           cp ~/build/diff-yamls ~/project/diff-yamls
     - run:
         name: Install helm
-        environment:
-          HELM_VERSION: v3.5.3
-        command: |
-          HELM_FILENAME="helm-${HELM_VERSION}-linux-amd64.tar.gz"
-          curl -Lo ${HELM_FILENAME} "https://get.helm.sh/${HELM_FILENAME}"
-          tar zxf ${HELM_FILENAME} linux-amd64/helm
-          chmod +x linux-amd64/helm
-          sudo mv linux-amd64/helm /usr/local/bin/
+        command: cd .circleci; make helm
+        # environment:
+        #   HELM_VERSION: v3.5.3
+        # command: |
+        #   HELM_FILENAME="helm-${HELM_VERSION}-linux-amd64.tar.gz"
+        #   curl -Lo ${HELM_FILENAME} "https://get.helm.sh/${HELM_FILENAME}"
+        #   tar zxf ${HELM_FILENAME} linux-amd64/helm
+        #   chmod +x linux-amd64/helm
+        #   sudo mv linux-amd64/helm /usr/local/bin/
     - run:
         name: Install kustomize
-        environment:
-          KUSTOMIZE_VERSION: v3.8.8
-        command: |
-          KUSTOMIZE_FILENAME="kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
-          curl -Lo ${KUSTOMIZE_FILENAME} "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/${KUSTOMIZE_FILENAME}"
-          tar zxf ${KUSTOMIZE_FILENAME} kustomize
-          chmod +x kustomize
-          sudo mv kustomize /usr/local/bin/
+        command: cd .circleci; make kustomize
+        # environment:
+        #   KUSTOMIZE_VERSION: v3.8.8
+        # command: |
+        #   KUSTOMIZE_FILENAME="kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
+        #   curl -Lo ${KUSTOMIZE_FILENAME} "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/${KUSTOMIZE_FILENAME}"
+        #   tar zxf ${KUSTOMIZE_FILENAME} kustomize
+        #   chmod +x kustomize
+        #   sudo mv kustomize /usr/local/bin/
     - run:
         name: Deploy minikube
-        environment:
-          CHANGE_MINIKUBE_NONE_USER: true
-          K8S_VERSION: v1.12.3
-          MINIKUBE_VERSION: v0.30.0
-        command: |
-          curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl
-          chmod +x kubectl && sudo mv kubectl /usr/local/bin/
-          curl -Lo minikube https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-linux-amd64
-          chmod +x minikube && sudo mv minikube /usr/local/bin/
-          sudo -E minikube start --vm-driver=none --kubernetes-version=${K8S_VERSION}
-          sudo -E minikube update-context
-    - run:
-        name: Wait for nodes to become ready
-        command: JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
+        command: cd .circleci; make minikube
+        # environment:
+        #   CHANGE_MINIKUBE_NONE_USER: true
+        #   K8S_VERSION: v1.12.3
+        #   MINIKUBE_VERSION: v0.30.0
+        # command: |
+        #   curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl
+        #   chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+        #   curl -Lo minikube https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-linux-amd64
+        #   chmod +x minikube && sudo mv minikube /usr/local/bin/
+        #   sudo -E minikube start --vm-driver=none --kubernetes-version=${K8S_VERSION}
+        #   sudo -E minikube update-context
+    # - run:
+    #     name: Wait for nodes to become ready
+    #     command: JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
     - run:
         name: Execute integration tests
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,10 +79,6 @@ jobs:
   integration_tests:
     machine:
       image: circleci/classic:201808-01
-    environment:
-      CHANGE_MINIKUBE_NONE_USER: true
-      MINIKUBE_WANTUPDATENOTIFICATION: false
-      MINIKUBE_WANTREPORTERRORPROMPT: false
     steps:
       - checkout
       - run: mkdir ~/build
@@ -102,32 +98,8 @@ jobs:
             tar zxf ${HELM_FILENAME} linux-amd64/helm
             chmod +x linux-amd64/helm
             sudo mv linux-amd64/helm /usr/local/bin/
-      - run:
-          name: Install kustomize
-          environment:
-            KUSTOMIZE_VERSION: v3.6.1
-          command: |
-            KUSTOMIZE_FILENAME="kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
-            curl -Lo ${KUSTOMIZE_FILENAME} "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/${KUSTOMIZE_FILENAME}"
-            tar zxf ${KUSTOMIZE_FILENAME} kustomize
-            chmod +x kustomize
-            sudo mv kustomize /usr/local/bin/
-      - run:
-          name: Deploy minikube
-          environment:
-            CHANGE_MINIKUBE_NONE_USER: true
-            K8S_VERSION: v1.12.3
-            MINIKUBE_VERSION: v0.30.0
-          command: |
-            curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl
-            chmod +x kubectl && sudo mv kubectl /usr/local/bin/
-            curl -Lo minikube https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-linux-amd64
-            chmod +x minikube && sudo mv minikube /usr/local/bin/
-            sudo -E minikube start --vm-driver=none --kubernetes-version=${K8S_VERSION}
-            sudo -E minikube update-context
-      - run:
-          name: Wait for nodes to become ready
-          command: JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
+      - run: make -C .circleci kustomize
+      - run: make -C .circleci minikube
       - run:
           name: Execute integration tests
           command: |
@@ -137,10 +109,6 @@ jobs:
   integration_tests_helm3:
     machine:
       image: circleci/classic:201808-01
-    # environment:
-    #   CHANGE_MINIKUBE_NONE_USER: true
-    #   MINIKUBE_WANTUPDATENOTIFICATION: false
-    #   MINIKUBE_WANTREPORTERRORPROMPT: false
     steps:
     - checkout
     - run: mkdir ~/build
@@ -150,45 +118,9 @@ jobs:
         command: |
           cp ~/build/helmfile ~/project/helmfile
           cp ~/build/diff-yamls ~/project/diff-yamls
-    - run:
-        name: Install helm
-        command: cd .circleci; make helm
-        # environment:
-        #   HELM_VERSION: v3.5.3
-        # command: |
-        #   HELM_FILENAME="helm-${HELM_VERSION}-linux-amd64.tar.gz"
-        #   curl -Lo ${HELM_FILENAME} "https://get.helm.sh/${HELM_FILENAME}"
-        #   tar zxf ${HELM_FILENAME} linux-amd64/helm
-        #   chmod +x linux-amd64/helm
-        #   sudo mv linux-amd64/helm /usr/local/bin/
-    - run:
-        name: Install kustomize
-        command: cd .circleci; make kustomize
-        # environment:
-        #   KUSTOMIZE_VERSION: v3.8.8
-        # command: |
-        #   KUSTOMIZE_FILENAME="kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
-        #   curl -Lo ${KUSTOMIZE_FILENAME} "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/${KUSTOMIZE_FILENAME}"
-        #   tar zxf ${KUSTOMIZE_FILENAME} kustomize
-        #   chmod +x kustomize
-        #   sudo mv kustomize /usr/local/bin/
-    - run:
-        name: Deploy minikube
-        command: cd .circleci; make minikube
-        # environment:
-        #   CHANGE_MINIKUBE_NONE_USER: true
-        #   K8S_VERSION: v1.12.3
-        #   MINIKUBE_VERSION: v0.30.0
-        # command: |
-        #   curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl
-        #   chmod +x kubectl && sudo mv kubectl /usr/local/bin/
-        #   curl -Lo minikube https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-linux-amd64
-        #   chmod +x minikube && sudo mv minikube /usr/local/bin/
-        #   sudo -E minikube start --vm-driver=none --kubernetes-version=${K8S_VERSION}
-        #   sudo -E minikube update-context
-    # - run:
-    #     name: Wait for nodes to become ready
-    #     command: JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
+    - run: make -C .circleci helm
+    - run: make -C .circleci kustomize
+    - run: make -C .circleci minikube
     - run:
         name: Execute integration tests
         command: |

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,8 @@ dist/
 .idea/
 helmfile
 helmfile.lock
+diff-yamls
 test/integration/tmp
 vendor/
+*.log
+.vagrant/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ test/integration/tmp
 vendor/
 *.log
 .vagrant/
+*.lock

--- a/Dockerfile.helm3
+++ b/Dockerfile.helm3
@@ -46,7 +46,7 @@ RUN set -x && \
     mv kustomize /usr/local/bin/kustomize
 
 RUN helm plugin install https://github.com/databus23/helm-diff --version v3.1.3 && \
-    helm plugin install https://github.com/jkroepke/helm-secrets && \
+    helm plugin install https://github.com/jkroepke/helm-secrets --version v3.5.0 && \
     helm plugin install https://github.com/hypnoglow/helm-s3.git && \
     helm plugin install https://github.com/aslafy-z/helm-git.git
 

--- a/Dockerfile.helm3
+++ b/Dockerfile.helm3
@@ -11,10 +11,10 @@ FROM alpine:3.11
 
 RUN apk add --no-cache ca-certificates git bash curl jq
 
-ARG HELM_VERSION="v3.5.0"
+ARG HELM_VERSION="v3.5.3"
 ARG HELM_LOCATION="https://get.helm.sh"
 ARG HELM_FILENAME="helm-${HELM_VERSION}-linux-amd64.tar.gz"
-ARG HELM_SHA256="3fff0354d5fba4c73ebd5db59a59db72f8a5bbe1117a0b355b0c2983e98db95b"
+ARG HELM_SHA256="2170a1a644a9e0b863f00c17b761ce33d4323da64fc74562a3a6df2abbf6cd70"
 RUN set -x && \
     wget ${HELM_LOCATION}/${HELM_FILENAME} && \
     echo Verifying ${HELM_FILENAME}... && \

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ cross:
 .PHONY: cross
 
 static-linux:
-	env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GOFLAGS=-mod=vendor go build -o "dist/helmfile_linux_amd64" -ldflags '-X github.com/roboll/helmfile/pkg/app/version.Version=${TAG}' ${TARGETS}
+	env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GOFLAGS=-mod=readonly go build -o "dist/helmfile_linux_amd64" -ldflags '-X github.com/roboll/helmfile/pkg/app/version.Version=${TAG}' ${TARGETS}
 .PHONY: static-linux
 
 install:
@@ -62,7 +62,6 @@ run: image
 
 push: image
 	docker push quay.io/${ORG}/helmfile:${TAG}
-
 
 image/helm3:
 	docker build -f Dockerfile.helm3 -t quay.io/${ORG}/helmfile:helm3-${TAG} .

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,19 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/xenial64"
+  config.vm.hostname = "minikube.box"
+  config.vm.provision :shell, privileged: false,
+    inline: <<-EOS
+      set -e
+      sudo apt-get update
+      sudo apt-get install -y make docker.io=18.09.7-*
+      sudo systemctl start docker
+      sudo usermod -G docker $USER
+      cd /vagrant/.circleci
+      make all
+    EOS
+
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 2048
+    v.cpus = 2
+  end
+end

--- a/test/integration/default.values.yaml
+++ b/test/integration/default.values.yaml
@@ -1,0 +1,3 @@
+key_1: value
+key_2: value
+key_shared: value

--- a/test/integration/env-1.secrets.yaml
+++ b/test/integration/env-1.secrets.yaml
@@ -1,0 +1,2 @@
+key_1: value_1
+key_shared: value_1

--- a/test/integration/env-2.secrets.yaml
+++ b/test/integration/env-2.secrets.yaml
@@ -1,0 +1,2 @@
+key_2: value_2
+key_shared: value_2

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -50,14 +50,15 @@ if helm version --client 2>/dev/null | grep '"v2\.'; then
   helm_major_version=2
   info "Using Helm version: $(helm version --short --client | grep -o v.*$)"
   ${helm} init --stable-repo-url https://charts.helm.sh/stable --wait --override spec.template.spec.automountServiceAccountToken=true
+  ${helm} plugin ls | grep diff || ${helm} plugin install https://github.com/databus23/helm-diff --version v2.11.0+5
 # helm v3
 else
   helm_major_version=3
   info "Using Helm version: $(helm version --short | grep -o v.*$)"
+  ${helm} plugin ls | grep diff || ${helm} plugin install https://github.com/databus23/helm-diff --version v3.1.3
+  ${helm} plugin ls | grep secrets || ${helm} plugin install https://github.com/jkroepke/helm-secrets --version v3.5.0
 fi
 info "Using Kustomize version: $(kustomize version --short | grep -o 'v[^ ]+')"
-${helm} plugin ls | grep diff || ${helm} plugin install https://github.com/databus23/helm-diff --version v3.1.3
-${helm} plugin ls | grep secrets || ${helm} plugin install https://github.com/jkroepke/helm-secrets --version v3.5.0
 ${kubectl} get namespace ${test_ns} &> /dev/null && warn "Namespace ${test_ns} exists, from a previous test run?"
 $kubectl create namespace ${test_ns} || fail "Could not create namespace ${test_ns}"
 trap "{ $kubectl delete namespace ${test_ns}; }" EXIT # remove namespace whenever we exit this script

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -56,7 +56,8 @@ else
   info "Using Helm version: $(helm version --short | grep -o v.*$)"
 fi
 info "Using Kustomize version: $(kustomize version --short | grep -o 'v[^ ]+')"
-${helm} plugin install https://github.com/databus23/helm-diff --version v3.0.0-rc.7
+${helm} plugin ls | grep diff || ${helm} plugin install https://github.com/databus23/helm-diff --version v3.1.3
+${helm} plugin ls | grep secrets || ${helm} plugin install https://github.com/jkroepke/helm-secrets --version v3.5.0
 ${kubectl} get namespace ${test_ns} &> /dev/null && warn "Namespace ${test_ns} exists, from a previous test run?"
 $kubectl create namespace ${test_ns} || fail "Could not create namespace ${test_ns}"
 trap "{ $kubectl delete namespace ${test_ns}; }" EXIT # remove namespace whenever we exit this script

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # vim: set tabstop=4 shiftwidth=4
 
+set -e
+set -o pipefail
+
 # IMPORTS -----------------------------------------------------------------------------------------------------------
 
 # determine working directory to use to relative paths irrespective of starting directory
@@ -137,10 +140,10 @@ if [[ helm_major_version -eq 3 ]]; then
   test_start "secretssops"
 
   info "Ensure helm-secrets is not installed"
-  ${helm} plugin rm secrets
+  ${helm} plugin rm secrets || true
 
   info "Ensure helmfile fails when no helm-secrets is installed"
-  ${helmfile} -f ${dir}/secretssops.yaml -e direct build && fail "\"helmfile build\" should fail without secrets plugin"
+  ${helmfile} -f ${dir}/secretssops.yaml -e direct build; code="$?"; echo Code: "$code"; [ "${code}" -ne 0 ] || fail "\"helmfile build\" should fail without secrets plugin"
 
   info "Ensure helm-secrets is installed"
   ${helm} plugin install https://github.com/jkroepke/helm-secrets --version v3.5.0

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -136,8 +136,13 @@ if [[ helm_major_version -eq 3 ]]; then
   export VAULT_ADDR=http://127.0.0.1:8200
   export VAULT_TOKEN=toor
   sops="sops --hc-vault-transit $VAULT_ADDR/v1/sops/keys/key"
+  mkdir -p ${dir}/tmp
 
   test_start "secretssops"
+
+  info "Encrypt secrets"
+  ${sops} -e ${dir}/env-1.secrets.yaml > ${dir}/tmp/env-1.secrets.sops.yaml || fail "${sops} failed at ${dir}/env-1.secrets.yaml"
+  ${sops} -e ${dir}/env-2.secrets.yaml > ${dir}/tmp/env-2.secrets.sops.yaml || fail "${sops} failed at ${dir}/env-2.secrets.yaml"
 
   info "Ensure helm-secrets is not installed"
   ${helm} plugin rm secrets || true
@@ -147,10 +152,6 @@ if [[ helm_major_version -eq 3 ]]; then
 
   info "Ensure helm-secrets is installed"
   ${helm} plugin install https://github.com/jkroepke/helm-secrets --version v3.5.0
-
-  info "Encrypt secrets"
-  ${sops} -e ${dir}/env-1.secrets.yaml > ${dir}/tmp/env-1.secrets.sops.yaml || fail "${sops} failed"
-  ${sops} -e ${dir}/env-2.secrets.yaml > ${dir}/tmp/env-2.secrets.sops.yaml || fail "${sops} failed"
 
   info "Ensure helmfile succeed when helm-secrets is installed"
   ${helmfile} -f ${dir}/secretssops.yaml -e direct build || fail "\"helmfile build\" shouldn't fail"

--- a/test/integration/secretssops.yaml
+++ b/test/integration/secretssops.yaml
@@ -1,0 +1,30 @@
+environments:
+  direct:
+    values:
+      - default.values.yaml
+    secrets:
+      - tmp/env-1.secrets.sops.yaml
+      - tmp/env-2.secrets.sops.yaml
+  reverse:
+    values:
+      - default.values.yaml
+    secrets:
+      - tmp/env-2.secrets.sops.yaml
+      - tmp/env-1.secrets.sops.yaml
+---
+repositories:
+  - name: center
+    url: https://repo.chartcenter.io
+
+helmDefaults:
+  kubeContext: minikube
+
+releases:
+
+  - name: raw
+    chart: center/incubator/raw
+    version: 0.2.3
+    values:
+      - mysecret: {{ .Environment.Values.key_1 }}
+      - mysecret: {{ .Environment.Values.key_2 }}
+      - mysecret: {{ .Environment.Values.key_shared }}


### PR DESCRIPTION
Hey!

I've created some integration test infra for helm-secrets testing as a prerequisite to fix secrets ordering in helmfile. Secrets ordering is broken since #790 

1. Moved integration provisioning to Makefile to reuse some code
2. Added `Vagrantfile` to be able to run integration tests locally in similar environment
3. Made some fixes to make integration tests reusable
4. Added some simple secrets handling tests

TODOs:

- [ ] Add secrets ordering tests (secrets ordering is broken right now)
- [ ] Fix the ordering issue

I need some help to fix the issue with helmfile secrets handling: it should fail when secrets decryption fails (or the result produced might be incorrect). Right now it does not (I know about this issue for a long time). Here is the test run to show that: https://app.circleci.com/pipelines/github/astorath/helmfile/34/workflows/6a533209-b1cf-4d47-bb22-9daf80d48691/jobs/153/parallel-runs/0/steps/0-110

I need some guide on where should I fix the issue (the code is a bit messy in secrets handling for me).