### PR TITLE
Feature: kubectl hooks

### DIFF
--- a/pkg/event/bus.go
+++ b/pkg/event/bus.go
@@ -63,10 +63,10 @@ func (bus *Bus) Trigger(evt string, evtErr error, context map[string]interface{}
 		switch class := hook.Class; class {
 			case "apply":
 				hook.Command = "kubectl"
-				hook.Args = append([]string{"apply", "-f"}, hook.Args...)
+				hook.Args = append([]string{"apply", "-n" , "{{.Release.Namespace}}", "-f"}, hook.Args...)
 			case "kustomize":
 				hook.Command = "kubectl"
-				hook.Args = append([]string{"apply", "-k"}, hook.Args...)
+				hook.Args = append([]string{"apply", "-n" , "{{.Release.Namespace}}", "-k"}, hook.Args...)
 		}
 
 		name := hook.Name

--- a/pkg/event/bus.go
+++ b/pkg/event/bus.go
@@ -15,6 +15,7 @@ type Hook struct {
 	Name     string   `yaml:"name"`
 	Events   []string `yaml:"events"`
 	Command  string   `yaml:"command"`
+	Class    string   `yaml:"class"`
 	Args     []string `yaml:"args"`
 	ShowLogs bool     `yaml:"showlogs"`
 }
@@ -58,6 +59,15 @@ func (bus *Bus) Trigger(evt string, evtErr error, context map[string]interface{}
 		}
 
 		var err error
+
+		switch class := hook.Class; class {
+			case "apply":
+				hook.Command = "kubectl"
+				hook.Args = append([]string{"apply", "-f"}, hook.Args...)
+			case "kustomize":
+				hook.Command = "kubectl"
+				hook.Args = append([]string{"apply", "-k"}, hook.Args...)
+		}
 
 		name := hook.Name
 		if name == "" {


### PR DESCRIPTION
This is an attempt to make less verbose simple hooks. If you like this, I'll add some documentation and tests.
This will allow replacing
```yaml
- events: [ postsync ]
  command: kubectl
  args:
    - apply
    - --kustomize=kustom
```
with
```yaml
- events: [ postsync ]
  command: kustomize
  args:
    - kustom
```