### PR TITLE
(feat) Add chart & version to list cmd

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -61,6 +61,8 @@ type HelmRelease struct {
 	Namespace string `json:"namespace"`
 	Enabled   bool   `json:"enabled"`
 	Labels    string `json:"labels"`
+	Chart     string `json:"chart"`
+	Version   string `json:"version"`
 }
 
 func New(conf ConfigProvider) *App {
@@ -507,6 +509,8 @@ func (a *App) ListReleases(c ListConfigProvider) error {
 					Namespace: r.Namespace,
 					Enabled:   installed,
 					Labels:    labels,
+					Chart:     r.Chart,
+					Version:   r.Version,
 				})
 			}
 		})

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -4514,11 +4514,11 @@ releases:
 		assert.NilError(t, err)
 	})
 
-	expected := `NAME      	NAMESPACE	ENABLED	LABELS                    
-myrelease1	         	false  	common:label,id:myrelease1
-myrelease2	         	true   	common:label              
-myrelease3	         	true   	                          
-myrelease4	         	true   	id:myrelease1             
+	expected := `NAME      	NAMESPACE	ENABLED	LABELS                    	CHART   	VERSION
+myrelease1	         	false  	common:label,id:myrelease1	mychart1	       
+myrelease2	         	true   	common:label              	mychart1	       
+myrelease3	         	true   	                          	mychart1	       
+myrelease4	         	true   	id:myrelease1             	mychart1	       
 `
 	assert.Equal(t, expected, out)
 }
@@ -4571,7 +4571,7 @@ releases:
 		assert.NilError(t, err)
 	})
 
-	expected := `[{"name":"myrelease1","namespace":"","enabled":false,"labels":"id:myrelease1"},{"name":"myrelease2","namespace":"","enabled":true,"labels":""},{"name":"myrelease3","namespace":"","enabled":true,"labels":""},{"name":"myrelease4","namespace":"","enabled":true,"labels":"id:myrelease1"}]
+	expected := `[{"name":"myrelease1","namespace":"","enabled":false,"labels":"id:myrelease1","chart":"mychart1","version":""},{"name":"myrelease2","namespace":"","enabled":true,"labels":"","chart":"mychart1","version":""},{"name":"myrelease3","namespace":"","enabled":true,"labels":"","chart":"mychart1","version":""},{"name":"myrelease4","namespace":"","enabled":true,"labels":"id:myrelease1","chart":"mychart1","version":""}]
 `
 	assert.Equal(t, expected, out)
 }

--- a/pkg/app/formatters.go
+++ b/pkg/app/formatters.go
@@ -9,10 +9,10 @@ import (
 
 func FormatAsTable(releases []*HelmRelease) error {
 	table := uitable.New()
-	table.AddRow("NAME", "NAMESPACE", "ENABLED", "LABELS")
+	table.AddRow("NAME", "NAMESPACE", "ENABLED", "LABELS", "CHART", "VERSION")
 
 	for _, r := range releases {
-		table.AddRow(r.Name, r.Namespace, fmt.Sprintf("%t", r.Enabled), r.Labels)
+		table.AddRow(r.Name, r.Namespace, fmt.Sprintf("%t", r.Enabled), r.Labels, r.Chart, r.Version)
 	}
 
 	fmt.Println(table.String())


### PR DESCRIPTION
Please squash.

Motivation:
I want to make a command to `helm pull` all charts to have a local version to debug.
```
for row in $(helm list --output json | jq -r '.[] | {chart: .chart, version: .version} | @base64' | uniq); do
	   chart=$(echo ${row} | base64 -d | jq -r '.chart');
	   version=$(echo ${row} | base64 -d | jq -r '.version');
	   echo "Downloading ${chart} ${version}";
	   helm pull ${chart} --version ${version} --untar --untardir debug/charts/${chart}/${version} || :;
done
```