### PR TITLE
Add `kubectl` hooks for applying file(s) or kustomize

### DIFF
--- a/pkg/event/bus.go
+++ b/pkg/event/bus.go
@@ -15,6 +15,7 @@ type Hook struct {
 	Name     string   `yaml:"name"`
 	Events   []string `yaml:"events"`
 	Command  string   `yaml:"command"`
+	Kubectl  string   `yaml:"kubectlApply"`
 	Args     []string `yaml:"args"`
 	ShowLogs bool     `yaml:"showlogs"`
 }
@@ -58,6 +59,10 @@ func (bus *Bus) Trigger(evt string, evtErr error, context map[string]interface{}
 		}
 
 		var err error
+
+		if hook.Kubectl != "" {
+			hook.Command = "kubectl"
+		}
 
 		name := hook.Name
 		if name == "" {

--- a/pkg/event/bus.go
+++ b/pkg/event/bus.go
@@ -73,6 +73,9 @@ func (bus *Bus) Trigger(evt string, evtErr error, context map[string]interface{}
 				hook.Args = append([]string{"apply", "-f"}, val)
 			} else if val, found := hook.Kubectl["kustomize"]; found {
 				hook.Args = append([]string{"apply", "-k"}, val)
+			} else {
+				bus.Logger.Errorf("err: either kustomize or filename must be given to kubectlApply hook")
+				continue
 			}
 		}
 

--- a/pkg/event/bus.go
+++ b/pkg/event/bus.go
@@ -63,11 +63,17 @@ func (bus *Bus) Trigger(evt string, evtErr error, context map[string]interface{}
 		var err error
 
 		if hook.Kubectl != "" {
+			if hook.Command != "" {
+				bus.Logger.Warnf("warn: ignoring command '%s' given within a kubectlApply hook", hook.Command)
+			}
 			hook.Command = "kubectl"
+			if hook.Filename != "" && hook.Kustomize != "" {
+				bus.logger.Errorf("err: kustomize & filename cannot be used together, skipping kubectlApply hook")
+				continue
+			}
 			if hook.Filename != "" {
 				hook.Args = append([]string{"apply", "-f"}, hook.Filename...)
-			}
-			if hook.Kustomize != "" {
+			} else if hook.Kustomize != "" {
 				hook.Args = append([]string{"apply", "-k"}, hook.Kustomize...)
 			}
 		}

--- a/pkg/event/bus.go
+++ b/pkg/event/bus.go
@@ -12,12 +12,14 @@ import (
 )
 
 type Hook struct {
-	Name     string   `yaml:"name"`
-	Events   []string `yaml:"events"`
-	Command  string   `yaml:"command"`
-	Kubectl  string   `yaml:"kubectlApply"`
-	Args     []string `yaml:"args"`
-	ShowLogs bool     `yaml:"showlogs"`
+	Name      string   `yaml:"name"`
+	Events    []string `yaml:"events"`
+	Command   string   `yaml:"command"`
+	Kubectl   string   `yaml:"kubectlApply"`
+	Args      []string `yaml:"args"`
+	Kustomize string   `yaml:"kustomize"`
+	Filename  string   `yaml:"filename"`
+	ShowLogs  bool     `yaml:"showlogs"`
 }
 
 type event struct {
@@ -62,6 +64,12 @@ func (bus *Bus) Trigger(evt string, evtErr error, context map[string]interface{}
 
 		if hook.Kubectl != "" {
 			hook.Command = "kubectl"
+			if hook.Filename != "" {
+				hook.Args = append([]string{"apply", "-f"}, hook.Filename...)
+			}
+			if hook.Kustomize != "" {
+				hook.Args = append([]string{"apply", "-k"}, hook.Kustomize...)
+			}
 		}
 
 		name := hook.Name

--- a/pkg/event/bus.go
+++ b/pkg/event/bus.go
@@ -67,8 +67,7 @@ func (bus *Bus) Trigger(evt string, evtErr error, context map[string]interface{}
 			hook.Command = "kubectl"
 			if val, found := hook.Kubectl["filename"]; found {
 				if _, found := hook.Kubectl["kustomize"]; found {
-					bus.Logger.Errorf("err: kustomize & filename cannot be used together, skipping kubectlApply hook")
-					continue
+					return false, fmt.Errorf("hook[%s]: kustomize & filename cannot be used together on kubectlApply hook", hook.Name)
 				}
 				hook.Args = append([]string{"apply", "-f"}, val)
 			} else if val, found := hook.Kubectl["kustomize"]; found {

--- a/pkg/event/bus.go
+++ b/pkg/event/bus.go
@@ -73,8 +73,7 @@ func (bus *Bus) Trigger(evt string, evtErr error, context map[string]interface{}
 			} else if val, found := hook.Kubectl["kustomize"]; found {
 				hook.Args = append([]string{"apply", "-k"}, val)
 			} else {
-				bus.Logger.Errorf("err: either kustomize or filename must be given to kubectlApply hook")
-				continue
+				return false, fmt.Errorf("hook[%s]: either kustomize or filename must be given to kubectlApply hook", hook.Name)
 			}
 		}
 

--- a/pkg/event/bus.go
+++ b/pkg/event/bus.go
@@ -15,7 +15,7 @@ type Hook struct {
 	Name     string            `yaml:"name"`
 	Events   []string          `yaml:"events"`
 	Command  string            `yaml:"command"`
-	Kubectl  map[string]string `yaml:"kubectlApply"`
+	Kubectl  map[string]string `yaml:"kubectlApply,omitempty"`
 	Args     []string          `yaml:"args"`
 	ShowLogs bool              `yaml:"showlogs"`
 }

--- a/pkg/event/bus_test.go
+++ b/pkg/event/bus_test.go
@@ -83,6 +83,34 @@ func TestTrigger(t *testing.T) {
 			false,
 			"hook[nghook2]: command `ok` failed: cmd failed due to invalid arg: ng",
 		},
+		{
+			"okkubeapply1",
+			&Hook{"okkubeapply1", []string{"foo"}, "", map[string]string{"kustomize": "kustodir"}, []string{}, false},
+			"foo",
+			true,
+			"",
+		},
+		{
+			"okkubeapply2",
+			&Hook{"okkubeapply2", []string{"foo"}, "", map[string]string{"filename": "resource.yaml"}, []string{}, false},
+			"foo",
+			true,
+			"",
+		},
+		{
+			"kokubeapply",
+			&Hook{"kokubeapply", []string{"foo"}, "", map[string]string{"kustomize": "kustodir", "filename": "resource.yaml"}, []string{}, true},
+			"foo",
+			false,
+			"err: kustomize & filename cannot be used together, skipping kubectlApply hook",
+		},
+		{
+			"warnkubeapply1",
+			&Hook{"warnkubeapply1", []string{"foo"}, "ok", map[string]string{"filename": "resource.yaml"}, []string{}, true},
+			"foo",
+			true,
+			"warn: ignoring command 'ok' given within a kubectlApply hook",
+		},
 	}
 	readFile := func(filename string) ([]byte, error) {
 		return nil, fmt.Errorf("unexpected call to readFile: %s", filename)

--- a/pkg/event/bus_test.go
+++ b/pkg/event/bus_test.go
@@ -43,21 +43,21 @@ func TestTrigger(t *testing.T) {
 	}{
 		{
 			"okhook1",
-			&Hook{"okhook1", []string{"foo"}, "ok", []string{}, true},
+			&Hook{"okhook1", []string{"foo"}, "ok", nil, []string{}, true},
 			"foo",
 			true,
 			"",
 		},
 		{
 			"okhooké",
-			&Hook{"okhook2", []string{"foo"}, "ok", []string{}, false},
+			&Hook{"okhook2", []string{"foo"}, "ok", nil, []string{}, false},
 			"foo",
 			true,
 			"",
 		},
 		{
 			"missinghook1",
-			&Hook{"okhook1", []string{"foo"}, "ok", []string{}, false},
+			&Hook{"okhook1", []string{"foo"}, "ok", nil, []string{}, false},
 			"bar",
 			false,
 			"",
@@ -71,14 +71,14 @@ func TestTrigger(t *testing.T) {
 		},
 		{
 			"nghook1",
-			&Hook{"nghook1", []string{"foo"}, "ng", []string{}, false},
+			&Hook{"nghook1", []string{"foo"}, "ng", nil, []string{}, false},
 			"foo",
 			false,
 			"hook[nghook1]: command `ng` failed: cmd failed due to invalid cmd: ng",
 		},
 		{
 			"nghook2",
-			&Hook{"nghook2", []string{"foo"}, "ok", []string{"ng"}, false},
+			&Hook{"nghook2", []string{"foo"}, "ok", nil, []string{"ng"}, false},
 			"foo",
 			false,
 			"hook[nghook2]: command `ok` failed: cmd failed due to invalid arg: ng",

--- a/pkg/event/bus_test.go
+++ b/pkg/event/bus_test.go
@@ -116,21 +116,21 @@ func TestTrigger(t *testing.T) {
 			&Hook{"warnkubeapply1", []string{"foo"}, "ok", map[string]string{"filename": "resource.yaml"}, []string{}, true},
 			"foo",
 			true,
-			"warn: ignoring command 'ok' given within a kubectlApply hook",
+			"",
 		},
 		{
 			"warnkubeapply2",
 			&Hook{"warnkubeapply2", []string{"foo"}, "", map[string]string{"filename": "resource.yaml"}, []string{"ng"}, true},
 			"foo",
 			true,
-			"warn: ignoring command/args given for kubectlApply hook",
+			"",
 		},
 		{
 			"warnkubeapply3",
 			&Hook{"warnkubeapply3", []string{"foo"}, "ok", map[string]string{"filename": "resource.yaml"}, []string{"ng"}, true},
 			"foo",
 			true,
-			"warn: ignoring command/args given for kubectlApply hook",
+			"",
 		},
 	}
 	readFile := func(filename string) ([]byte, error) {

--- a/pkg/event/bus_test.go
+++ b/pkg/event/bus_test.go
@@ -173,7 +173,7 @@ func TestTrigger(t *testing.T) {
 
 		if c.expectedErr != "" {
 			if err == nil {
-				t.Error("error expected, but not occurred")
+				t.Errorf("error expected for case \"%s\", but not occurred", c.name)
 			} else if err.Error() != c.expectedErr {
 				t.Errorf("unexpected error for case \"%s\": expected=%s, actual=%v", c.name, c.expectedErr, err)
 			}

--- a/pkg/event/bus_test.go
+++ b/pkg/event/bus_test.go
@@ -105,6 +105,13 @@ func TestTrigger(t *testing.T) {
 			"hook[kokubeapply]: kustomize & filename cannot be used together on kubectlApply hook",
 		},
 		{
+			"kokubeapply2",
+			&Hook{"kokubeapply2", []string{"foo"}, "", map[string]string{}, []string{}, true},
+			"foo",
+			false,
+			"hook[kokubeapply2]: either kustomize or filename must be given to kubectlApply hook",
+		},
+		{
 			"warnkubeapply1",
 			&Hook{"warnkubeapply1", []string{"foo"}, "ok", map[string]string{"filename": "resource.yaml"}, []string{}, true},
 			"foo",

--- a/pkg/event/bus_test.go
+++ b/pkg/event/bus_test.go
@@ -111,6 +111,20 @@ func TestTrigger(t *testing.T) {
 			true,
 			"warn: ignoring command 'ok' given within a kubectlApply hook",
 		},
+		{
+			"warnkubeapply2",
+			&Hook{"warnkubeapply2", []string{"foo"}, "", map[string]string{"filename": "resource.yaml"}, []string{"ng"}, true},
+			"foo",
+			true,
+			"warn: ignoring command/args given for kubectlApply hook",
+		},
+		{
+			"warnkubeapply3",
+			&Hook{"warnkubeapply3", []string{"foo"}, "ok", map[string]string{"filename": "resource.yaml"}, []string{"ng"}, true},
+			"foo",
+			true,
+			"warn: ignoring command/args given for kubectlApply hook",
+		},
 	}
 	readFile := func(filename string) ([]byte, error) {
 		return nil, fmt.Errorf("unexpected call to readFile: %s", filename)

--- a/pkg/event/bus_test.go
+++ b/pkg/event/bus_test.go
@@ -102,14 +102,21 @@ func TestTrigger(t *testing.T) {
 			&Hook{"kokubeapply", []string{"foo"}, "", map[string]string{"kustomize": "kustodir", "filename": "resource.yaml"}, []string{}, true},
 			"foo",
 			false,
-			"hook[kokubeapply]: kustomize & filename cannot be used together on kubectlApply hook",
+			"hook[kokubeapply]: kustomize & filename cannot be used together",
 		},
 		{
 			"kokubeapply2",
 			&Hook{"kokubeapply2", []string{"foo"}, "", map[string]string{}, []string{}, true},
 			"foo",
 			false,
-			"hook[kokubeapply2]: either kustomize or filename must be given to kubectlApply hook",
+			"hook[kokubeapply2]: either kustomize or filename must be given",
+		},
+		{
+			"kokubeapply3",
+			&Hook{"", []string{"foo"}, "", map[string]string{}, []string{}, true},
+			"foo",
+			false,
+			"hook[kubectlApply]: either kustomize or filename must be given",
 		},
 		{
 			"warnkubeapply1",

--- a/pkg/event/bus_test.go
+++ b/pkg/event/bus_test.go
@@ -102,7 +102,7 @@ func TestTrigger(t *testing.T) {
 			&Hook{"kokubeapply", []string{"foo"}, "", map[string]string{"kustomize": "kustodir", "filename": "resource.yaml"}, []string{}, true},
 			"foo",
 			false,
-			"err: kustomize & filename cannot be used together, skipping kubectlApply hook",
+			"hook[kokubeapply]: kustomize & filename cannot be used together on kubectlApply hook",
 		},
 		{
 			"warnkubeapply1",


### PR DESCRIPTION
This PR allows the use within hooks of snippets like those below to simplify inclussion of `kubectl apply` commands
```yaml
kubectlApply:
  kustomize: kustom
---
kubectlApply:
  filename: resource.yaml
```
