### PR TITLE
feat: --show-secrets on diff and apply commands

### DIFF
--- a/main.go
+++ b/main.go
@@ -200,6 +200,10 @@ func main() {
 					Name:  "suppress-secrets",
 					Usage: "suppress secrets in the output. highly recommended to specify on CI/CD use-cases",
 				},
+				cli.BoolFlag{
+					Name:  "show-secrets",
+					Usage: "do not redact secret values in the output. should be used for debug purpose only",
+				},
 				cli.IntFlag{
 					Name:  "concurrency",
 					Value: 0,
@@ -438,6 +442,10 @@ func main() {
 				cli.BoolFlag{
 					Name:  "suppress-secrets",
 					Usage: "suppress secrets in the diff output. highly recommended to specify on CI/CD use-cases",
+				},
+				cli.BoolFlag{
+					Name:  "show-secrets",
+					Usage: "do not redact secret values in the diff output. should be used for debug purpose only",
 				},
 				cli.BoolFlag{
 					Name:  "suppress-diff",
@@ -711,6 +719,10 @@ func (c configImpl) IncludeTests() bool {
 
 func (c configImpl) SuppressSecrets() bool {
 	return c.c.Bool("suppress-secrets")
+}
+
+func (c configImpl) ShowSecrets() bool {
+	return c.c.Bool("show-secrets")
 }
 
 func (c configImpl) SuppressDiff() bool {

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -2308,6 +2308,7 @@ type applyConfig struct {
 	skipDeps          bool
 	includeTests      bool
 	suppressSecrets   bool
+	showSecrets       bool
 	suppressDiff      bool
 	noColor           bool
 	context           int
@@ -2358,6 +2359,10 @@ func (a applyConfig) IncludeTests() bool {
 
 func (a applyConfig) SuppressSecrets() bool {
 	return a.suppressSecrets
+}
+
+func (a applyConfig) ShowSecrets() bool {
+	return a.showSecrets
 }
 
 func (a applyConfig) SuppressDiff() bool {

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -45,6 +45,7 @@ type ApplyConfigProvider interface {
 	IncludeTests() bool
 
 	SuppressSecrets() bool
+	ShowSecrets() bool
 	SuppressDiff() bool
 
 	DetailedExitcode() bool
@@ -84,6 +85,7 @@ type DiffConfigProvider interface {
 	IncludeTests() bool
 
 	SuppressSecrets() bool
+	ShowSecrets() bool
 	SuppressDiff() bool
 
 	DetailedExitcode() bool

--- a/pkg/app/diff_test.go
+++ b/pkg/app/diff_test.go
@@ -23,6 +23,7 @@ type diffConfig struct {
 	skipDeps          bool
 	includeTests      bool
 	suppressSecrets   bool
+	showSecrets       bool
 	suppressDiff      bool
 	noColor           bool
 	context           int
@@ -58,6 +59,10 @@ func (a diffConfig) IncludeTests() bool {
 
 func (a diffConfig) SuppressSecrets() bool {
 	return a.suppressSecrets
+}
+
+func (a diffConfig) ShowSecrets() bool {
+	return a.showSecrets
 }
 
 func (a diffConfig) SuppressDiff() bool {

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -222,7 +222,7 @@ func (run *Run) diff(triggerCleanupEvent bool, detailedExitCode bool, c DiffConf
 
 	// TODO Better way to detect diff on only filtered releases
 	{
-		changedReleases, planningErrs = st.DiffReleases(helm, c.Values(), c.Concurrency(), detailedExitCode, c.IncludeTests(), c.SuppressSecrets(), c.SuppressDiff(), triggerCleanupEvent, diffOpts)
+		changedReleases, planningErrs = st.DiffReleases(helm, c.Values(), c.Concurrency(), detailedExitCode, c.IncludeTests(), c.SuppressSecrets(), c.ShowSecrets(), c.SuppressDiff(), triggerCleanupEvent, diffOpts)
 
 		var err error
 		deletingReleases, err = st.DetectReleasesToBeDeletedForSync(helm, st.Releases)

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1525,7 +1525,7 @@ type diffPrepareResult struct {
 	upgradeDueToSkippedDiff bool
 }
 
-func (st *HelmState) prepareDiffReleases(helm helmexec.Interface, additionalValues []string, concurrency int, detailedExitCode, includeTests, suppressSecrets bool, opt ...DiffOpt) ([]diffPrepareResult, []error) {
+func (st *HelmState) prepareDiffReleases(helm helmexec.Interface, additionalValues []string, concurrency int, detailedExitCode, includeTests, suppressSecrets bool, showSecrets bool, opt ...DiffOpt) ([]diffPrepareResult, []error) {
 	opts := &DiffOpts{}
 	for _, o := range opt {
 		o.Apply(opts)
@@ -1628,6 +1628,10 @@ func (st *HelmState) prepareDiffReleases(helm helmexec.Interface, additionalValu
 
 				if suppressSecrets {
 					flags = append(flags, "--suppress-secrets")
+				}
+
+				if showSecrets {
+					flags = append(flags, "--show-secrets")
 				}
 
 				if opts.NoColor {
@@ -1735,13 +1739,13 @@ type DiffOpt interface{ Apply(*DiffOpts) }
 // For example, terraform-provider-helmfile runs a helmfile-diff on `terraform plan` and another on `terraform apply`.
 // `terraform`, by design, fails when helmfile-diff outputs were not equivalent.
 // Stabilized helmfile-diff output rescues that.
-func (st *HelmState) DiffReleases(helm helmexec.Interface, additionalValues []string, workerLimit int, detailedExitCode, includeTests, suppressSecrets, suppressDiff, triggerCleanupEvents bool, opt ...DiffOpt) ([]ReleaseSpec, []error) {
+func (st *HelmState) DiffReleases(helm helmexec.Interface, additionalValues []string, workerLimit int, detailedExitCode, includeTests, suppressSecrets, showSecrets, suppressDiff, triggerCleanupEvents bool, opt ...DiffOpt) ([]ReleaseSpec, []error) {
 	opts := &DiffOpts{}
 	for _, o := range opt {
 		o.Apply(opts)
 	}
 
-	preps, prepErrs := st.prepareDiffReleases(helm, additionalValues, workerLimit, detailedExitCode, includeTests, suppressSecrets, opts)
+	preps, prepErrs := st.prepareDiffReleases(helm, additionalValues, workerLimit, detailedExitCode, includeTests, suppressSecrets, showSecrets, opts)
 
 	defer func() {
 		if opts.SkipCleanup {

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -1570,7 +1570,7 @@ func TestHelmState_DiffReleases(t *testing.T) {
 				valsRuntime:    valsRuntime,
 				RenderedValues: map[string]interface{}{},
 			}
-			_, errs := state.DiffReleases(tt.helm, []string{}, 1, false, false, false, false, false)
+			_, errs := state.DiffReleases(tt.helm, []string{}, 1, false, false, false, false, false, false)
 			if errs != nil && len(errs) > 0 {
 				t.Errorf("unexpected error: %v", errs)
 			}
@@ -1741,7 +1741,7 @@ func TestHelmState_DiffReleasesCleanup(t *testing.T) {
 `,
 			})
 			state = injectFs(state, testfs)
-			if _, errs := state.DiffReleases(tt.helm, []string{}, 1, false, false, false, false, false); errs != nil && len(errs) > 0 {
+			if _, errs := state.DiffReleases(tt.helm, []string{}, 1, false, false, false, false, false, false); errs != nil && len(errs) > 0 {
 				t.Errorf("unexpected errors: %v", errs)
 			}
 


### PR DESCRIPTION
This PR adds --show-secrets argument on the diff and apply commands that is useful for debugging purposes.

Resolves #1674