### PR TITLE
Fix chartify not to fail on a chart with dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/tatsushid/go-prettytable v0.0.0-20141013043238-ed2d14c29939
 	github.com/urfave/cli v1.22.5
-	github.com/variantdev/chartify v0.7.1
+	github.com/variantdev/chartify v0.7.2
 	github.com/variantdev/dag v0.0.0-20191028002400-bb0b3c785363
 	github.com/variantdev/vals v0.13.0
 	go.uber.org/multierr v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -577,6 +577,8 @@ github.com/variantdev/chartify v0.7.0 h1:LQU9bW734CPTIRRx9AG6rIolqW3GgbqaFZQTOCN
 github.com/variantdev/chartify v0.7.0/go.mod h1:qF4XzQlkfH/6k2jAi1hLas+lK4zSCa8kY+r5JdmLA68=
 github.com/variantdev/chartify v0.7.1 h1:m03k/LDf1skLmOjX8Fj1QmnlaW84BD5iwi1EP56AvaU=
 github.com/variantdev/chartify v0.7.1/go.mod h1:qF4XzQlkfH/6k2jAi1hLas+lK4zSCa8kY+r5JdmLA68=
+github.com/variantdev/chartify v0.7.2 h1:H7a9xD4rfyKkLDhCO/Oj3VfYnJRb92Dqk+GR6vpUXK4=
+github.com/variantdev/chartify v0.7.2/go.mod h1:qF4XzQlkfH/6k2jAi1hLas+lK4zSCa8kY+r5JdmLA68=
 github.com/variantdev/dag v0.0.0-20191028002400-bb0b3c785363 h1:KrfQBEUn+wEOQ/6UIfoqRDvn+Q/wZridQ7t0G1vQqKE=
 github.com/variantdev/dag v0.0.0-20191028002400-bb0b3c785363/go.mod h1:pH1TQsNSLj2uxMo9NNl9zdGy01Wtn+/2MT96BrKmVyE=
 github.com/variantdev/vals v0.13.0 h1:zdtTBjoWKkUGdFauxETkDVjqWXdjUNwI+ggWcUmpxv8=


### PR DESCRIPTION
Manually verified to work by using the following example from @damoon (https://github.com/roboll/helmfile/issues/1655#issuecomment-801122431):

```
repositories:
  - name: prometheus-community
    url: https://prometheus-community.github.io/helm-charts
releases:
- name: metrics
  namespace: monitoring
  chart: prometheus-community/kube-prometheus-stack
  version: 13.13.0
  jsonPatches:
    - target:
        version: v1
        kind: Service
        name: metrics-kube-prometheus-st-kube-etcd
        namespace: kube-system
      patch:
        - op: replace
          path: /spec/ports/0/port
          value: "2381"
        - op: replace
          path: /spec/ports/0/targetPort
          value: "2381"
```

Before this fix:
```
$ helmfile template
(snip)
COMBINED OUTPUT:
  Error: found in Chart.yaml, but missing in charts/ directory: kube-state-metrics, prometheus-node-exporter, grafana
```

After this fix:

```
$ helmfile template | grep 2381
(snip)
Removing /tmp/chartify718204429/monitoring-metrics-f5479c8b8/kube-prometheus-stack/strategicmergepatches
Removing /tmp/chartify718204429/monitoring-metrics-f5479c8b8/kube-prometheus-stack/kustomization.yaml
Templating release=metrics, chart=/tmp/chartify718204429/monitoring-metrics-f5479c8b8/kube-prometheus-stack
    port: "2381"
    targetPort: "2381"
```

Fixes #1655

Ref https://github.com/variantdev/chartify/commit/07c3054d66021fa190464a998ade18607312c715