### PR TITLE
Allow users other than root to use helm plugins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,9 @@ RUN helm plugin install https://github.com/databus23/helm-diff && \
     helm plugin install https://github.com/aslafy-z/helm-git.git && \
     helm plugin install https://github.com/rimusz/helm-tiller
 
+# Allow users other than root to use helm plugins located in root home
+RUN chmod 751 /root
+
 COPY --from=builder /workspace/helmfile/dist/helmfile_linux_amd64 /usr/local/bin/helmfile
 
 CMD ["/usr/local/bin/helmfile", "--help"]

--- a/Dockerfile.helm3
+++ b/Dockerfile.helm3
@@ -50,6 +50,9 @@ RUN helm plugin install https://github.com/databus23/helm-diff --version v3.1.3 
     helm plugin install https://github.com/hypnoglow/helm-s3.git && \
     helm plugin install https://github.com/aslafy-z/helm-git.git
 
+# Allow users other than root to use helm plugins located in root home
+RUN chmod 751 /root
+
 COPY --from=builder /workspace/helmfile/dist/helmfile_linux_amd64 /usr/local/bin/helmfile
 
 CMD ["/usr/local/bin/helmfile"]


### PR DESCRIPTION
Hi,
as discussed in this issue  https://github.com/roboll/helmfile/issues/1134, I propose to allow all users to go through root directory to be able to use helm plugins in container running as non root users.