### PR TITLE
Add --{include,skip}-needs to various helmfile commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/tatsushid/go-prettytable v0.0.0-20141013043238-ed2d14c29939
 	github.com/urfave/cli v1.22.5
 	github.com/variantdev/chartify v0.8.0
-	github.com/variantdev/dag v0.0.0-20191028002400-bb0b3c785363
+	github.com/variantdev/dag v1.0.0
 	github.com/variantdev/vals v0.13.0
 	go.uber.org/multierr v1.6.0
 	go.uber.org/zap v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -585,6 +585,8 @@ github.com/variantdev/chartify v0.8.0 h1:yIBsS/dIUeMjWP8U6JWlT3PM0Lky7en9QBi+MgD
 github.com/variantdev/chartify v0.8.0/go.mod h1:qF4XzQlkfH/6k2jAi1hLas+lK4zSCa8kY+r5JdmLA68=
 github.com/variantdev/dag v0.0.0-20191028002400-bb0b3c785363 h1:KrfQBEUn+wEOQ/6UIfoqRDvn+Q/wZridQ7t0G1vQqKE=
 github.com/variantdev/dag v0.0.0-20191028002400-bb0b3c785363/go.mod h1:pH1TQsNSLj2uxMo9NNl9zdGy01Wtn+/2MT96BrKmVyE=
+github.com/variantdev/dag v1.0.0 h1:7SFjATxHtrYV20P3tx53yNDBMegz6RT4jv8JPHqAHdM=
+github.com/variantdev/dag v1.0.0/go.mod h1:pH1TQsNSLj2uxMo9NNl9zdGy01Wtn+/2MT96BrKmVyE=
 github.com/variantdev/vals v0.13.0 h1:zdtTBjoWKkUGdFauxETkDVjqWXdjUNwI+ggWcUmpxv8=
 github.com/variantdev/vals v0.13.0/go.mod h1:pBwm+vPLQALN6otkNqiT1fUKdWHfjAm4070UkrNLsVA=
 github.com/vektra/mockery v1.1.2/go.mod h1:VcfZjKaFOPO+MpN4ZvwPjs4c48lkq1o3Ym8yHZJu0jU=

--- a/main.go
+++ b/main.go
@@ -392,7 +392,7 @@ func main() {
 				},
 				cli.BoolFlag{
 					Name:  "include-needs",
-					Usage: `automaticlaly include releases from the target release's "needs" when --selector/-l flag is provided. Does nothing when when --selector/-l flag is not provided`,
+					Usage: `automatically include releases from the target release's "needs" when --selector/-l flag is provided. Does nothing when when --selector/-l flag is not provided`,
 				},
 				cli.BoolFlag{
 					Name:  "wait",
@@ -456,7 +456,7 @@ func main() {
 				},
 				cli.BoolFlag{
 					Name:  "include-needs",
-					Usage: `automaticlaly include releases from the target release's "needs" when --selector/-l flag is provided. Does nothing when when --selector/-l flag is not provided`,
+					Usage: `automatically include releases from the target release's "needs" when --selector/-l flag is provided. Does nothing when when --selector/-l flag is not provided`,
 				},
 				cli.BoolFlag{
 					Name:  "skip-diff-on-install",

--- a/main.go
+++ b/main.go
@@ -386,6 +386,14 @@ func main() {
 					Name:  "skip-deps",
 					Usage: `skip running "helm repo update" and "helm dependency build"`,
 				},
+				cli.BoolTFlag{
+					Name:  "skip-needs",
+					Usage: `do not automatically include releases from the target release's "needs" when --selector/-l flag is provided. Does nothing when when --selector/-l flag is not provided`,
+				},
+				cli.BoolFlag{
+					Name:  "include-needs",
+					Usage: `automaticlaly include releases from the target release's "needs" when --selector/-l flag is provided. Does nothing when when --selector/-l flag is not provided`,
+				},
 				cli.BoolFlag{
 					Name:  "wait",
 					Usage: `Override helmDefaults.wait setting "helm upgrade --install --wait"`,
@@ -441,6 +449,14 @@ func main() {
 				cli.BoolFlag{
 					Name:  "skip-crds",
 					Usage: "if set, no CRDs will be installed on sync. By default, CRDs are installed if not already present",
+				},
+				cli.BoolTFlag{
+					Name:  "skip-needs",
+					Usage: `do not automatically include releases from the target release's "needs" when --selector/-l flag is provided. Does nothing when when --selector/-l flag is not provided`,
+				},
+				cli.BoolFlag{
+					Name:  "include-needs",
+					Usage: `automaticlaly include releases from the target release's "needs" when --selector/-l flag is provided. Does nothing when when --selector/-l flag is not provided`,
 				},
 				cli.BoolFlag{
 					Name:  "skip-diff-on-install",
@@ -708,6 +724,14 @@ func (c configImpl) Concurrency() int {
 
 func (c configImpl) HasCommandName(name string) bool {
 	return c.c.Command.HasName(name)
+}
+
+func (c configImpl) SkipNeeds() bool {
+	return c.c.Bool("skip-needs")
+}
+
+func (c configImpl) IncludeNeeds() bool {
+	return c.c.Bool("include-needs")
 }
 
 // DiffConfig

--- a/main.go
+++ b/main.go
@@ -200,6 +200,14 @@ func main() {
 					Usage: "enable the diffing of the helm test hooks",
 				},
 				cli.BoolFlag{
+					Name:  "skip-needs",
+					Usage: `do not automatically include releases from the target release's "needs" when --selector/-l flag is provided. Does nothing when when --selector/-l flag is not provided`,
+				},
+				cli.BoolFlag{
+					Name:  "include-needs",
+					Usage: `automatically include releases from the target release's "needs" when --selector/-l flag is provided. Does nothing when when --selector/-l flag is not provided`,
+				},
+				cli.BoolFlag{
 					Name:  "suppress-secrets",
 					Usage: "suppress secrets in the output. highly recommended to specify on CI/CD use-cases",
 				},
@@ -259,6 +267,10 @@ func main() {
 				cli.BoolFlag{
 					Name:  "include-crds",
 					Usage: "include CRDs in the templated output",
+				},
+				cli.BoolFlag{
+					Name:  "include-needs",
+					Usage: `automatically include releases from the target release's "needs" when --selector/-l flag is provided. Does nothing when when --selector/-l flag is not provided`,
 				},
 				cli.BoolFlag{
 					Name:  "skip-deps",
@@ -386,7 +398,7 @@ func main() {
 					Name:  "skip-deps",
 					Usage: `skip running "helm repo update" and "helm dependency build"`,
 				},
-				cli.BoolTFlag{
+				cli.BoolFlag{
 					Name:  "skip-needs",
 					Usage: `do not automatically include releases from the target release's "needs" when --selector/-l flag is provided. Does nothing when when --selector/-l flag is not provided`,
 				},
@@ -450,7 +462,7 @@ func main() {
 					Name:  "skip-crds",
 					Usage: "if set, no CRDs will be installed on sync. By default, CRDs are installed if not already present",
 				},
-				cli.BoolTFlag{
+				cli.BoolFlag{
 					Name:  "skip-needs",
 					Usage: `do not automatically include releases from the target release's "needs" when --selector/-l flag is provided. Does nothing when when --selector/-l flag is not provided`,
 				},

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1564,7 +1564,7 @@ func (a *App) sync(r *Run, c SyncConfigProvider) (bool, []error) {
 	// on running various helm commands on unnecessary releases
 	st.Releases = toSync
 
-	toDelete, err := st.DetectReleasesToBeDeletedForSync(helm, toSync)
+	toDelete, err := st.DetectReleasesToBeDeletedForSync(helm, toSyncWithNeeds)
 	if err != nil {
 		return false, []error{err}
 	}

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1580,6 +1580,10 @@ func (a *App) sync(r *Run, c SyncConfigProvider) (bool, []error) {
 		if _, deleted := releasesToDelete[state.ReleaseToID(&r)]; !deleted {
 			if r.Installed == nil || *r.Installed {
 				toUpdate = append(toUpdate, r)
+			} else {
+				// TODO Emit error when the user opted to fail when the needed release is disabled,
+				// instead of silently ignoring it.
+				// See https://github.com/roboll/helmfile/issues/1018
 			}
 		}
 	}

--- a/pkg/app/app_apply_test.go
+++ b/pkg/app/app_apply_test.go
@@ -1,0 +1,809 @@
+package app
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/roboll/helmfile/pkg/exectest"
+	"github.com/roboll/helmfile/pkg/helmexec"
+	"github.com/roboll/helmfile/pkg/testhelper"
+	"github.com/variantdev/vals"
+)
+
+func TestApply_2(t *testing.T) {
+	type fields struct {
+		skipNeeds    bool
+		includeNeeds bool
+	}
+
+	type testcase struct {
+		fields            fields
+		ns                string
+		concurrency       int
+		skipDiffOnInstall bool
+		error             string
+		files             map[string]string
+		selectors         []string
+		lists             map[exectest.ListKey]string
+		diffs             map[exectest.DiffKey]error
+		upgraded          []exectest.Release
+		deleted           []exectest.Release
+		log               string
+	}
+
+	check := func(t *testing.T, tc testcase) {
+		t.Helper()
+
+		wantUpgrades := tc.upgraded
+		wantDeletes := tc.deleted
+
+		var helm = &exectest.Helm{
+			FailOnUnexpectedList: true,
+			FailOnUnexpectedDiff: true,
+			Lists:                tc.lists,
+			Diffs:                tc.diffs,
+			DiffMutex:            &sync.Mutex{},
+			ChartsMutex:          &sync.Mutex{},
+			ReleasesMutex:        &sync.Mutex{},
+		}
+
+		bs := &bytes.Buffer{}
+
+		func() {
+			t.Helper()
+
+			logReader, logWriter := io.Pipe()
+
+			logFlushed := &sync.WaitGroup{}
+			// Ensure all the log is consumed into `bs` by calling `logWriter.Close()` followed by `logFlushed.Wait()`
+			logFlushed.Add(1)
+			go func() {
+				scanner := bufio.NewScanner(logReader)
+				for scanner.Scan() {
+					bs.Write(scanner.Bytes())
+					bs.WriteString("\n")
+				}
+				logFlushed.Done()
+			}()
+
+			defer func() {
+				// This is here to avoid data-trace on bytes buffer `bs` to capture logs
+				if err := logWriter.Close(); err != nil {
+					panic(err)
+				}
+				logFlushed.Wait()
+			}()
+
+			logger := helmexec.NewLogger(logWriter, "debug")
+
+			valsRuntime, err := vals.New(vals.Options{CacheSize: 32})
+			if err != nil {
+				t.Errorf("unexpected error creating vals runtime: %v", err)
+			}
+
+			app := appWithFs(&App{
+				OverrideHelmBinary:  DefaultHelmBinary,
+				glob:                filepath.Glob,
+				abs:                 filepath.Abs,
+				OverrideKubeContext: "default",
+				Env:                 "default",
+				Logger:              logger,
+				helms: map[helmKey]helmexec.Interface{
+					createHelmKey("helm", "default"): helm,
+				},
+				valsRuntime: valsRuntime,
+			}, tc.files)
+
+			if tc.ns != "" {
+				app.Namespace = tc.ns
+			}
+
+			if tc.selectors != nil {
+				app.Selectors = tc.selectors
+			}
+
+			syncErr := app.Apply(applyConfig{
+				// if we check log output, concurrency must be 1. otherwise the test becomes non-deterministic.
+				concurrency:       tc.concurrency,
+				logger:            logger,
+				skipDiffOnInstall: tc.skipDiffOnInstall,
+				skipNeeds:         tc.fields.skipNeeds,
+				includeNeeds:      tc.fields.includeNeeds,
+			})
+
+			var gotErr string
+			if syncErr != nil {
+				gotErr = syncErr.Error()
+			}
+
+			if d := cmp.Diff(tc.error, gotErr); d != "" {
+				t.Fatalf("unexpected error: want (-), got (+): %s", d)
+			}
+
+			if len(wantUpgrades) > len(helm.Releases) {
+				t.Fatalf("insufficient number of upgrades: got %d, want %d", len(helm.Releases), len(wantUpgrades))
+			}
+
+			for relIdx := range wantUpgrades {
+				if wantUpgrades[relIdx].Name != helm.Releases[relIdx].Name {
+					t.Errorf("releases[%d].name: got %q, want %q", relIdx, helm.Releases[relIdx].Name, wantUpgrades[relIdx].Name)
+				}
+				for flagIdx := range wantUpgrades[relIdx].Flags {
+					if wantUpgrades[relIdx].Flags[flagIdx] != helm.Releases[relIdx].Flags[flagIdx] {
+						t.Errorf("releaes[%d].flags[%d]: got %v, want %v", relIdx, flagIdx, helm.Releases[relIdx].Flags[flagIdx], wantUpgrades[relIdx].Flags[flagIdx])
+					}
+				}
+			}
+
+			if len(wantDeletes) > len(helm.Deleted) {
+				t.Fatalf("insufficient number of deletes: got %d, want %d", len(helm.Deleted), len(wantDeletes))
+			}
+
+			for relIdx := range wantDeletes {
+				if wantDeletes[relIdx].Name != helm.Deleted[relIdx].Name {
+					t.Errorf("releases[%d].name: got %q, want %q", relIdx, helm.Deleted[relIdx].Name, wantDeletes[relIdx].Name)
+				}
+				for flagIdx := range wantDeletes[relIdx].Flags {
+					if wantDeletes[relIdx].Flags[flagIdx] != helm.Deleted[relIdx].Flags[flagIdx] {
+						t.Errorf("releaes[%d].flags[%d]: got %v, want %v", relIdx, flagIdx, helm.Deleted[relIdx].Flags[flagIdx], wantDeletes[relIdx].Flags[flagIdx])
+					}
+				}
+			}
+		}()
+
+		if tc.log != "" {
+			actual := bs.String()
+
+			diff, exists := testhelper.Diff(tc.log, actual, 3)
+			if exists {
+				t.Errorf("unexpected log:\nDIFF\n%s\nEOD", diff)
+			}
+		}
+	}
+
+	t.Run("skip-needs=true", func(t *testing.T) {
+		check(t, testcase{
+			fields: fields{
+				skipNeeds: true,
+			},
+			files: map[string]string{
+				"/path/to/helmfile.yaml": `
+{{ $mark := "a" }}
+
+releases:
+- name: kubernetes-external-secrets
+  chart: incubator/raw
+  namespace: kube-system
+
+- name: external-secrets
+  chart: incubator/raw
+  namespace: default
+  labels:
+    app: test
+  needs:
+  - kube-system/kubernetes-external-secrets
+
+- name: my-release
+  chart: incubator/raw
+  namespace: default
+  labels:
+    app: test
+  needs:
+  - default/external-secrets
+`,
+			},
+			selectors: []string{"app=test"},
+			upgraded: []exectest.Release{
+				{Name: "external-secrets", Flags: []string{"--kube-context", "default", "--namespace", "default"}},
+				{Name: "my-release", Flags: []string{"--kube-context", "default", "--namespace", "default"}},
+			},
+			diffs: map[exectest.DiffKey]error{
+				exectest.DiffKey{Name: "external-secrets", Chart: "incubator/raw", Flags: "--kube-contextdefault--namespacedefault--detailed-exitcode"}: helmexec.ExitError{Code: 2},
+				exectest.DiffKey{Name: "my-release", Chart: "incubator/raw", Flags: "--kube-contextdefault--namespacedefault--detailed-exitcode"}:       helmexec.ExitError{Code: 2},
+			},
+			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
+			concurrency: 1,
+			log: `processing file "helmfile.yaml" in directory "."
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: 
+ 2: 
+ 3: releases:
+ 4: - name: kubernetes-external-secrets
+ 5:   chart: incubator/raw
+ 6:   namespace: kube-system
+ 7: 
+ 8: - name: external-secrets
+ 9:   chart: incubator/raw
+10:   namespace: default
+11:   labels:
+12:     app: test
+13:   needs:
+14:   - kube-system/kubernetes-external-secrets
+15: 
+16: - name: my-release
+17:   chart: incubator/raw
+18:   namespace: default
+19:   labels:
+20:     app: test
+21:   needs:
+22:   - default/external-secrets
+23: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: 
+ 2: 
+ 3: releases:
+ 4: - name: kubernetes-external-secrets
+ 5:   chart: incubator/raw
+ 6:   namespace: kube-system
+ 7: 
+ 8: - name: external-secrets
+ 9:   chart: incubator/raw
+10:   namespace: default
+11:   labels:
+12:     app: test
+13:   needs:
+14:   - kube-system/kubernetes-external-secrets
+15: 
+16: - name: my-release
+17:   chart: incubator/raw
+18:   namespace: default
+19:   labels:
+20:     app: test
+21:   needs:
+22:   - default/external-secrets
+23: 
+
+merged environment: &{default map[] map[]}
+2 release(s) matching app=test found in helmfile.yaml
+
+Affected releases are:
+  external-secrets (incubator/raw) UPDATED
+  my-release (incubator/raw) UPDATED
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     default/external-secrets
+2     default/my-release
+
+processing releases in group 1/2: default/external-secrets
+getting deployed release version failed:unexpected list key: {^external-secrets$ --kube-contextdefault--deployed--failed--pending}
+processing releases in group 2/2: default/my-release
+getting deployed release version failed:unexpected list key: {^my-release$ --kube-contextdefault--deployed--failed--pending}
+
+UPDATED RELEASES:
+NAME               CHART           VERSION
+external-secrets   incubator/raw          
+my-release         incubator/raw          
+
+`,
+		})
+	})
+
+	t.Run("skip-needs=false include-needs=true", func(t *testing.T) {
+		check(t, testcase{
+			fields: fields{
+				skipNeeds:    false,
+				includeNeeds: true,
+			},
+			error: ``,
+			files: map[string]string{
+				"/path/to/helmfile.yaml": `
+{{ $mark := "a" }}
+
+releases:
+- name: kubernetes-external-secrets
+  chart: incubator/raw
+  namespace: kube-system
+
+- name: external-secrets
+  chart: incubator/raw
+  namespace: default
+  labels:
+    app: test
+  needs:
+  - kube-system/kubernetes-external-secrets
+
+- name: my-release
+  chart: incubator/raw
+  namespace: default
+  labels:
+    app: test
+  needs:
+  - default/external-secrets
+`,
+			},
+			selectors: []string{"app=test"},
+			upgraded:  []exectest.Release{},
+			diffs: map[exectest.DiffKey]error{
+				exectest.DiffKey{Name: "kubernetes-external-secrets", Chart: "incubator/raw", Flags: "--kube-contextdefault--namespacekube-system--detailed-exitcode"}: helmexec.ExitError{Code: 2},
+				exectest.DiffKey{Name: "external-secrets", Chart: "incubator/raw", Flags: "--kube-contextdefault--namespacedefault--detailed-exitcode"}:                helmexec.ExitError{Code: 2},
+				exectest.DiffKey{Name: "my-release", Chart: "incubator/raw", Flags: "--kube-contextdefault--namespacedefault--detailed-exitcode"}:                      helmexec.ExitError{Code: 2},
+			},
+			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
+			concurrency: 1,
+			log: `processing file "helmfile.yaml" in directory "."
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: 
+ 2: 
+ 3: releases:
+ 4: - name: kubernetes-external-secrets
+ 5:   chart: incubator/raw
+ 6:   namespace: kube-system
+ 7: 
+ 8: - name: external-secrets
+ 9:   chart: incubator/raw
+10:   namespace: default
+11:   labels:
+12:     app: test
+13:   needs:
+14:   - kube-system/kubernetes-external-secrets
+15: 
+16: - name: my-release
+17:   chart: incubator/raw
+18:   namespace: default
+19:   labels:
+20:     app: test
+21:   needs:
+22:   - default/external-secrets
+23: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: 
+ 2: 
+ 3: releases:
+ 4: - name: kubernetes-external-secrets
+ 5:   chart: incubator/raw
+ 6:   namespace: kube-system
+ 7: 
+ 8: - name: external-secrets
+ 9:   chart: incubator/raw
+10:   namespace: default
+11:   labels:
+12:     app: test
+13:   needs:
+14:   - kube-system/kubernetes-external-secrets
+15: 
+16: - name: my-release
+17:   chart: incubator/raw
+18:   namespace: default
+19:   labels:
+20:     app: test
+21:   needs:
+22:   - default/external-secrets
+23: 
+
+merged environment: &{default map[] map[]}
+2 release(s) matching app=test found in helmfile.yaml
+
+Affected releases are:
+  external-secrets (incubator/raw) UPDATED
+  kubernetes-external-secrets (incubator/raw) UPDATED
+  my-release (incubator/raw) UPDATED
+
+processing 3 groups of releases in this order:
+GROUP RELEASES
+1     kube-system/kubernetes-external-secrets
+2     default/external-secrets
+3     default/my-release
+
+processing releases in group 1/3: kube-system/kubernetes-external-secrets
+getting deployed release version failed:unexpected list key: {^kubernetes-external-secrets$ --kube-contextdefault--deployed--failed--pending}
+processing releases in group 2/3: default/external-secrets
+getting deployed release version failed:unexpected list key: {^external-secrets$ --kube-contextdefault--deployed--failed--pending}
+processing releases in group 3/3: default/my-release
+getting deployed release version failed:unexpected list key: {^my-release$ --kube-contextdefault--deployed--failed--pending}
+
+UPDATED RELEASES:
+NAME                          CHART           VERSION
+kubernetes-external-secrets   incubator/raw          
+external-secrets              incubator/raw          
+my-release                    incubator/raw          
+
+`,
+		})
+	})
+
+	t.Run("skip-needs=false include-needs=true with installed but disabled release", func(t *testing.T) {
+		check(t, testcase{
+			fields: fields{
+				skipNeeds:    false,
+				includeNeeds: true,
+			},
+			error: ``,
+			files: map[string]string{
+				"/path/to/helmfile.yaml": `
+{{ $mark := "a" }}
+
+releases:
+- name: kubernetes-external-secrets
+  chart: incubator/raw
+  namespace: kube-system
+  installed: false
+
+- name: external-secrets
+  chart: incubator/raw
+  namespace: default
+  labels:
+    app: test
+  needs:
+  - kube-system/kubernetes-external-secrets
+
+- name: my-release
+  chart: incubator/raw
+  namespace: default
+  labels:
+    app: test
+  needs:
+  - default/external-secrets
+`,
+			},
+			selectors: []string{"app=test"},
+			upgraded:  []exectest.Release{},
+			lists: map[exectest.ListKey]string{
+				// delete frontend-v1 and backend-v1
+				exectest.ListKey{Filter: "^kubernetes-external-secrets$", Flags: "--kube-contextdefault--deployed--failed--pending"}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+^kubernetes-external-secrets$ 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	backend-3.1.0	3.1.0      	default
+`,
+			},
+			diffs: map[exectest.DiffKey]error{
+				exectest.DiffKey{Name: "external-secrets", Chart: "incubator/raw", Flags: "--kube-contextdefault--namespacedefault--detailed-exitcode"}: helmexec.ExitError{Code: 2},
+				exectest.DiffKey{Name: "my-release", Chart: "incubator/raw", Flags: "--kube-contextdefault--namespacedefault--detailed-exitcode"}:       helmexec.ExitError{Code: 2},
+			},
+			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
+			concurrency: 1,
+			log: `processing file "helmfile.yaml" in directory "."
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: 
+ 2: 
+ 3: releases:
+ 4: - name: kubernetes-external-secrets
+ 5:   chart: incubator/raw
+ 6:   namespace: kube-system
+ 7:   installed: false
+ 8: 
+ 9: - name: external-secrets
+10:   chart: incubator/raw
+11:   namespace: default
+12:   labels:
+13:     app: test
+14:   needs:
+15:   - kube-system/kubernetes-external-secrets
+16: 
+17: - name: my-release
+18:   chart: incubator/raw
+19:   namespace: default
+20:   labels:
+21:     app: test
+22:   needs:
+23:   - default/external-secrets
+24: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: 
+ 2: 
+ 3: releases:
+ 4: - name: kubernetes-external-secrets
+ 5:   chart: incubator/raw
+ 6:   namespace: kube-system
+ 7:   installed: false
+ 8: 
+ 9: - name: external-secrets
+10:   chart: incubator/raw
+11:   namespace: default
+12:   labels:
+13:     app: test
+14:   needs:
+15:   - kube-system/kubernetes-external-secrets
+16: 
+17: - name: my-release
+18:   chart: incubator/raw
+19:   namespace: default
+20:   labels:
+21:     app: test
+22:   needs:
+23:   - default/external-secrets
+24: 
+
+merged environment: &{default map[] map[]}
+2 release(s) matching app=test found in helmfile.yaml
+
+Affected releases are:
+  external-secrets (incubator/raw) UPDATED
+  kubernetes-external-secrets (incubator/raw) DELETED
+  my-release (incubator/raw) UPDATED
+
+processing 1 groups of releases in this order:
+GROUP RELEASES
+1     kube-system/kubernetes-external-secrets
+
+processing releases in group 1/1: kube-system/kubernetes-external-secrets
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     default/external-secrets
+2     default/my-release
+
+processing releases in group 1/2: default/external-secrets
+getting deployed release version failed:unexpected list key: {^external-secrets$ --kube-contextdefault--deployed--failed--pending}
+processing releases in group 2/2: default/my-release
+getting deployed release version failed:unexpected list key: {^my-release$ --kube-contextdefault--deployed--failed--pending}
+
+UPDATED RELEASES:
+NAME               CHART           VERSION
+external-secrets   incubator/raw          
+my-release         incubator/raw          
+
+
+DELETED RELEASES:
+NAME
+kubernetes-external-secrets
+`,
+		})
+	})
+
+	t.Run("skip-needs=false include-needs=true with not installed and disabled release", func(t *testing.T) {
+		check(t, testcase{
+			fields: fields{
+				skipNeeds:    false,
+				includeNeeds: true,
+			},
+			error: ``,
+			files: map[string]string{
+				"/path/to/helmfile.yaml": `
+{{ $mark := "a" }}
+
+releases:
+- name: kubernetes-external-secrets
+  chart: incubator/raw
+  namespace: kube-system
+  installed: false
+
+- name: external-secrets
+  chart: incubator/raw
+  namespace: default
+  labels:
+    app: test
+  needs:
+  - kube-system/kubernetes-external-secrets
+
+- name: my-release
+  chart: incubator/raw
+  namespace: default
+  labels:
+    app: test
+  needs:
+  - default/external-secrets
+`,
+			},
+			selectors: []string{"app=test"},
+			upgraded:  []exectest.Release{},
+			lists: map[exectest.ListKey]string{
+				// delete frontend-v1 and backend-v1
+				exectest.ListKey{Filter: "^kubernetes-external-secrets$", Flags: "--kube-contextdefault--deployed--failed--pending"}: ``,
+			},
+			diffs: map[exectest.DiffKey]error{
+				exectest.DiffKey{Name: "external-secrets", Chart: "incubator/raw", Flags: "--kube-contextdefault--namespacedefault--detailed-exitcode"}: helmexec.ExitError{Code: 2},
+				exectest.DiffKey{Name: "my-release", Chart: "incubator/raw", Flags: "--kube-contextdefault--namespacedefault--detailed-exitcode"}:       helmexec.ExitError{Code: 2},
+			},
+			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
+			concurrency: 1,
+			log: `processing file "helmfile.yaml" in directory "."
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: 
+ 2: 
+ 3: releases:
+ 4: - name: kubernetes-external-secrets
+ 5:   chart: incubator/raw
+ 6:   namespace: kube-system
+ 7:   installed: false
+ 8: 
+ 9: - name: external-secrets
+10:   chart: incubator/raw
+11:   namespace: default
+12:   labels:
+13:     app: test
+14:   needs:
+15:   - kube-system/kubernetes-external-secrets
+16: 
+17: - name: my-release
+18:   chart: incubator/raw
+19:   namespace: default
+20:   labels:
+21:     app: test
+22:   needs:
+23:   - default/external-secrets
+24: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: 
+ 2: 
+ 3: releases:
+ 4: - name: kubernetes-external-secrets
+ 5:   chart: incubator/raw
+ 6:   namespace: kube-system
+ 7:   installed: false
+ 8: 
+ 9: - name: external-secrets
+10:   chart: incubator/raw
+11:   namespace: default
+12:   labels:
+13:     app: test
+14:   needs:
+15:   - kube-system/kubernetes-external-secrets
+16: 
+17: - name: my-release
+18:   chart: incubator/raw
+19:   namespace: default
+20:   labels:
+21:     app: test
+22:   needs:
+23:   - default/external-secrets
+24: 
+
+merged environment: &{default map[] map[]}
+2 release(s) matching app=test found in helmfile.yaml
+
+Affected releases are:
+  external-secrets (incubator/raw) UPDATED
+  my-release (incubator/raw) UPDATED
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     default/external-secrets
+2     default/my-release
+
+processing releases in group 1/2: default/external-secrets
+getting deployed release version failed:unexpected list key: {^external-secrets$ --kube-contextdefault--deployed--failed--pending}
+processing releases in group 2/2: default/my-release
+getting deployed release version failed:unexpected list key: {^my-release$ --kube-contextdefault--deployed--failed--pending}
+
+UPDATED RELEASES:
+NAME               CHART           VERSION
+external-secrets   incubator/raw          
+my-release         incubator/raw          
+
+`,
+		})
+	})
+
+	t.Run("bad --selector", func(t *testing.T) {
+		check(t, testcase{
+			files: map[string]string{
+				"/path/to/helmfile.yaml": `
+{{ $mark := "a" }}
+
+releases:
+- name: kubernetes-external-secrets
+  chart: incubator/raw
+  namespace: kube-system
+
+- name: external-secrets
+  chart: incubator/raw
+  namespace: default
+  labels:
+    app: test
+  needs:
+  - kube-system/kubernetes-external-secrets
+
+- name: my-release
+  chart: incubator/raw
+  namespace: default
+  labels:
+    app: test
+  needs:
+  - default/external-secrets
+`,
+			},
+			selectors: []string{"app=test_non_existent"},
+			upgraded:  []exectest.Release{},
+			error:     "err: no releases found that matches specified selector(app=test_non_existent) and environment(default), in any helmfile",
+			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
+			concurrency: 1,
+			log: `processing file "helmfile.yaml" in directory "."
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: 
+ 2: 
+ 3: releases:
+ 4: - name: kubernetes-external-secrets
+ 5:   chart: incubator/raw
+ 6:   namespace: kube-system
+ 7: 
+ 8: - name: external-secrets
+ 9:   chart: incubator/raw
+10:   namespace: default
+11:   labels:
+12:     app: test
+13:   needs:
+14:   - kube-system/kubernetes-external-secrets
+15: 
+16: - name: my-release
+17:   chart: incubator/raw
+18:   namespace: default
+19:   labels:
+20:     app: test
+21:   needs:
+22:   - default/external-secrets
+23: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: 
+ 2: 
+ 3: releases:
+ 4: - name: kubernetes-external-secrets
+ 5:   chart: incubator/raw
+ 6:   namespace: kube-system
+ 7: 
+ 8: - name: external-secrets
+ 9:   chart: incubator/raw
+10:   namespace: default
+11:   labels:
+12:     app: test
+13:   needs:
+14:   - kube-system/kubernetes-external-secrets
+15: 
+16: - name: my-release
+17:   chart: incubator/raw
+18:   namespace: default
+19:   labels:
+20:     app: test
+21:   needs:
+22:   - default/external-secrets
+23: 
+
+merged environment: &{default map[] map[]}
+0 release(s) matching app=test_non_existent found in helmfile.yaml
+
+`,
+		})
+	})
+}

--- a/pkg/app/app_sync_test.go
+++ b/pkg/app/app_sync_test.go
@@ -53,6 +53,8 @@ func TestSync(t *testing.T) {
 		bs := &bytes.Buffer{}
 
 		func() {
+			t.Helper()
+
 			logReader, logWriter := io.Pipe()
 
 			logFlushed := &sync.WaitGroup{}
@@ -109,6 +111,7 @@ func TestSync(t *testing.T) {
 				logger:            logger,
 				skipDiffOnInstall: tc.skipDiffOnInstall,
 				skipNeeds:         tc.fields.skipNeeds,
+				includeNeeds:      tc.fields.includeNeeds,
 			})
 
 			var gotErr string
@@ -291,7 +294,7 @@ my-release         incubator/raw
 				skipNeeds:    false,
 				includeNeeds: true,
 			},
-			error: `in ./helmfile.yaml: release "default/external-secrets" depends on "kube-system/kubernetes-external-secrets" which does not match the selectors. Please add a selector like "--selector name=kubernetes-external-secrets", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies`,
+			error: ``,
 			files: map[string]string{
 				"/path/to/helmfile.yaml": `
 {{ $mark := "a" }}
@@ -385,7 +388,174 @@ second-pass rendering result of "helmfile.yaml.part.0":
 merged environment: &{default map[] map[]}
 2 release(s) matching app=test found in helmfile.yaml
 
-err: release "default/external-secrets" depends on "kube-system/kubernetes-external-secrets" which does not match the selectors. Please add a selector like "--selector name=kubernetes-external-secrets", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies
+Affected releases are:
+  external-secrets (incubator/raw) UPDATED
+  kubernetes-external-secrets (incubator/raw) UPDATED
+  my-release (incubator/raw) UPDATED
+
+processing 3 groups of releases in this order:
+GROUP RELEASES
+1     kube-system/kubernetes-external-secrets
+2     default/external-secrets
+3     default/my-release
+
+processing releases in group 1/3: kube-system/kubernetes-external-secrets
+getting deployed release version failed:unexpected list key: {^kubernetes-external-secrets$ --kube-contextdefault--deployed--failed--pending}
+processing releases in group 2/3: default/external-secrets
+getting deployed release version failed:unexpected list key: {^external-secrets$ --kube-contextdefault--deployed--failed--pending}
+processing releases in group 3/3: default/my-release
+getting deployed release version failed:unexpected list key: {^my-release$ --kube-contextdefault--deployed--failed--pending}
+
+UPDATED RELEASES:
+NAME                          CHART           VERSION
+kubernetes-external-secrets   incubator/raw          
+external-secrets              incubator/raw          
+my-release                    incubator/raw          
+
+`,
+		})
+	})
+
+	t.Run("skip-needs=false include-needs=true with installed but disabled release", func(t *testing.T) {
+		check(t, testcase{
+			fields: fields{
+				skipNeeds:    false,
+				includeNeeds: true,
+			},
+			error: ``,
+			files: map[string]string{
+				"/path/to/helmfile.yaml": `
+{{ $mark := "a" }}
+
+releases:
+- name: kubernetes-external-secrets
+  chart: incubator/raw
+  namespace: kube-system
+  installed: false
+
+- name: external-secrets
+  chart: incubator/raw
+  namespace: default
+  labels:
+    app: test
+  needs:
+  - kube-system/kubernetes-external-secrets
+
+- name: my-release
+  chart: incubator/raw
+  namespace: default
+  labels:
+    app: test
+  needs:
+  - default/external-secrets
+`,
+			},
+			selectors: []string{"app=test"},
+			upgraded:  []exectest.Release{},
+			lists: map[exectest.ListKey]string{
+				// delete frontend-v1 and backend-v1
+				exectest.ListKey{Filter: "^kubernetes-external-secrets$", Flags: "--kube-contextdefault--deployed--failed--pending"}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+^kubernetes-external-secrets$ 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	backend-3.1.0	3.1.0      	default
+`,
+			},
+			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
+			concurrency: 1,
+			log: `processing file "helmfile.yaml" in directory "."
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: 
+ 2: 
+ 3: releases:
+ 4: - name: kubernetes-external-secrets
+ 5:   chart: incubator/raw
+ 6:   namespace: kube-system
+ 7:   installed: false
+ 8: 
+ 9: - name: external-secrets
+10:   chart: incubator/raw
+11:   namespace: default
+12:   labels:
+13:     app: test
+14:   needs:
+15:   - kube-system/kubernetes-external-secrets
+16: 
+17: - name: my-release
+18:   chart: incubator/raw
+19:   namespace: default
+20:   labels:
+21:     app: test
+22:   needs:
+23:   - default/external-secrets
+24: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: 
+ 2: 
+ 3: releases:
+ 4: - name: kubernetes-external-secrets
+ 5:   chart: incubator/raw
+ 6:   namespace: kube-system
+ 7:   installed: false
+ 8: 
+ 9: - name: external-secrets
+10:   chart: incubator/raw
+11:   namespace: default
+12:   labels:
+13:     app: test
+14:   needs:
+15:   - kube-system/kubernetes-external-secrets
+16: 
+17: - name: my-release
+18:   chart: incubator/raw
+19:   namespace: default
+20:   labels:
+21:     app: test
+22:   needs:
+23:   - default/external-secrets
+24: 
+
+merged environment: &{default map[] map[]}
+2 release(s) matching app=test found in helmfile.yaml
+
+Affected releases are:
+  external-secrets (incubator/raw) UPDATED
+  kubernetes-external-secrets (incubator/raw) DELETED
+  my-release (incubator/raw) UPDATED
+
+processing 3 groups of releases in this order:
+GROUP RELEASES
+1     default/my-release
+2     default/external-secrets
+3     kube-system/kubernetes-external-secrets
+
+processing releases in group 1/3: default/my-release
+processing releases in group 2/3: default/external-secrets
+processing releases in group 3/3: kube-system/kubernetes-external-secrets
+processing 3 groups of releases in this order:
+GROUP RELEASES
+1     kube-system/kubernetes-external-secrets
+2     default/external-secrets
+3     default/my-release
+
+processing releases in group 1/3: kube-system/kubernetes-external-secrets
+processing releases in group 2/3: default/external-secrets
+getting deployed release version failed:unexpected list key: {^external-secrets$ --kube-contextdefault--deployed--failed--pending}
+processing releases in group 3/3: default/my-release
+getting deployed release version failed:unexpected list key: {^my-release$ --kube-contextdefault--deployed--failed--pending}
+
+UPDATED RELEASES:
+NAME               CHART           VERSION
+external-secrets   incubator/raw          
+my-release         incubator/raw          
+
 `,
 		})
 	})

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -2972,26 +2972,20 @@ Affected releases are:
   logging (charts/fluent-bit) UPDATED
   servicemesh (charts/istio) UPDATED
 
-processing 5 groups of releases in this order:
+processing 2 groups of releases in this order:
 GROUP RELEASES
-1     frontend-v1, frontend-v2, frontend-v3
-2     backend-v1, backend-v2
-3     anotherbackend
-4     database, servicemesh
-5     logging, front-proxy
+1     frontend-v1
+2     backend-v1
 
-processing releases in group 1/5: frontend-v1, frontend-v2, frontend-v3
-processing releases in group 2/5: backend-v1, backend-v2
-processing releases in group 3/5: anotherbackend
-processing releases in group 4/5: database, servicemesh
-processing releases in group 5/5: logging, front-proxy
+processing releases in group 1/2: frontend-v1
+processing releases in group 2/2: backend-v1
 processing 5 groups of releases in this order:
 GROUP RELEASES
 1     logging, front-proxy
 2     database, servicemesh
 3     anotherbackend
-4     backend-v1, backend-v2
-5     frontend-v1, frontend-v2, frontend-v3
+4     backend-v2
+5     frontend-v3
 
 processing releases in group 1/5: logging, front-proxy
 getting deployed release version failed:unexpected list key: {^logging$ --kube-contextdefault--deployed--failed--pending}
@@ -3001,9 +2995,9 @@ getting deployed release version failed:unexpected list key: {^database$ --kube-
 getting deployed release version failed:unexpected list key: {^servicemesh$ --kube-contextdefault--deployed--failed--pending}
 processing releases in group 3/5: anotherbackend
 getting deployed release version failed:unexpected list key: {^anotherbackend$ --kube-contextdefault--deployed--failed--pending}
-processing releases in group 4/5: backend-v1, backend-v2
+processing releases in group 4/5: backend-v2
 getting deployed release version failed:unexpected list key: {^backend-v2$ --kube-contextdefault--deployed--failed--pending}
-processing releases in group 5/5: frontend-v1, frontend-v2, frontend-v3
+processing releases in group 5/5: frontend-v3
 getting deployed release version failed:unexpected list key: {^frontend-v3$ --kube-contextdefault--deployed--failed--pending}
 
 UPDATED RELEASES:

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -2245,6 +2245,9 @@ type configImpl struct {
 	skipCleanup bool
 	skipCRDs    bool
 	skipDeps    bool
+
+	skipNeeds    bool
+	includeNeeds bool
 }
 
 func (a configImpl) Selectors() []string {
@@ -2277,6 +2280,14 @@ func (c configImpl) SkipCRDs() bool {
 
 func (c configImpl) SkipDeps() bool {
 	return c.skipDeps
+}
+
+func (c configImpl) SkipNeeds() bool {
+	return c.skipNeeds
+}
+
+func (c configImpl) IncludeNeeds() bool {
+	return c.includeNeeds
 }
 
 func (c configImpl) OutputDir() string {
@@ -2312,6 +2323,8 @@ type applyConfig struct {
 	skipCleanup       bool
 	skipCRDs          bool
 	skipDeps          bool
+	skipNeeds         bool
+	includeNeeds      bool
 	includeTests      bool
 	suppressSecrets   bool
 	showSecrets       bool
@@ -2361,6 +2374,14 @@ func (a applyConfig) SkipCRDs() bool {
 
 func (a applyConfig) SkipDeps() bool {
 	return a.skipDeps
+}
+
+func (c applyConfig) SkipNeeds() bool {
+	return c.skipNeeds
+}
+
+func (c applyConfig) IncludeNeeds() bool {
+	return c.includeNeeds
 }
 
 func (a applyConfig) IncludeTests() bool {

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -59,6 +59,9 @@ type ApplyConfigProvider interface {
 	SkipCleanup() bool
 	SkipDiffOnInstall() bool
 
+	SkipNeeds() bool
+	IncludeNeeds() bool
+
 	concurrencyConfig
 	interactive
 	loggingConfig
@@ -73,6 +76,9 @@ type SyncConfigProvider interface {
 	SkipDeps() bool
 	Wait() bool
 	WaitForJobs() bool
+
+	SkipNeeds() bool
+	IncludeNeeds() bool
 
 	concurrencyConfig
 	loggingConfig
@@ -91,6 +97,9 @@ type DiffConfigProvider interface {
 	SuppressSecrets() bool
 	ShowSecrets() bool
 	SuppressDiff() bool
+
+	SkipNeeds() bool
+	IncludeNeeds() bool
 
 	DetailedExitcode() bool
 	NoColor() bool

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -164,6 +164,7 @@ type TemplateConfigProvider interface {
 	SkipCleanup() bool
 	OutputDir() string
 	IncludeCRDs() bool
+	IncludeNeeds() bool
 
 	concurrencyConfig
 }

--- a/pkg/app/diff_test.go
+++ b/pkg/app/diff_test.go
@@ -1062,7 +1062,7 @@ releases:
 			upgraded: []exectest.Release{},
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
 			concurrency: 1,
-			error:       `in ./helmfile.yaml: release "default/external-secrets" depends on "kube-system/kubernetes-external-secrets" which is not included in the selector. Please indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies`,
+			error:       `in ./helmfile.yaml: release "default/external-secrets" depends on "kube-system/kubernetes-external-secrets" which does not match the selectors. Please add a selector like "--selector name=kubernetes-external-secrets", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies`,
 			log: `processing file "helmfile.yaml" in directory "."
 first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
 first-pass uses: &{default map[] map[]}
@@ -1126,7 +1126,7 @@ second-pass rendering result of "helmfile.yaml.part.0":
 merged environment: &{default map[] map[]}
 2 release(s) matching app=test found in helmfile.yaml
 
-err: release "default/external-secrets" depends on "kube-system/kubernetes-external-secrets" which is not included in the selector. Please indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies
+err: release "default/external-secrets" depends on "kube-system/kubernetes-external-secrets" which does not match the selectors. Please add a selector like "--selector name=kubernetes-external-secrets", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies
 `,
 		},
 		{

--- a/pkg/app/diff_test.go
+++ b/pkg/app/diff_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/roboll/helmfile/pkg/exectest"
 	"github.com/roboll/helmfile/pkg/helmexec"
 	"github.com/roboll/helmfile/pkg/testhelper"
@@ -24,6 +25,8 @@ type diffConfig struct {
 	skipCRDs          bool
 	skipDeps          bool
 	includeTests      bool
+	includeNeeds      bool
+	skipNeeds         bool
 	suppressSecrets   bool
 	showSecrets       bool
 	suppressDiff      bool
@@ -61,6 +64,14 @@ func (a diffConfig) SkipDeps() bool {
 
 func (a diffConfig) IncludeTests() bool {
 	return a.includeTests
+}
+
+func (a diffConfig) IncludeNeeds() bool {
+	return a.includeNeeds
+}
+
+func (a diffConfig) SkipNeeds() bool {
+	return a.skipNeeds
 }
 
 func (a diffConfig) SuppressSecrets() bool {
@@ -104,6 +115,10 @@ func (a diffConfig) RetainValuesFiles() bool {
 }
 
 func TestDiff(t *testing.T) {
+	type flags struct {
+		skipNeeds bool
+	}
+
 	testcases := []struct {
 		name             string
 		loc              string
@@ -111,6 +126,7 @@ func TestDiff(t *testing.T) {
 		concurrency      int
 		detailedExitcode bool
 		error            string
+		flags            flags
 		files            map[string]string
 		selectors        []string
 		lists            map[exectest.ListKey]string
@@ -899,8 +915,9 @@ bar 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart2-3.1.0	3.1.0      	defau
 		//
 		{
 			// see https://github.com/roboll/helmfile/issues/919#issuecomment-549831747
-			name: "upgrades with good selector",
-			loc:  location(),
+			name:  "upgrades with good selector with --skip-needs=true",
+			loc:   location(),
+			flags: flags{skipNeeds: true},
 			files: map[string]string{
 				"/path/to/helmfile.yaml": `
 {{ $mark := "a" }}
@@ -1004,6 +1021,112 @@ Affected releases are:
   external-secrets (incubator/raw) UPDATED
   my-release (incubator/raw) UPDATED
 
+`,
+		},
+		{
+			name:  "upgrades with good selector with --skip-needs=false",
+			loc:   location(),
+			flags: flags{skipNeeds: false},
+			files: map[string]string{
+				"/path/to/helmfile.yaml": `
+{{ $mark := "a" }}
+
+releases:
+- name: kubernetes-external-secrets
+  chart: incubator/raw
+  namespace: kube-system
+
+- name: external-secrets
+  chart: incubator/raw
+  namespace: default
+  labels:
+    app: test
+  needs:
+  - kube-system/kubernetes-external-secrets
+
+- name: my-release
+  chart: incubator/raw
+  namespace: default
+  labels:
+    app: test
+  needs:
+  - default/external-secrets
+`,
+			},
+			selectors:        []string{"app=test"},
+			detailedExitcode: true,
+			diffs: map[exectest.DiffKey]error{
+				exectest.DiffKey{Name: "external-secrets", Chart: "incubator/raw", Flags: "--kube-contextdefault--namespacedefault--detailed-exitcode"}: helmexec.ExitError{Code: 2},
+				exectest.DiffKey{Name: "my-release", Chart: "incubator/raw", Flags: "--kube-contextdefault--namespacedefault--detailed-exitcode"}:       helmexec.ExitError{Code: 2},
+			},
+			upgraded: []exectest.Release{},
+			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
+			concurrency: 1,
+			error:       `in ./helmfile.yaml: release "default/external-secrets" depends on "kube-system/kubernetes-external-secrets" which is not included in the selector. Please indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies`,
+			log: `processing file "helmfile.yaml" in directory "."
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: 
+ 2: 
+ 3: releases:
+ 4: - name: kubernetes-external-secrets
+ 5:   chart: incubator/raw
+ 6:   namespace: kube-system
+ 7: 
+ 8: - name: external-secrets
+ 9:   chart: incubator/raw
+10:   namespace: default
+11:   labels:
+12:     app: test
+13:   needs:
+14:   - kube-system/kubernetes-external-secrets
+15: 
+16: - name: my-release
+17:   chart: incubator/raw
+18:   namespace: default
+19:   labels:
+20:     app: test
+21:   needs:
+22:   - default/external-secrets
+23: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: 
+ 2: 
+ 3: releases:
+ 4: - name: kubernetes-external-secrets
+ 5:   chart: incubator/raw
+ 6:   namespace: kube-system
+ 7: 
+ 8: - name: external-secrets
+ 9:   chart: incubator/raw
+10:   namespace: default
+11:   labels:
+12:     app: test
+13:   needs:
+14:   - kube-system/kubernetes-external-secrets
+15: 
+16: - name: my-release
+17:   chart: incubator/raw
+18:   namespace: default
+19:   labels:
+20:     app: test
+21:   needs:
+22:   - default/external-secrets
+23: 
+
+merged environment: &{default map[] map[]}
+2 release(s) matching app=test found in helmfile.yaml
+
+err: release "default/external-secrets" depends on "kube-system/kubernetes-external-secrets" which is not included in the selector. Please indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies
 `,
 		},
 		{
@@ -1250,13 +1373,16 @@ err: "foo" depends on nonexistent release "bar"
 					concurrency:      tc.concurrency,
 					logger:           logger,
 					detailedExitcode: tc.detailedExitcode,
+					skipNeeds:        tc.flags.skipNeeds,
 				})
-				if tc.error == "" && diffErr != nil {
-					t.Fatalf("unexpected error for data defined at %s: %v", tc.loc, diffErr)
-				} else if tc.error != "" && diffErr == nil {
-					t.Fatalf("expected error did not occur for data defined at %s", tc.loc)
-				} else if tc.error != "" && diffErr != nil && tc.error != diffErr.Error() {
-					t.Fatalf("invalid error: expected %q, got %q", tc.error, diffErr.Error())
+
+				var diffErrStr string
+				if diffErr != nil {
+					diffErrStr = diffErr.Error()
+				}
+
+				if d := cmp.Diff(tc.error, diffErrStr); d != "" {
+					t.Fatalf("invalid error: want (-), got (+): %s", d)
 				}
 
 				if len(wantUpgrades) > len(helm.Releases) {

--- a/pkg/state/state_run.go
+++ b/pkg/state/state_run.go
@@ -204,12 +204,16 @@ func GroupReleasesByDependency(releases []Release, opts PlanOptions) ([][]Releas
 					verb = "depend"
 				}
 
+				idComponents := strings.Split(id, "/")
+				name := idComponents[len(idComponents)-1]
+
 				msg := fmt.Sprintf(
-					"release %s %s on %q which is not included in the selector. "+
-						"Please indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies",
+					"release %s %s on %q which does not match the selectors. "+
+						"Please add a selector like \"--selector name=%s\", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies",
 					dsHumanized,
 					verb,
 					id,
+					name,
 				)
 				msgs[i] = msg
 			}

--- a/pkg/state/state_run.go
+++ b/pkg/state/state_run.go
@@ -1,8 +1,10 @@
 package state
 
 import (
+	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 
 	"github.com/roboll/helmfile/pkg/helmexec"
@@ -97,17 +99,20 @@ func (st *HelmState) iterateOnReleases(helm helmexec.Interface, concurrency int,
 	return nil
 }
 
-type PlanOpts struct {
-	Reverse bool
+type PlanOptions struct {
+	Reverse          bool
+	IncludeNeeds     bool
+	SkipNeeds        bool
+	SelectedReleases []ReleaseSpec
 }
 
-func (st *HelmState) PlanReleases(reverse bool) ([][]Release, error) {
+func (st *HelmState) PlanReleases(opts PlanOptions) ([][]Release, error) {
 	marked, err := st.SelectReleasesWithOverrides()
 	if err != nil {
 		return nil, err
 	}
 
-	groups, err := SortedReleaseGroups(marked, reverse)
+	groups, err := SortedReleaseGroups(marked, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -115,8 +120,10 @@ func (st *HelmState) PlanReleases(reverse bool) ([][]Release, error) {
 	return groups, nil
 }
 
-func SortedReleaseGroups(releases []Release, reverse bool) ([][]Release, error) {
-	groups, err := GroupReleasesByDependency(releases)
+func SortedReleaseGroups(releases []Release, opts PlanOptions) ([][]Release, error) {
+	reverse := opts.Reverse
+
+	groups, err := GroupReleasesByDependency(releases, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +137,7 @@ func SortedReleaseGroups(releases []Release, reverse bool) ([][]Release, error) 
 	return groups, nil
 }
 
-func GroupReleasesByDependency(releases []Release) ([][]Release, error) {
+func GroupReleasesByDependency(releases []Release, opts PlanOptions) ([][]Release, error) {
 	idToReleases := map[string][]Release{}
 	idToIndex := map[string]int{}
 
@@ -159,8 +166,55 @@ func GroupReleasesByDependency(releases []Release) ([][]Release, error) {
 		}
 	}
 
-	plan, err := d.Plan()
+	var selectedReleaseIDs []string
+
+	for _, r := range opts.SelectedReleases {
+		id := ReleaseToID(&r)
+		selectedReleaseIDs = append(selectedReleaseIDs, id)
+	}
+
+	plan, err := d.Plan(dag.SortOptions{
+		Only:                selectedReleaseIDs,
+		WithDependencies:    opts.IncludeNeeds,
+		WithoutDependencies: opts.SkipNeeds,
+	})
 	if err != nil {
+		if ude, ok := err.(*dag.UnhandledDependencyError); ok {
+			msgs := make([]string, len(ude.UnhandledDependencies))
+			for i, ud := range ude.UnhandledDependencies {
+				id := ud.Id
+
+				ds := make([]string, len(ud.Dependents))
+				for i, d := range ud.Dependents {
+					ds[i] = fmt.Sprintf("%q", d)
+				}
+
+				var dsHumanized string
+				if len(ds) < 3 {
+					dsHumanized = strings.Join(ds, " and ")
+				} else {
+					dsHumanized = strings.Join(ds[:len(ds)-1], ", ")
+					dsHumanized += ", and " + ds[len(ds)-1]
+				}
+
+				var verb string
+				if len(ds) == 1 {
+					verb = "depends"
+				} else {
+					verb = "depend"
+				}
+
+				msg := fmt.Sprintf(
+					"release %s %s on %q which is not included in the selector. "+
+						"Please indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies",
+					dsHumanized,
+					verb,
+					id,
+				)
+				msgs[i] = msg
+			}
+			return nil, errors.New(msgs[0])
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
Currently, this is going to be a breaking change for whoever relied on the helmfile's existing behavior of `helmfile -l foo=bar apply` silently ignoring the unfulfilled `needs`.

Since this change, for example, `helmfile -l name=myapp apply` with the below helmfile.yaml would fail and require you to add either `--include-needs` or `--skip-needs` to make it successful:

```
releases:
- name: myapp
  chart: charts/myapp
  needs:
  - mydb
- name: mydb
  chart: charts/mydb
```

## Affected commands

- `helmfile template` defaults to `--skip-needs=true` + `--include-needs=false` assuming the primary use of `helmfile template` is piping to `kubectl apply` and Argo CD, or saving to the disk.
- `helmfile diff`, `helmfile sync`, and `helmfile apply` defaults to `--skip-needs=false` + `--include-needs=false` assuming the user would like to be sure which is the behaviour they want given feedbacks in #1692

## Breaking change

- `helmfile -l name=myapp [apply|diff|sync]` now fail due to the unhandled unfulfilled dependency `mydb`

## Additional features

- `helmfile -l name=myapp sync --include-needs` syncs `mydb` and then `myapp`
- `helmfile -l name=myapp sync --skip-needs` syncs `myapp` only. This was the default behaviour before this change.
- `helmfile -l name=myapp diff --include-needs` diffs `mydb` and then `myapp`
- `helmfile -l name=myapp diff --skip-needs` diffs `myapp` only. This was the default behaviour before this change.
- `helmfile -l name=myapp apply --include-needs` syncs `mydb` and then `myapp`
- `helmfile -l name=myapp apply --skip-needs` syncs `myapp` only. This was the default behaviour before this change.

Resolves #1692

@bseenu @roderik @mwakkach @antaloala @FWest98 It's mostly implemented, except that I need to make the error more user-friendly. Currently it's like `"mydb" depended by "myapp" is not included`, which is hard for the user to know if they need to add either `--include-needs` or `--skip-needs` to make it successful.