### PR TITLE
Feature/diff simple

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ vendor/
 *.log
 .vagrant/
 *.lock
+test/integration/.gnupg/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,11 +1,11 @@
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/xenial64"
+  config.vm.box = "ubuntu/focal64"
   config.vm.hostname = "minikube.box"
   config.vm.provision :shell, privileged: false,
     inline: <<-EOS
       set -e
       sudo apt-get update
-      sudo apt-get install -y make docker.io=18.09.7-*
+      sudo apt-get install -y make docker.io
       sudo systemctl start docker
       sudo usermod -G docker $USER
       cd /vagrant/.circleci

--- a/main.go
+++ b/main.go
@@ -225,6 +225,11 @@ func main() {
 					Value: 0,
 					Usage: "output NUM lines of context around changes",
 				},
+				cli.StringFlag{
+					Name:  "diff-output",
+					Value: "",
+					Usage: "output format for diff plugin",
+				},
 			},
 			Action: action(func(a *app.App, c configImpl) error {
 				return a.Diff(c)
@@ -440,6 +445,11 @@ func main() {
 					Name:  "context",
 					Value: 0,
 					Usage: "output NUM lines of context around changes",
+				},
+				cli.StringFlag{
+					Name:  "diff-output",
+					Value: "",
+					Usage: "output format for diff plugin",
 				},
 				cli.BoolFlag{
 					Name:  "detailed-exitcode",
@@ -853,6 +863,10 @@ func (c configImpl) NoColor() bool {
 
 func (c configImpl) Context() int {
 	return c.c.Int("context")
+}
+
+func (c configImpl) DiffOutput() string {
+	return c.c.String("diff-output")
 }
 
 func (c configImpl) SkipCleanup() bool {

--- a/main.go
+++ b/main.go
@@ -866,7 +866,7 @@ func (c configImpl) Context() int {
 }
 
 func (c configImpl) DiffOutput() string {
-	return c.c.String("diff-output")
+	return c.c.String("output")
 }
 
 func (c configImpl) SkipCleanup() bool {

--- a/main.go
+++ b/main.go
@@ -226,7 +226,7 @@ func main() {
 					Usage: "output NUM lines of context around changes",
 				},
 				cli.StringFlag{
-					Name:  "diff-output",
+					Name:  "output",
 					Value: "",
 					Usage: "output format for diff plugin",
 				},
@@ -447,7 +447,7 @@ func main() {
 					Usage: "output NUM lines of context around changes",
 				},
 				cli.StringFlag{
-					Name:  "diff-output",
+					Name:  "output",
 					Value: "",
 					Usage: "output format for diff plugin",
 				},

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1153,6 +1153,7 @@ func (a *App) apply(r *Run, c ApplyConfigProvider) (bool, bool, []error) {
 	diffOpts := &state.DiffOpts{
 		NoColor:           c.NoColor(),
 		Context:           c.Context(),
+		Output:            c.DiffOutput(),
 		Set:               c.Set(),
 		SkipCleanup:       c.RetainValuesFiles() || c.SkipCleanup(),
 		SkipDiffOnInstall: c.SkipDiffOnInstall(),
@@ -1378,6 +1379,7 @@ func (a *App) diff(r *Run, c DiffConfigProvider) (*string, bool, bool, []error) 
 
 	opts := &state.DiffOpts{
 		Context: c.Context(),
+		Output:  c.DiffOutput(),
 		NoColor: c.NoColor(),
 		Set:     c.Set(),
 	}

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -2331,6 +2331,7 @@ type applyConfig struct {
 	suppressDiff      bool
 	noColor           bool
 	context           int
+	diffOutput        string
 	concurrency       int
 	detailedExitcode  bool
 	interactive       bool
@@ -2406,6 +2407,10 @@ func (a applyConfig) NoColor() bool {
 
 func (a applyConfig) Context() int {
 	return a.context
+}
+
+func (a applyConfig) DiffOutput() string {
+	return a.diffOutput
 }
 
 func (a applyConfig) Concurrency() int {

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -54,6 +54,7 @@ type ApplyConfigProvider interface {
 
 	NoColor() bool
 	Context() int
+	DiffOutput() string
 
 	RetainValuesFiles() bool
 	SkipCleanup() bool
@@ -104,6 +105,7 @@ type DiffConfigProvider interface {
 	DetailedExitcode() bool
 	NoColor() bool
 	Context() int
+	DiffOutput() string
 
 	concurrencyConfig
 }

--- a/pkg/app/diff_test.go
+++ b/pkg/app/diff_test.go
@@ -32,6 +32,7 @@ type diffConfig struct {
 	suppressDiff      bool
 	noColor           bool
 	context           int
+	diffOutput        string
 	concurrency       int
 	detailedExitcode  bool
 	interactive       bool
@@ -92,6 +93,10 @@ func (a diffConfig) NoColor() bool {
 
 func (a diffConfig) Context() int {
 	return a.context
+}
+
+func (a diffConfig) DiffOutput() string {
+	return a.diffOutput
 }
 
 func (a diffConfig) Concurrency() int {

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1664,6 +1664,10 @@ func (st *HelmState) prepareDiffReleases(helm helmexec.Interface, additionalValu
 					flags = append(flags, "--context", fmt.Sprintf("%d", opts.Context))
 				}
 
+				if opts.Output != "" {
+					flags = append(flags, "--output", fmt.Sprintf("%s", opts.Output))
+				}
+
 				if opts.Set != nil {
 					for _, s := range opts.Set {
 						flags = append(flags, "--set", s)
@@ -1739,6 +1743,7 @@ func (st *HelmState) createHelmContextWithWriter(spec *ReleaseSpec, w io.Writer)
 
 type DiffOpts struct {
 	Context int
+	Output  string
 	NoColor bool
 	Set     []string
 

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -26,7 +26,7 @@ export HELM_HOME="${HELM_DATA_HOME}"
 export HELM_PLUGINS="${HELM_DATA_HOME}/plugins"
 export HELM_CONFIG_HOME="${helm_dir}/config"
 HELM_SECRETS_VERSION=3.5.0
-HELM_DIFF_VERSION=3.0.0-rc.7
+HELM_DIFF_VERSION=3.1.3
 export GNUPGHOME="${PWD}/${dir}/.gnupg"
 export SOPS_PGP_FP="B2D6D7BBEC03B2E66571C8C00AD18E16CFDEF700"
 
@@ -94,6 +94,9 @@ bash -c "${helmfile} -f ${dir}/happypath.yaml --no-color diff --detailed-exitcod
 
 info "Diffing ${dir}/happypath.yaml with limited context"
 bash -c "${helmfile} -f ${dir}/happypath.yaml diff --context 3 --detailed-exitcode; code="'$?'"; [ "'${code}'" -eq 2 ]" || fail "unexpected exit code returned by helmfile diff"
+
+info "Diffing ${dir}/happypath.yaml with altered output"
+bash -c "${helmfile} -f ${dir}/happypath.yaml diff --diff-output simple --detailed-exitcode; code="'$?'"; [ "'${code}'" -eq 2 ]" || fail "unexpected exit code returned by helmfile diff"
 
 info "Templating ${dir}/happypath.yaml"
 rm -rf ${dir}/tmp

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -96,7 +96,7 @@ info "Diffing ${dir}/happypath.yaml with limited context"
 bash -c "${helmfile} -f ${dir}/happypath.yaml diff --context 3 --detailed-exitcode; code="'$?'"; [ "'${code}'" -eq 2 ]" || fail "unexpected exit code returned by helmfile diff"
 
 info "Diffing ${dir}/happypath.yaml with altered output"
-bash -c "${helmfile} -f ${dir}/happypath.yaml diff --diff-output simple --detailed-exitcode; code="'$?'"; [ "'${code}'" -eq 2 ]" || fail "unexpected exit code returned by helmfile diff"
+bash -c "${helmfile} -f ${dir}/happypath.yaml diff --output simple --detailed-exitcode; code="'$?'"; [ "'${code}'" -eq 2 ]" || fail "unexpected exit code returned by helmfile diff"
 
 info "Templating ${dir}/happypath.yaml"
 rm -rf ${dir}/tmp


### PR DESCRIPTION
Added an option to use helm-diff's `--output` flag, e.g.:
```
helmfile diff --diff-output simple
```

see: https://github.com/databus23/helm-diff/pull/221