### PR TITLE
Bump chartify to 0.8.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/tatsushid/go-prettytable v0.0.0-20141013043238-ed2d14c29939
 	github.com/urfave/cli v1.22.5
-	github.com/variantdev/chartify v0.8.0
+	github.com/variantdev/chartify v0.8.1
 	github.com/variantdev/dag v1.0.0
 	github.com/variantdev/vals v0.13.0
 	go.uber.org/multierr v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -583,6 +583,8 @@ github.com/variantdev/chartify v0.7.3 h1:uX0mN8PmYHZDWILcg41sQfasJ7TT/CYnYWSmDgs
 github.com/variantdev/chartify v0.7.3/go.mod h1:qF4XzQlkfH/6k2jAi1hLas+lK4zSCa8kY+r5JdmLA68=
 github.com/variantdev/chartify v0.8.0 h1:yIBsS/dIUeMjWP8U6JWlT3PM0Lky7en9QBi+MgDu2U8=
 github.com/variantdev/chartify v0.8.0/go.mod h1:qF4XzQlkfH/6k2jAi1hLas+lK4zSCa8kY+r5JdmLA68=
+github.com/variantdev/chartify v0.8.1 h1:LNW3QjwikyqGK8NQ+qivNvfZ9WLeWB8wZVk+R7OeDDs=
+github.com/variantdev/chartify v0.8.1/go.mod h1:qF4XzQlkfH/6k2jAi1hLas+lK4zSCa8kY+r5JdmLA68=
 github.com/variantdev/dag v0.0.0-20191028002400-bb0b3c785363 h1:KrfQBEUn+wEOQ/6UIfoqRDvn+Q/wZridQ7t0G1vQqKE=
 github.com/variantdev/dag v0.0.0-20191028002400-bb0b3c785363/go.mod h1:pH1TQsNSLj2uxMo9NNl9zdGy01Wtn+/2MT96BrKmVyE=
 github.com/variantdev/dag v1.0.0 h1:7SFjATxHtrYV20P3tx53yNDBMegz6RT4jv8JPHqAHdM=


### PR DESCRIPTION
This version fixes that chartify not to fail when the target chart misses `templates` directory.