### PR TITLE
feat: moved chartify logs to Debug

### DIFF
--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1066,6 +1066,7 @@ func (st *HelmState) PrepareCharts(helm helmexec.Interface, dir string, concurre
 					c := chartify.New(
 						chartify.HelmBin(st.DefaultHelmBinary),
 						chartify.UseHelm3(helm3),
+						chartify.WithLogf(st.logger.Debugf),
 					)
 
 					chartifyOpts := chartification.Opts


### PR DESCRIPTION
Chartify logs are very _chatty_ and stands out event in quiet mode. This PR moves them to debug to hide chart building process in normal output.