### PR TITLE
Fix chartify not to break when two or more releases sharing the same chart and the namespace, but kubeContext

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/tatsushid/go-prettytable v0.0.0-20141013043238-ed2d14c29939
 	github.com/urfave/cli v1.22.5
-	github.com/variantdev/chartify v0.8.2
+	github.com/variantdev/chartify v0.8.3
 	github.com/variantdev/dag v1.0.0
 	github.com/variantdev/vals v0.13.0
 	go.uber.org/multierr v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -587,6 +587,8 @@ github.com/variantdev/chartify v0.8.1 h1:LNW3QjwikyqGK8NQ+qivNvfZ9WLeWB8wZVk+R7O
 github.com/variantdev/chartify v0.8.1/go.mod h1:qF4XzQlkfH/6k2jAi1hLas+lK4zSCa8kY+r5JdmLA68=
 github.com/variantdev/chartify v0.8.2 h1:g+BjSvz7LoUH130PO67HwBS5emkzdccJ9tizyQNUy5E=
 github.com/variantdev/chartify v0.8.2/go.mod h1:qF4XzQlkfH/6k2jAi1hLas+lK4zSCa8kY+r5JdmLA68=
+github.com/variantdev/chartify v0.8.3 h1:9PHZqmRoI7YdXMmWuGJm8PUvOyFGRBoy+j8xM1x2eWE=
+github.com/variantdev/chartify v0.8.3/go.mod h1:qF4XzQlkfH/6k2jAi1hLas+lK4zSCa8kY+r5JdmLA68=
 github.com/variantdev/dag v0.0.0-20191028002400-bb0b3c785363 h1:KrfQBEUn+wEOQ/6UIfoqRDvn+Q/wZridQ7t0G1vQqKE=
 github.com/variantdev/dag v0.0.0-20191028002400-bb0b3c785363/go.mod h1:pH1TQsNSLj2uxMo9NNl9zdGy01Wtn+/2MT96BrKmVyE=
 github.com/variantdev/dag v1.0.0 h1:7SFjATxHtrYV20P3tx53yNDBMegz6RT4jv8JPHqAHdM=

--- a/pkg/state/helmx.go
+++ b/pkg/state/helmx.go
@@ -90,6 +90,7 @@ func (st *HelmState) PrepareChartify(helm helmexec.Interface, release *ReleaseSp
 			EnableKustomizeAlphaPlugins: true,
 			ChartVersion:                release.Version,
 			Namespace:                   release.Namespace,
+			ID:                          ReleaseToID(release),
 		},
 	}
 


### PR DESCRIPTION
Fixes #1695