### PR TITLE
Fix destory, delete, and test to work with chartify on local chart with dependencies that are not yet downloaded

### DIFF
--- a/main.go
+++ b/main.go
@@ -554,6 +554,10 @@ func main() {
 					Name:  "purge",
 					Usage: "purge releases i.e. free release names and histories",
 				},
+				cli.BoolFlag{
+					Name:  "skip-deps",
+					Usage: `skip running "helm repo update" and "helm dependency build"`,
+				},
 			},
 			Action: action(func(a *app.App, c configImpl) error {
 				return a.Delete(c)
@@ -572,6 +576,10 @@ func main() {
 					Name:  "args",
 					Value: "",
 					Usage: "pass args to helm exec",
+				},
+				cli.BoolFlag{
+					Name:  "skip-deps",
+					Usage: `skip running "helm repo update" and "helm dependency build"`,
 				},
 			},
 			Action: action(func(a *app.App, c configImpl) error {
@@ -604,6 +612,10 @@ func main() {
 					Name:  "concurrency",
 					Value: 0,
 					Usage: "maximum number of concurrent helm processes to run, 0 is unlimited",
+				},
+				cli.BoolFlag{
+					Name:  "skip-deps",
+					Usage: `skip running "helm repo update" and "helm dependency build"`,
 				},
 			},
 			Action: action(func(a *app.App, c configImpl) error {

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -396,8 +396,8 @@ func (a *App) Status(c StatusesConfigProvider) error {
 func (a *App) Delete(c DeleteConfigProvider) error {
 	return a.ForEachState(func(run *Run) (ok bool, errs []error) {
 		err := run.withPreparedCharts("delete", state.ChartPrepareOptions{
-			SkipRepos: true,
-			SkipDeps:  true,
+			SkipRepos: c.SkipDeps(),
+			SkipDeps:  c.SkipDeps(),
 		}, func() {
 			ok, errs = a.delete(run, c.Purge(), c)
 		})
@@ -413,8 +413,8 @@ func (a *App) Delete(c DeleteConfigProvider) error {
 func (a *App) Destroy(c DestroyConfigProvider) error {
 	return a.ForEachState(func(run *Run) (ok bool, errs []error) {
 		err := run.withPreparedCharts("destroy", state.ChartPrepareOptions{
-			SkipRepos: true,
-			SkipDeps:  true,
+			SkipRepos: c.SkipDeps(),
+			SkipDeps:  c.SkipDeps(),
 		}, func() {
 			ok, errs = a.delete(run, true, c)
 		})
@@ -436,8 +436,8 @@ func (a *App) Test(c TestConfigProvider) error {
 		}
 
 		err := run.withPreparedCharts("test", state.ChartPrepareOptions{
-			SkipRepos: true,
-			SkipDeps:  true,
+			SkipRepos: c.SkipDeps(),
+			SkipDeps:  c.SkipDeps(),
 		}, func() {
 			errs = a.test(run, c)
 		})

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -114,6 +114,7 @@ type DeleteConfigProvider interface {
 	Args() string
 
 	Purge() bool
+	SkipDeps() bool
 
 	interactive
 	loggingConfig
@@ -123,6 +124,8 @@ type DeleteConfigProvider interface {
 type DestroyConfigProvider interface {
 	Args() string
 
+	SkipDeps() bool
+
 	interactive
 	loggingConfig
 	concurrencyConfig
@@ -131,6 +134,7 @@ type DestroyConfigProvider interface {
 type TestConfigProvider interface {
 	Args() string
 
+	SkipDeps() bool
 	Timeout() int
 	Cleanup() bool
 	Logs() bool

--- a/pkg/app/destroy_test.go
+++ b/pkg/app/destroy_test.go
@@ -26,6 +26,7 @@ type destroyConfig struct {
 	args        string
 	concurrency int
 	interactive bool
+	skipDeps    bool
 	logger      *zap.SugaredLogger
 }
 
@@ -43,6 +44,10 @@ func (d destroyConfig) Logger() *zap.SugaredLogger {
 
 func (d destroyConfig) Concurrency() int {
 	return d.concurrency
+}
+
+func (d destroyConfig) SkipDeps() bool {
+	return d.skipDeps
 }
 
 func TestDestroy(t *testing.T) {


### PR DESCRIPTION
This also adds `--skip-deps` to `helmfile destroy`, `helmfile delete`, and `helmfile test` for whoever wants the previous behaviour, when one exactly knows that they don't need to download local chart's dependencies(already downloaded beforehand, or included in the git repo, etc).

Fixes #1800