### PR TITLE
Fix repo sync to work on repos duplicated between helm v2 and v3

### DIFF
--- a/pkg/app/context.go
+++ b/pkg/app/context.go
@@ -5,17 +5,28 @@ import (
 )
 
 type Context struct {
-	updatedRepos map[string]bool
+	updatedRepos   map[string]bool
+	updatedReposV2 map[string]bool
 }
 
 func NewContext() Context {
 	return Context{
-		updatedRepos: map[string]bool{},
+		updatedRepos:   map[string]bool{},
+		updatedReposV2: map[string]bool{},
 	}
 }
 
 func (ctx Context) SyncReposOnce(st *state.HelmState, helm state.RepoUpdater) error {
-	updated, err := st.SyncRepos(helm, ctx.updatedRepos)
+	var (
+		updated []string
+		err     error
+	)
+
+	if helm.IsHelm3() {
+		updated, err = st.SyncRepos(helm, ctx.updatedRepos)
+	} else {
+		updated, err = st.SyncRepos(helm, ctx.updatedReposV2)
+	}
 
 	for _, r := range updated {
 		ctx.updatedRepos[r] = true

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -348,6 +348,7 @@ func (st *HelmState) ApplyOverrides(spec *ReleaseSpec) {
 }
 
 type RepoUpdater interface {
+	IsHelm3() bool
 	AddRepo(name, repository, cafile, certfile, keyfile, username, password string, managed string) error
 	UpdateRepo() error
 	RegistryLogin(name string, username string, password string) error


### PR DESCRIPTION
Trying to `helm repo add` the same Helm chart repository to Helm V2 and V3 in a single Helmfile run had been resulting in an incomplete result, only the latter `helm repo add` being skipped. This fixes that.

Fixes #1815