### PR TITLE
Fix --selector to correctly deduplicate releases

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1095,14 +1095,31 @@ func (a *App) findDesiredStateFiles(specifiedPath string, opts LoadOpts) ([]stri
 	return files, nil
 }
 
-func (a *App) getSelectedReleases(r *Run) ([]state.ReleaseSpec, error) {
-	releases, err := r.state.GetSelectedReleasesWithOverrides()
+func (a *App) getSelectedReleases(r *Run) ([]state.ReleaseSpec, []state.ReleaseSpec, error) {
+	selected, err := r.state.GetSelectedReleasesWithOverrides()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
+	}
+
+	allReleases := r.state.GetReleasesWithOverrides()
+
+	needed := map[string]struct{}{}
+	for _, r := range selected {
+		needed[state.ReleaseToID(&r)] = struct{}{}
+		for _, id := range r.Needs {
+			needed[id] = struct{}{}
+		}
+	}
+
+	var releases []state.ReleaseSpec
+	for _, r := range allReleases {
+		if _, ok := needed[state.ReleaseToID(&r)]; ok {
+			releases = append(releases, r)
+		}
 	}
 
 	if err := checkDuplicates(r.helm, r.state, releases); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var extra string
@@ -1111,16 +1128,16 @@ func (a *App) getSelectedReleases(r *Run) ([]state.ReleaseSpec, error) {
 		extra = " matching " + strings.Join(r.state.Selectors, ",")
 	}
 
-	a.Logger.Debugf("%d release(s)%s found in %s\n", len(releases), extra, r.state.FilePath)
+	a.Logger.Debugf("%d release(s)%s found in %s\n", len(selected), extra, r.state.FilePath)
 
-	return releases, nil
+	return selected, releases, nil
 }
 
 func (a *App) apply(r *Run, c ApplyConfigProvider) (bool, bool, []error) {
 	st := r.state
 	helm := r.helm
 
-	selectedReleases, err := a.getSelectedReleases(r)
+	selectedReleases, selectedAndNeededReleases, err := a.getSelectedReleases(r)
 	if err != nil {
 		return false, false, []error{err}
 	}
@@ -1132,7 +1149,7 @@ func (a *App) apply(r *Run, c ApplyConfigProvider) (bool, bool, []error) {
 	// Without this, `PlanReleases` conflates duplicates and return both in `batches`,
 	// even if we provided `SelectedReleases: selectedReleases`.
 	// See https://github.com/roboll/helmfile/issues/1818 for more context.
-	st.Releases = selectedReleases
+	st.Releases = selectedAndNeededReleases
 
 	plan, err := st.PlanReleases(state.PlanOptions{Reverse: false, SelectedReleases: selectedReleases, SkipNeeds: c.SkipNeeds(), IncludeNeeds: c.IncludeNeeds()})
 	if err != nil {
@@ -1281,7 +1298,7 @@ func (a *App) delete(r *Run, purge bool, c DestroyConfigProvider) (bool, []error
 
 	affectedReleases := state.AffectedReleases{}
 
-	toSync, err := a.getSelectedReleases(r)
+	toSync, _, err := a.getSelectedReleases(r)
 	if err != nil {
 		return false, []error{err}
 	}
@@ -1321,6 +1338,8 @@ func (a *App) delete(r *Run, purge bool, c DestroyConfigProvider) (bool, []error
 		names[i] = fmt.Sprintf("  %s (%s)", r.Name, r.Chart)
 	}
 
+	st.Releases = st.GetReleasesWithOverrides()
+
 	var errs []error
 
 	msg := fmt.Sprintf(`Affected releases are:
@@ -1335,17 +1354,7 @@ Do you really want to delete?
 		r.helm.SetExtraArgs(argparser.GetArgs(c.Args(), r.state)...)
 
 		if len(releasesToDelete) > 0 {
-			_, deletionErrs := withDAG(st, helm, a.Logger, state.PlanOptions{Reverse: true, SkipNeeds: true}, a.Wrap(func(subst *state.HelmState, helm helmexec.Interface) []error {
-				var rs []state.ReleaseSpec
-
-				for _, r := range subst.Releases {
-					if _, ok := releasesToDelete[state.ReleaseToID(&r)]; ok {
-						rs = append(rs, r)
-					}
-				}
-
-				subst.Releases = rs
-
+			_, deletionErrs := withDAG(st, helm, a.Logger, state.PlanOptions{SelectedReleases: toDelete, Reverse: true, SkipNeeds: true}, a.WrapWithoutSelector(func(subst *state.HelmState, helm helmexec.Interface) []error {
 				return subst.DeleteReleases(&affectedReleases, helm, c.Concurrency(), purge)
 			}))
 
@@ -1361,7 +1370,7 @@ Do you really want to delete?
 func (a *App) diff(r *Run, c DiffConfigProvider) (*string, bool, bool, []error) {
 	st := r.state
 
-	selectedReleases, err := a.getSelectedReleases(r)
+	selectedReleases, selectedAndNeededReleases, err := a.getSelectedReleases(r)
 	if err != nil {
 		return nil, false, false, []error{err}
 	}
@@ -1379,7 +1388,7 @@ func (a *App) diff(r *Run, c DiffConfigProvider) (*string, bool, bool, []error) 
 		Set:     c.Set(),
 	}
 
-	st.Releases = selectedReleases
+	st.Releases = selectedAndNeededReleases
 
 	plan, err := st.PlanReleases(state.PlanOptions{Reverse: false, SelectedReleases: selectedReleases, SkipNeeds: c.SkipNeeds(), IncludeNeeds: c.IncludeNeeds()})
 	if err != nil {
@@ -1416,7 +1425,7 @@ func (a *App) lint(r *Run, c LintConfigProvider) (bool, []error) {
 
 	allReleases := st.GetReleasesWithOverrides()
 
-	selectedReleases, err := a.getSelectedReleases(r)
+	selectedReleases, _, err := a.getSelectedReleases(r)
 	if err != nil {
 		return false, []error{err}
 	}
@@ -1482,7 +1491,7 @@ func (a *App) status(r *Run, c StatusesConfigProvider) (bool, []error) {
 
 	allReleases := st.GetReleasesWithOverrides()
 
-	selectedReleases, err := a.getSelectedReleases(r)
+	selectedReleases, selectedAndNeededReleases, err := a.getSelectedReleases(r)
 	if err != nil {
 		return false, []error{err}
 	}
@@ -1492,7 +1501,7 @@ func (a *App) status(r *Run, c StatusesConfigProvider) (bool, []error) {
 
 	// Do build deps and prepare only on selected releases so that we won't waste time
 	// on running various helm commands on unnecessary releases
-	st.Releases = selectedReleases
+	st.Releases = selectedAndNeededReleases
 
 	releasesToRender := map[string]state.ReleaseSpec{}
 	for _, r := range selectedReleases {
@@ -1543,7 +1552,7 @@ func (a *App) sync(r *Run, c SyncConfigProvider) (bool, []error) {
 	st := r.state
 	helm := r.helm
 
-	selectedReleases, err := a.getSelectedReleases(r)
+	selectedReleases, selectedAndNeededReleases, err := a.getSelectedReleases(r)
 	if err != nil {
 		return false, []error{err}
 	}
@@ -1555,7 +1564,7 @@ func (a *App) sync(r *Run, c SyncConfigProvider) (bool, []error) {
 	// Without this, `PlanReleases` conflates duplicates and return both in `batches`,
 	// even if we provided `SelectedReleases: selectedReleases`.
 	// See https://github.com/roboll/helmfile/issues/1818 for more context.
-	st.Releases = selectedReleases
+	st.Releases = selectedAndNeededReleases
 
 	batches, err := st.PlanReleases(state.PlanOptions{Reverse: false, SelectedReleases: selectedReleases, IncludeNeeds: c.IncludeNeeds(), SkipNeeds: c.SkipNeeds()})
 	if err != nil {
@@ -1699,7 +1708,7 @@ func (a *App) template(r *Run, c TemplateConfigProvider) (bool, []error) {
 	st := r.state
 	helm := r.helm
 
-	selectedReleases, err := a.getSelectedReleases(r)
+	selectedReleases, selectedAndNeededReleases, err := a.getSelectedReleases(r)
 	if err != nil {
 		return false, []error{err}
 	}
@@ -1711,7 +1720,7 @@ func (a *App) template(r *Run, c TemplateConfigProvider) (bool, []error) {
 	// Without this, `PlanReleases` conflates duplicates and return both in `batches`,
 	// even if we provided `SelectedReleases: selectedReleases`.
 	// See https://github.com/roboll/helmfile/issues/1818 for more context.
-	st.Releases = selectedReleases
+	st.Releases = selectedAndNeededReleases
 
 	batches, err := st.PlanReleases(state.PlanOptions{Reverse: false, SelectedReleases: selectedReleases, IncludeNeeds: c.IncludeNeeds(), SkipNeeds: !c.IncludeNeeds()})
 	if err != nil {
@@ -1777,7 +1786,7 @@ func (a *App) test(r *Run, c TestConfigProvider) []error {
 
 	st := r.state
 
-	toTest, err := a.getSelectedReleases(r)
+	toTest, _, err := a.getSelectedReleases(r)
 	if err != nil {
 		return []error{err}
 	}
@@ -1799,7 +1808,7 @@ func (a *App) writeValues(r *Run, c WriteValuesConfigProvider) (bool, []error) {
 	st := r.state
 	helm := r.helm
 
-	toRender, err := a.getSelectedReleases(r)
+	toRender, _, err := a.getSelectedReleases(r)
 	if err != nil {
 		return false, []error{err}
 	}

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1693,6 +1693,12 @@ func (a *App) template(r *Run, c TemplateConfigProvider) (bool, []error) {
 		return false, nil
 	}
 
+	// This is required when you're trying to deduplicate releases by the selector.
+	// Without this, `PlanReleases` conflates duplicates and return both in `batches`,
+	// even if we provided `SelectedReleases: selectedReleases`.
+	// See https://github.com/roboll/helmfile/issues/1818 for more context.
+	st.Releases = selectedReleases
+
 	batches, err := st.PlanReleases(state.PlanOptions{Reverse: false, SelectedReleases: selectedReleases, IncludeNeeds: c.IncludeNeeds(), SkipNeeds: !c.IncludeNeeds()})
 	if err != nil {
 		return false, []error{err}

--- a/pkg/app/app_apply_test.go
+++ b/pkg/app/app_apply_test.go
@@ -163,6 +163,8 @@ func TestApply_2(t *testing.T) {
 			if exists {
 				t.Errorf("unexpected log:\nDIFF\n%s\nEOD", diff)
 			}
+		} else {
+			assertEqualsToSnapshot(t, "log", bs.String())
 		}
 	}
 
@@ -1074,12 +1076,6 @@ releases:
     app: test
     component: raw
     index: '1'
-  values:
-  - resources:
-    - apiVersion: v1
-      kind: ConfigMap
-      metadata:
-        name: cm1
 
 - name: foo
   chart: incubator/raw
@@ -1088,83 +1084,16 @@ releases:
     app: test
     component: raw
     index: '2'
-    values:
-    - resources:
-      - apiVersion: v1
-	    kind: ConfigMap
-        metadata:
-          name: cm2  
 `,
 			},
 			selectors: []string{"index=1"},
 			upgraded:  []exectest.Release{},
-			error:     "err: no releases found that matches specified selector(app=test_non_existent) and environment(default), in any helmfile",
+			diffs: map[exectest.DiffKey]error{
+				exectest.DiffKey{Name: "foo", Chart: "incubator/raw", Flags: "--kube-contextdefault--namespacedefault--detailed-exitcode"}: helmexec.ExitError{Code: 2},
+			},
+			error: "",
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
 			concurrency: 1,
-			log: `processing file "helmfile.yaml" in directory "."
-first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
-first-pass uses: &{default map[] map[]}
-first-pass rendering output of "helmfile.yaml.part.0":
- 0: 
- 1: 
- 2: 
- 3: releases:
- 4: - name: kubernetes-external-secrets
- 5:   chart: incubator/raw
- 6:   namespace: kube-system
- 7: 
- 8: - name: external-secrets
- 9:   chart: incubator/raw
-10:   namespace: default
-11:   labels:
-12:     app: test
-13:   needs:
-14:   - kube-system/kubernetes-external-secrets
-15: 
-16: - name: my-release
-17:   chart: incubator/raw
-18:   namespace: default
-19:   labels:
-20:     app: test
-21:   needs:
-22:   - default/external-secrets
-23: 
-
-first-pass produced: &{default map[] map[]}
-first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
-vals:
-map[]
-defaultVals:[]
-second-pass rendering result of "helmfile.yaml.part.0":
- 0: 
- 1: 
- 2: 
- 3: releases:
- 4: - name: kubernetes-external-secrets
- 5:   chart: incubator/raw
- 6:   namespace: kube-system
- 7: 
- 8: - name: external-secrets
- 9:   chart: incubator/raw
-10:   namespace: default
-11:   labels:
-12:     app: test
-13:   needs:
-14:   - kube-system/kubernetes-external-secrets
-15: 
-16: - name: my-release
-17:   chart: incubator/raw
-18:   namespace: default
-19:   labels:
-20:     app: test
-21:   needs:
-22:   - default/external-secrets
-23: 
-
-merged environment: &{default map[] map[]}
-0 release(s) matching app=test_non_existent found in helmfile.yaml
-
-`,
 		})
 	})
 }

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -2979,30 +2979,30 @@ Affected releases are:
 
 processing 2 groups of releases in this order:
 GROUP RELEASES
-1     default/frontend-v1
-2     default/backend-v1
+1     default//frontend-v1
+2     default//backend-v1
 
-processing releases in group 1/2: default/frontend-v1
-processing releases in group 2/2: default/backend-v1
+processing releases in group 1/2: default//frontend-v1
+processing releases in group 2/2: default//backend-v1
 processing 5 groups of releases in this order:
 GROUP RELEASES
-1     default/logging, default/front-proxy
-2     default/database, default/servicemesh
-3     default/anotherbackend
-4     default/backend-v2
-5     default/frontend-v3
+1     default//logging, default//front-proxy
+2     default//database, default//servicemesh
+3     default//anotherbackend
+4     default//backend-v2
+5     default//frontend-v3
 
-processing releases in group 1/5: default/logging, default/front-proxy
+processing releases in group 1/5: default//logging, default//front-proxy
 getting deployed release version failed:unexpected list key: {^logging$ --kube-contextdefault--deleting--deployed--failed--pending}
 getting deployed release version failed:unexpected list key: {^front-proxy$ --kube-contextdefault--deleting--deployed--failed--pending}
-processing releases in group 2/5: default/database, default/servicemesh
+processing releases in group 2/5: default//database, default//servicemesh
 getting deployed release version failed:unexpected list key: {^database$ --kube-contextdefault--deleting--deployed--failed--pending}
 getting deployed release version failed:unexpected list key: {^servicemesh$ --kube-contextdefault--deleting--deployed--failed--pending}
-processing releases in group 3/5: default/anotherbackend
+processing releases in group 3/5: default//anotherbackend
 getting deployed release version failed:unexpected list key: {^anotherbackend$ --kube-contextdefault--deleting--deployed--failed--pending}
-processing releases in group 4/5: default/backend-v2
+processing releases in group 4/5: default//backend-v2
 getting deployed release version failed:unexpected list key: {^backend-v2$ --kube-contextdefault--deleting--deployed--failed--pending}
-processing releases in group 5/5: default/frontend-v3
+processing releases in group 5/5: default//frontend-v3
 getting deployed release version failed:unexpected list key: {^frontend-v3$ --kube-contextdefault--deleting--deployed--failed--pending}
 
 UPDATED RELEASES:
@@ -3128,13 +3128,13 @@ Affected releases are:
 
 processing 2 groups of releases in this order:
 GROUP RELEASES
-1     default/baz, default/bar
-2     default/foo
+1     default//baz, default//bar
+2     default//foo
 
-processing releases in group 1/2: default/baz, default/bar
+processing releases in group 1/2: default//baz, default//bar
 getting deployed release version failed:unexpected list key: {^baz$ --kube-contextdefault--deleting--deployed--failed--pending}
 getting deployed release version failed:unexpected list key: {^bar$ --kube-contextdefault--deleting--deployed--failed--pending}
-processing releases in group 2/2: default/foo
+processing releases in group 2/2: default//foo
 getting deployed release version failed:unexpected list key: {^foo$ --kube-contextdefault--deleting--deployed--failed--pending}
 
 UPDATED RELEASES:
@@ -3238,11 +3238,11 @@ Affected releases are:
 
 processing 2 groups of releases in this order:
 GROUP RELEASES
-1     default/baz, default/bar
-2     default/foo
+1     default//baz, default//bar
+2     default//foo
 
-processing releases in group 1/2: default/baz, default/bar
-processing releases in group 2/2: default/foo
+processing releases in group 1/2: default//baz, default//bar
+processing releases in group 2/2: default//foo
 getting deployed release version failed:Failed to get the version for:mychart1
 
 UPDATED RELEASES:
@@ -3346,11 +3346,11 @@ Affected releases are:
 
 processing 2 groups of releases in this order:
 GROUP RELEASES
-1     default/baz, default/bar
-2     default/foo
+1     default//baz, default//bar
+2     default//foo
 
-processing releases in group 1/2: default/baz, default/bar
-processing releases in group 2/2: default/foo
+processing releases in group 1/2: default//baz, default//bar
+processing releases in group 2/2: default//foo
 getting deployed release version failed:Failed to get the version for:mychart1
 
 UPDATED RELEASES:
@@ -3509,7 +3509,7 @@ releases:
 			},
 		},
 		{
-			name: "upgrade when tns1/ns1/foo needs tns2/ns2/bar",
+			name: "helm2: upgrade when tns1/foo needs tns2/bar",
 			loc:  location(),
 
 			files: map[string]string{
@@ -3520,7 +3520,7 @@ releases:
   namespace: ns1
   tillerNamespace: tns1
   needs:
-  - tns2/ns2/bar
+  - tns2/bar
 - name: bar
   chart: stable/mychart2
   namespace: ns2
@@ -3537,7 +3537,7 @@ releases:
 			},
 		},
 		{
-			name: "upgrade when tns2/ns2/bar needs tns1/ns1/foo",
+			name: "helm2: upgrade when tns2/bar needs tns1/foo",
 			loc:  location(),
 			files: map[string]string{
 				"/path/to/helmfile.yaml": `
@@ -3547,7 +3547,7 @@ releases:
   namespace: ns2
   tillerNamespace: tns2
   needs:
-  - tns1/ns1/foo
+  - tns1/foo
 - name: foo
   chart: stable/mychart1
   namespace: ns1
@@ -3575,7 +3575,7 @@ first-pass rendering output of "helmfile.yaml.part.0":
  4:   namespace: ns2
  5:   tillerNamespace: tns2
  6:   needs:
- 7:   - tns1/ns1/foo
+ 7:   - tns1/foo
  8: - name: foo
  9:   chart: stable/mychart1
 10:   namespace: ns1
@@ -3595,7 +3595,7 @@ second-pass rendering result of "helmfile.yaml.part.0":
  4:   namespace: ns2
  5:   tillerNamespace: tns2
  6:   needs:
- 7:   - tns1/ns1/foo
+ 7:   - tns1/foo
  8: - name: foo
  9:   chart: stable/mychart1
 10:   namespace: ns1
@@ -3611,12 +3611,12 @@ Affected releases are:
 
 processing 2 groups of releases in this order:
 GROUP RELEASES
-1     default/tns1/ns1/foo
-2     default/tns2/ns2/bar
+1     default/tns1/foo
+2     default/tns2/bar
 
-processing releases in group 1/2: default/tns1/ns1/foo
+processing releases in group 1/2: default/tns1/foo
 getting deployed release version failed:unexpected list key: {^foo$ --tiller-namespacetns1--kube-contextdefault--deleting--deployed--failed--pending}
-processing releases in group 2/2: default/tns2/ns2/bar
+processing releases in group 2/2: default/tns2/bar
 getting deployed release version failed:unexpected list key: {^bar$ --tiller-namespacetns2--kube-contextdefault--deleting--deployed--failed--pending}
 
 UPDATED RELEASES:
@@ -4201,7 +4201,7 @@ releases:
 			upgraded:    []exectest.Release{},
 			deleted:     []exectest.Release{},
 			concurrency: 1,
-			error:       `in ./helmfile.yaml: release "default/foo" depends on "default/bar" which does not match the selectors. Please add a selector like "--selector name=bar", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies`,
+			error:       `in ./helmfile.yaml: release "default//foo" depends on "default//bar" which does not match the selectors. Please add a selector like "--selector name=bar", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies`,
 			log: `processing file "helmfile.yaml" in directory "."
 first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
 first-pass uses: &{default map[] map[]}
@@ -4237,7 +4237,7 @@ second-pass rendering result of "helmfile.yaml.part.0":
 merged environment: &{default map[] map[]}
 2 release(s) found in helmfile.yaml
 
-err: release "default/foo" depends on "default/bar" which does not match the selectors. Please add a selector like "--selector name=bar", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies
+err: release "default//foo" depends on "default//bar" which does not match the selectors. Please add a selector like "--selector name=bar", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies
 `,
 		},
 	}

--- a/pkg/app/destroy_test.go
+++ b/pkg/app/destroy_test.go
@@ -442,25 +442,25 @@ merged environment: &{default map[] map[]}
 
 processing 5 groups of releases in this order:
 GROUP RELEASES
-1     default/frontend-v3, default/frontend-v2, default/frontend-v1
-2     default/backend-v2, default/backend-v1
-3     default/anotherbackend
-4     default/servicemesh, default/database
-5     default/front-proxy, default/logging
+1     default//frontend-v3, default//frontend-v2, default//frontend-v1
+2     default//backend-v2, default//backend-v1
+3     default//anotherbackend
+4     default//servicemesh, default//database
+5     default//front-proxy, default//logging
 
-processing releases in group 1/5: default/frontend-v3, default/frontend-v2, default/frontend-v1
+processing releases in group 1/5: default//frontend-v3, default//frontend-v2, default//frontend-v1
 release "frontend-v3" processed
 release "frontend-v2" processed
 release "frontend-v1" processed
-processing releases in group 2/5: default/backend-v2, default/backend-v1
+processing releases in group 2/5: default//backend-v2, default//backend-v1
 release "backend-v2" processed
 release "backend-v1" processed
-processing releases in group 3/5: default/anotherbackend
+processing releases in group 3/5: default//anotherbackend
 release "anotherbackend" processed
-processing releases in group 4/5: default/servicemesh, default/database
+processing releases in group 4/5: default//servicemesh, default//database
 release "servicemesh" processed
 release "database" processed
-processing releases in group 5/5: default/front-proxy, default/logging
+processing releases in group 5/5: default//front-proxy, default//logging
 release "front-proxy" processed
 release "logging" processed
 
@@ -648,9 +648,9 @@ merged environment: &{default map[] map[]}
 
 processing 1 groups of releases in this order:
 GROUP RELEASES
-1     default/logging
+1     default//logging
 
-processing releases in group 1/1: default/logging
+processing releases in group 1/1: default//logging
 release "logging" processed
 
 DELETED RELEASES:
@@ -713,12 +713,12 @@ merged environment: &{default map[] map[]}
 
 processing 2 groups of releases in this order:
 GROUP RELEASES
-1     default/frontend-v1
-2     default/backend-v1
+1     default//frontend-v1
+2     default//backend-v1
 
-processing releases in group 1/2: default/frontend-v1
+processing releases in group 1/2: default//frontend-v1
 release "frontend-v1" processed
-processing releases in group 2/2: default/backend-v1
+processing releases in group 2/2: default//backend-v1
 release "backend-v1" processed
 
 DELETED RELEASES:
@@ -783,12 +783,12 @@ merged environment: &{default map[] map[]}
 
 processing 2 groups of releases in this order:
 GROUP RELEASES
-1     default/frontend-v1
-2     default/backend-v1
+1     default//frontend-v1
+2     default//backend-v1
 
-processing releases in group 1/2: default/frontend-v1
+processing releases in group 1/2: default//frontend-v1
 release "frontend-v1" processed
-processing releases in group 2/2: default/backend-v1
+processing releases in group 2/2: default//backend-v1
 release "backend-v1" processed
 
 DELETED RELEASES:

--- a/pkg/app/snapshot_test.go
+++ b/pkg/app/snapshot_test.go
@@ -1,0 +1,65 @@
+package app
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func assertEqualsToSnapshot(t *testing.T, name string, data string) {
+	type thisPkgLocator struct{}
+
+	t.Helper()
+
+	snapshotFileName := snapshotFileName(t, name)
+
+	if os.Getenv("HELMFILE_UPDATE_SNAPSHOT") != "" {
+		update(t, snapshotFileName, []byte(data))
+
+		return
+	}
+
+	wantData, err := ioutil.ReadFile(snapshotFileName)
+	if err != nil {
+		t.Fatalf(
+			"Snapshot file %q does not exist. Rerun this test with `HELMFILE_UPDATE_SNAPSHOT=1 go test -v -run %s %s` to create the snapshot",
+			snapshotFileName,
+			t.Name(),
+			reflect.TypeOf(thisPkgLocator{}).PkgPath(),
+		)
+	}
+
+	want := string(wantData)
+
+	if d := cmp.Diff(want, data); d != "" {
+		t.Errorf("unexpected %s: want (-), got (+): %s", name, d)
+		t.Errorf(
+			"If you think this is due to the snapshot file being outdated, rerun this test with `HELMFILE_UPDATE_SNAPSHOT=1 go test -v -run %s %s` to update the snapshot",
+			t.Name(),
+			reflect.TypeOf(thisPkgLocator{}).PkgPath(),
+		)
+	}
+}
+
+func update(t *testing.T, snapshotFileName string, data []byte) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(snapshotFileName), 0755); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	if err := ioutil.WriteFile(snapshotFileName, data, 0644); err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+func snapshotFileName(t *testing.T, name string) string {
+	dir := filepath.Join(strings.Split(strings.ToLower(t.Name()), "/")...)
+
+	return filepath.Join("testdata", dir, name)
+}

--- a/pkg/app/testdata/testapply_2/deduplicate_by_--selector/log
+++ b/pkg/app/testdata/testapply_2/deduplicate_by_--selector/log
@@ -1,0 +1,65 @@
+processing file "helmfile.yaml" in directory "."
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: incubator/raw
+ 4:   namespace: default
+ 5:   labels:
+ 6:     app: test
+ 7:     component: raw
+ 8:     index: '1'
+ 9: 
+10: - name: foo
+11:   chart: incubator/raw
+12:   namespace: default
+13:   labels:
+14:     app: test
+15:     component: raw
+16:     index: '2'
+17: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: incubator/raw
+ 4:   namespace: default
+ 5:   labels:
+ 6:     app: test
+ 7:     component: raw
+ 8:     index: '1'
+ 9: 
+10: - name: foo
+11:   chart: incubator/raw
+12:   namespace: default
+13:   labels:
+14:     app: test
+15:     component: raw
+16:     index: '2'
+17: 
+
+merged environment: &{default map[] map[]}
+1 release(s) matching index=1 found in helmfile.yaml
+
+Affected releases are:
+  foo (incubator/raw) UPDATED
+
+processing 1 groups of releases in this order:
+GROUP RELEASES
+1     default/default/foo
+
+processing releases in group 1/1: default/default/foo
+getting deployed release version failed:unexpected list key: {^foo$ --kube-contextdefault--deleting--deployed--failed--pending}
+
+UPDATED RELEASES:
+NAME   CHART           VERSION
+foo    incubator/raw          
+

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -676,10 +676,13 @@ func ReleaseToID(r *ReleaseSpec) string {
 
 	if kc != "" {
 		if tns == "" && ns == "" {
-			// This is intentionalt to avoid conflating kubecontext=,namespace=foo,name=bar and kubecontext=foo,namespace=,name=bar
-			// as they are both `foo/bar`, we explicitly differentiate each with `foo//bar` and `foo/bar`.
+			// This is intentional to avoid conflating kc=,ns=foo,name=bar and kc=foo,ns=,name=bar.
+			// Before https://github.com/roboll/helmfile/pull/1823 they were both `foo/bar` which turned out to break `needs` in many ways.
+			//
+			// We now explicitly differentiate each with `foo//bar` and `foo/bar`.
 			// Note that `foo//bar` is not always a equivalent to `foo/default/bar` as the default namespace is depedent on
 			// the user's kubeconfig.
+			// That's why we use `foo//bar` even if it looked unintuitive.
 			id += "/"
 		}
 	}

--- a/pkg/state/state_run.go
+++ b/pkg/state/state_run.go
@@ -151,18 +151,18 @@ func GroupReleasesByDependency(releases []Release, opts PlanOptions) ([][]Releas
 
 		// Only compute dependencies from non-filtered releases
 		if !r.Filtered {
-			// Since the representation differs between needs and id,
-			// correct it by prepending KubeContext.
 			var needs []string
 			for i := 0; i < len(r.Needs); i++ {
 				n := r.Needs[i]
-				if r.KubeContext != "" {
-					n = r.KubeContext + "/" + n
-				}
 				needs = append(needs, n)
 			}
 			d.Add(id, dag.Dependencies(needs))
 		}
+	}
+
+	var ids []string
+	for id := range idToReleases {
+		ids = append(ids, id)
 	}
 
 	var selectedReleaseIDs []string
@@ -243,11 +243,11 @@ func GroupReleasesByDependency(releases []Release, opts PlanOptions) ([][]Releas
 		})
 
 		for _, id := range idsInGroup {
-			releases, ok := idToReleases[id]
+			rs, ok := idToReleases[id]
 			if !ok {
-				panic(fmt.Errorf("bug: unexpectedly failed to get releases for id %q", id))
+				panic(fmt.Errorf("bug: unexpectedly failed to get releases for id %q: %v", id, ids))
 			}
-			releasesInGroup = append(releasesInGroup, releases...)
+			releasesInGroup = append(releasesInGroup, rs...)
 		}
 
 		result = append(result, releasesInGroup)


### PR DESCRIPTION
#1772 broke `--selector` with `needs` in many ways.

The two biggest problems I've encountered were:

- duplicate releases even if you've provided a proper `selector` to deduplicate
- sync/deletion ordering broken when you have `needs`

For the first issue, we had to update `getSelectedReleases` function to also calculate the "selected releases and releases needed by the selected releases", and use that to calculate the DAG. That should have been done in #1772.

The latter started happening after I've fixed the first issue. The source of the issue was that `needs` turned out to be ambiguous in a few cases.

Previously, `needs: ["foo/bar"]` had two meanings. One for "needs release bar in kubecontext foo", another for "needs release bar in namespace foo".

Moreover, `needs: ["foo/bar/baz"]` had three meanings.

- `needs release baz in tiller namespace foo and namespace baz`
- `needs release baz in namespace bar in kubecontext foo`
- `needs release baz in tiller namespace bar in kubecontext foo`.

Especially, the first meaning doesn't make sense at all. Helm 2 solely use tillerNamespace for namespacing the release and Helm 3 uses namespace for that.

This fix sorts all the bugs and issues I've found so far around that, by changing the meanings of the above two examples as follows:

- `foo/bar` means `namespace=foo,name=bar` for Helm 3 and `tillerNamespace=foo,name=bar` for Helm 2
  - `needs release bar in kubecontext foo` is now `foo//bar`. Notice the extra `/` between `foo` and `bar`.
- `foo/bar/baz` means `kubecontext=foo,namespace=bar,name=baz` for Helm 3 and `kubecontext=foo,tillerNamespace=bar,name=baz` in Helm 2

Fixes #1818