### PR TITLE
Fix helmfile-lint not to stop on fisrt error

### DIFF
--- a/main.go
+++ b/main.go
@@ -946,6 +946,8 @@ func toCliError(c *cli.Context, err error) error {
 				noMatchingExitCode = 0
 			}
 			return cli.NewExitError(e.Error(), noMatchingExitCode)
+		case *app.MultiError:
+			return cli.NewExitError(e.Error(), 1)
 		case *app.Error:
 			return cli.NewExitError(e.Error(), e.Code())
 		default:


### PR DESCRIPTION
Changes `helmfile lint` to not stop on the first helm-lint error. It now aggregates helm-lint errors and produce the summary of errors at the end.

```
$ helmfile lint

*snip*

Failed with 1 errors:

Error 1:

  command "/home/mumoshu/bin/helm" exited with non-zero status:
  
  PATH:
    /home/mumoshu/bin/helm
  
  ARGS:
    0: helm (4 bytes)
    1: lint (4 bytes)
    2: brokenchart (11 bytes)
  
  ERROR:
    exit status 1
  
  EXIT STATUS
    1
  
  STDERR:
    Error: 1 chart(s) linted, 1 chart(s) failed
  
  COMBINED OUTPUT:
    Error: 1 chart(s) linted, 1 chart(s) failed
    ==> Linting brokenchart
    [ERROR] Chart.yaml: apiVersion 'v0' is not valid. The value must be either "v1" or "v2"
    [INFO] Chart.yaml: icon is recommended
    [ERROR] Chart.yaml: chart type is not valid in apiVersion 'v0'. It is valid in apiVersion 'v2'
```

Fixes #1826