### PR TITLE
cache path issue on Windows

### DIFF
--- a/pkg/state/helmx.go
+++ b/pkg/state/helmx.go
@@ -52,7 +52,7 @@ func (st *HelmState) downloadChartWithGoGetter(r *ReleaseSpec) (string, error) {
 		pathElems = append(pathElems, r.KubeContext)
 	}
 
-	pathElems = append(pathElems, r.Name, r.Chart)
+	pathElems = append(pathElems, r.Name)
 
 	cacheDir := filepath.Join(pathElems...)
 


### PR DESCRIPTION
v0.139.3
```
err: [release "pinpoint": fetching "git::https://github.com/pinpoint-apm/pinpoint-kubernetes.git@pinpoint?ref=master": get: error downloading 'https://github.com/pinpoint-apm/pinpoint-kubernetes.git?ref=master': CreateFile .helmfile\cache\pinpoint\git::https:\github.com\pinpoint-apm\pinpoint-kubernetes.git@pinpoint?ref=master\https_github_com_pinpoint-apm_pinpoint-kubernetes_git.ref=master: The filename, directory name, or volume label syntax is incorrect.; CreateFile .helmfile\cache\pinpoint\git::https:\github.com\pinpoint-apm\pinpoint-kubernetes.git@pinpoint?ref=master\https_github_com_pinpoint-apm_pinpoint-kubernetes_git.ref=master: The filename, directory name, or volume label syntax is incorrect.]
...
Path error in windows
```

Cache dir: `.helmfile\cache\pinpoint\git::https:\github.com\pinpoint-apm\pinpoint-kubernetes.git@pinpoint?ref=master\https_github_com_pinpoint-apm_pinpoint-kubernetes_git.ref=master`

Tried to sanitized chart URL with `[^a-z0-9_-] => _`
```
fatal: cannot write keep file 'E:/Data/workspace/github/helmfile/.test/.helmfile/cache/pinpoint/git__https___github_com_pinpoint-apm_pinpoint-kubernetes_git_pinpoint_ref_master/https_github_com_pinpoint-apm_pinpoint-kubernetes_git.ref=master/.git/objects/pack/pack-87115c11c9b9fd3824f439ab8ecb1ae9ba8a6d69.keep'
...
Path is too long on windows
```

Cache dir: `.helmfile/cache/pinpoint/git__https___github_com_pinpoint-apm_pinpoint-kubernetes_git_pinpoint_ref_master/https_github_com_pinpoint-apm_pinpoint-kubernetes_git.ref=master`

So I tried to remove the `r.Chart` in the path, maybe it's redundant?
PR will give this cache dir: `.helmfile/cache/pinpoint/https_github_com_pinpoint-apm_pinpoint-kubernetes_git.ref=master`