### PR TITLE
Fix Helmfile swallowing secrets decryption errors

### DIFF
--- a/pkg/state/create.go
+++ b/pkg/state/create.go
@@ -354,7 +354,7 @@ func (c *StateCreator) scatterGatherEnvSecretFiles(st *HelmState, envSecretFiles
 		},
 	)
 
-	if len(errs) > 1 {
+	if len(errs) > 0 {
 		for _, err := range errs {
 			st.logger.Error(err)
 		}


### PR DESCRIPTION
There appears to be a simple typo that prevents Helmfile from correctly reporting an error when a secrets file cannot be decrypted (e.g. with sops). Instead, empty values are silently substituted into the rendered template.