### PR TITLE
fix: Do not fail on deps when chart is fetched by go-getter

### DIFF
--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1119,7 +1119,7 @@ func (st *HelmState) PrepareCharts(helm helmexec.Interface, dir string, concurre
 				skipDepsGlobal := opts.SkipDeps
 				skipDepsRelease := release.SkipDeps != nil && *release.SkipDeps
 				skipDepsDefault := release.SkipDeps == nil && st.HelmDefaults.SkipDeps
-				skipDeps := !isLocal || skipDepsGlobal || skipDepsRelease || skipDepsDefault
+				skipDeps := (!isLocal && !chartFetchedByGoGetter) || skipDepsGlobal || skipDepsRelease || skipDepsDefault
 
 				if chartification != nil {
 					c := chartify.New(


### PR DESCRIPTION
The below now works:

```
releases:
- name: pinpoint
  chart: git::https://github.com/pinpoint-apm/pinpoint-kubernetes.git@pinpoint?ref=master
```

Trying to use chartify with go-getter on a broken chart might require you to add `skipDeps: true`, as originally intended in #1548:

```
repositories:
- name: linkerd
  url: https://helm.linkerd.io/stable

releases:
- name: linkerd
  chart: linkerd/linkerd2
  version: "2.8.1"
  skipDeps: true
  forceNamespace: linkerd
  values:
  - global:
      identityTrustAnchorsPEM: aaa
    identity:
      issuer:
        crtExpiry: foobar
        tls:
          crtPEM: foo
          keyPEM: bar
```

Fixes #1847
