### PR TITLE
fix go getter download directory

### DIFF
--- a/pkg/state/helmx.go
+++ b/pkg/state/helmx.go
@@ -39,9 +39,14 @@ type Chartify struct {
 	Clean func()
 }
 
-func (st *HelmState) downloadChartWithGoGetter(r *ReleaseSpec) (string, error) {
-	pathElems := []string{
-		remote.DefaultCacheDir,
+// downloadChartWithGoGetter downloads chart in ReleaseSpec to dir directory
+func (st *HelmState) downloadChartWithGoGetter(r *ReleaseSpec, dir string) (string, error) {
+	var pathElems []string
+
+	if dir == "" {
+		pathElems = append(pathElems, remote.DefaultCacheDir)
+	} else {
+		pathElems = append(pathElems, dir)
 	}
 
 	if r.Namespace != "" {

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1085,7 +1085,7 @@ func (st *HelmState) PrepareCharts(helm helmexec.Interface, dir string, concurre
 
 				chartName := release.Chart
 
-				chartPath, err := st.downloadChartWithGoGetter(release)
+				chartPath, err := st.downloadChartWithGoGetter(release, dir)
 				if err != nil {
 					results <- &chartPrepareResult{err: fmt.Errorf("release %q: %w", release.Name, err)}
 					return


### PR DESCRIPTION
go-getter curretly downloads to remote.DefaultCacheDir. fetch cmd (download charts to local for debug) has --output-dir flag and this is not respected for go-getter fetched charts.

This PR will breaks the caching mecanism because default folder used to download charts is temporary.