### PR TITLE
Fix --skip-cleanup to work with chartify

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -237,6 +237,7 @@ func (a *App) Template(c TemplateConfigProvider) error {
 			SkipRepos:     c.SkipDeps(),
 			SkipDeps:      c.SkipDeps(),
 			IncludeCRDs:   &includeCRDs,
+			SkipCleanup:   c.SkipCleanup(),
 		}, func() {
 			ok, errs = a.template(run, c)
 		})
@@ -390,6 +391,7 @@ func (a *App) Apply(c ApplyConfigProvider) error {
 			Wait:        c.Wait(),
 			WaitForJobs: c.WaitForJobs(),
 			IncludeCRDs: &includeCRDs,
+			SkipCleanup: c.RetainValuesFiles() || c.SkipCleanup(),
 		}, func() {
 			matched, updated, es := a.apply(run, c)
 

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -964,6 +964,7 @@ type ChartPrepareOptions struct {
 	SkipRepos     bool
 	SkipDeps      bool
 	SkipResolve   bool
+	SkipCleanup   bool
 	IncludeCRDs   *bool
 	Wait          bool
 	WaitForJobs   bool
@@ -1108,7 +1109,9 @@ func (st *HelmState) PrepareCharts(helm helmexec.Interface, dir string, concurre
 				isLocal := st.directoryExistsAt(normalizeChart(st.basePath, chartName))
 
 				chartification, clean, err := st.PrepareChartify(helm, release, chartPath, workerIndex)
-				defer clean()
+				if !opts.SkipCleanup {
+					defer clean()
+				}
 				if err != nil {
 					results <- &chartPrepareResult{err: err}
 					return


### PR DESCRIPTION
While debugging #1857 I realized that `--skip-cleanup` and `--retain-values` didn't have effects on values files passed to chartify. This fixes that.