### PR TITLE
Fix chartify inability to disable chart dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/tatsushid/go-prettytable v0.0.0-20141013043238-ed2d14c29939
 	github.com/urfave/cli v1.22.5
-	github.com/variantdev/chartify v0.8.5
+	github.com/variantdev/chartify v0.8.6
 	github.com/variantdev/dag v1.0.0
 	github.com/variantdev/vals v0.14.0
 	go.uber.org/multierr v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -628,6 +628,8 @@ github.com/variantdev/chartify v0.8.4 h1:xriH5eHMlUqza9FMGBhmrWt3I6LHMn494vuEIu0
 github.com/variantdev/chartify v0.8.4/go.mod h1:qF4XzQlkfH/6k2jAi1hLas+lK4zSCa8kY+r5JdmLA68=
 github.com/variantdev/chartify v0.8.5 h1:yAw2+IxftPDR5A2/vr97Y6DR1U/2lJCHxfp40DBxfw0=
 github.com/variantdev/chartify v0.8.5/go.mod h1:qF4XzQlkfH/6k2jAi1hLas+lK4zSCa8kY+r5JdmLA68=
+github.com/variantdev/chartify v0.8.6 h1:8WIJ/79qHg4cobFhZsA7VDyvLp0+W3O9SI31LlDnyOM=
+github.com/variantdev/chartify v0.8.6/go.mod h1:qF4XzQlkfH/6k2jAi1hLas+lK4zSCa8kY+r5JdmLA68=
 github.com/variantdev/dag v0.0.0-20191028002400-bb0b3c785363 h1:KrfQBEUn+wEOQ/6UIfoqRDvn+Q/wZridQ7t0G1vQqKE=
 github.com/variantdev/dag v0.0.0-20191028002400-bb0b3c785363/go.mod h1:pH1TQsNSLj2uxMo9NNl9zdGy01Wtn+/2MT96BrKmVyE=
 github.com/variantdev/dag v1.0.0 h1:7SFjATxHtrYV20P3tx53yNDBMegz6RT4jv8JPHqAHdM=


### PR DESCRIPTION
Fixes #1857

Ref https://github.com/variantdev/chartify/commit/8453c41422d62d1d547c96299dac9267c090f9fb