### PR TITLE
Fix chartify regression of missing chart dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/tatsushid/go-prettytable v0.0.0-20141013043238-ed2d14c29939
 	github.com/urfave/cli v1.22.5
-	github.com/variantdev/chartify v0.8.6
+	github.com/variantdev/chartify v0.8.9
 	github.com/variantdev/dag v1.0.0
 	github.com/variantdev/vals v0.14.0
 	go.uber.org/multierr v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -630,6 +630,10 @@ github.com/variantdev/chartify v0.8.5 h1:yAw2+IxftPDR5A2/vr97Y6DR1U/2lJCHxfp40DB
 github.com/variantdev/chartify v0.8.5/go.mod h1:qF4XzQlkfH/6k2jAi1hLas+lK4zSCa8kY+r5JdmLA68=
 github.com/variantdev/chartify v0.8.6 h1:8WIJ/79qHg4cobFhZsA7VDyvLp0+W3O9SI31LlDnyOM=
 github.com/variantdev/chartify v0.8.6/go.mod h1:qF4XzQlkfH/6k2jAi1hLas+lK4zSCa8kY+r5JdmLA68=
+github.com/variantdev/chartify v0.8.8 h1:dsQyEfoSexCOPmGTSHIWYUuGkArN53B+43qTMfE7xU0=
+github.com/variantdev/chartify v0.8.8/go.mod h1:qF4XzQlkfH/6k2jAi1hLas+lK4zSCa8kY+r5JdmLA68=
+github.com/variantdev/chartify v0.8.9 h1:kECyWario6UOShilDThKfuvk+FhXWjlFod/Cg/wTmVs=
+github.com/variantdev/chartify v0.8.9/go.mod h1:qF4XzQlkfH/6k2jAi1hLas+lK4zSCa8kY+r5JdmLA68=
 github.com/variantdev/dag v0.0.0-20191028002400-bb0b3c785363 h1:KrfQBEUn+wEOQ/6UIfoqRDvn+Q/wZridQ7t0G1vQqKE=
 github.com/variantdev/dag v0.0.0-20191028002400-bb0b3c785363/go.mod h1:pH1TQsNSLj2uxMo9NNl9zdGy01Wtn+/2MT96BrKmVyE=
 github.com/variantdev/dag v1.0.0 h1:7SFjATxHtrYV20P3tx53yNDBMegz6RT4jv8JPHqAHdM=

--- a/test/integration/issue.1857.yaml
+++ b/test/integration/issue.1857.yaml
@@ -1,0 +1,22 @@
+repositories:
+- name: prometheus-community
+  url: https://prometheus-community.github.io/helm-charts
+
+releases:
+  - name: prometheus-operator-k8s-test
+    chart: prometheus-community/kube-prometheus-stack
+    namespace: monitoring
+    forceNamespace: monitoring
+    version: 15.4.6
+    labels:
+      component: test-upg
+    values:
+      - nameOverride: k8s
+        fullnameOverride: prometheus-k8s
+        global:
+          imagePullSecrets:
+            - name: regsecret
+        alertmanager:
+          enabled: false
+        grafana:
+          enabled: {{ .Values.grafanaEnabled }}

--- a/test/integration/issue.1867.yaml
+++ b/test/integration/issue.1867.yaml
@@ -1,0 +1,18 @@
+repositories:
+- name: bitnami
+  url: https://charts.bitnami.com/bitnami
+
+releases:
+  - name: elasticsearch
+    chart: bitnami/elasticsearch
+    version: 15.2.2
+    jsonPatches:
+    - target:
+        version: v1
+        kind: StatefulSet
+        name: elasticsearch-master
+      patch:
+      - op: add
+        path: /spec/template/spec/containers/0/volumeMounts/0/subPathExpr
+        value: elasticsearch/$(MY_POD_NAME)
+  

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -150,6 +150,21 @@ info "Ensuring \"helmfile template\" output does contain only YAML docs"
 
 test_pass "happypath"
 
+test_start "regression tests"
+
+if [[ helm_major_version -eq 3 ]]; then
+  info "https://github.com/roboll/helmfile/issues/1857"
+  (${helmfile} -f ${dir}/issue.1857.yaml --state-values-set grafanaEnabled=true template | grep grafana 1>/dev/null) || fail "\"helmfile template\" shouldn't include grafana"
+  ! (${helmfile} -f ${dir}/issue.1857.yaml --state-values-set grafanaEnabled=false template | grep grafana) || fail "\"helmfile template\" shouldn't include grafana"
+
+  info "https://github.com/roboll/helmfile/issues/1867"
+  (${helmfile} -f ${dir}/issue.1867.yaml template 1>/dev/null) || fail "\"helmfile template\" shouldn't fail"
+else
+  info "There are no regression tests for helm 2 because all the target charts have dropped helm 2 support."
+fi
+
+test_pass "regression tests"
+
 if [[ helm_major_version -eq 3 ]]; then
   export VAULT_ADDR=http://127.0.0.1:8200
   export VAULT_TOKEN=toor


### PR DESCRIPTION
Fixes https://github.com/roboll/helmfile/issues/1867
Also see these changes in chartify: https://github.com/variantdev/chartify/compare/8453c41422d62d1d547c96299dac9267c090f9fb...ac3f04370d46bd585eef02d2082fd79e47a9aa4c