### PR TITLE
bases fetchable as remote files

### DIFF
--- a/pkg/state/create.go
+++ b/pkg/state/create.go
@@ -205,7 +205,12 @@ func (c *StateCreator) ParseAndLoad(content []byte, baseDir, file string, envNam
 func (c *StateCreator) loadBases(envValues *environment.Environment, st *HelmState, baseDir string) (*HelmState, error) {
 	layers := []*HelmState{}
 	for _, b := range st.Bases {
-		base, err := c.LoadFile(envValues, baseDir, b, false)
+		basePath, err := c.remote.Locate(b)
+		if err != nil {
+			return nil, err
+		}
+
+		base, err := c.LoadFile(envValues, baseDir, basePath, false)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
`bases` pulled and cached from remote sources like `helmfiles`

I went to refactor such that environment was in a repo for common sharing and found that bases didn't yet support `git::` paths like `helmfiles` does