### PR TITLE
bug: write-values deletes provided --values files.

### DIFF
--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1469,7 +1469,6 @@ func (st *HelmState) WriteReleasesValues(helm helmexec.Interface, additionalValu
 			if _, err := os.Stat(valfile); os.IsNotExist(err) {
 				return []error{err}
 			}
-			generatedFiles = append(generatedFiles, valfile)
 		}
 
 		outputValuesFile, err := st.GenerateOutputFilePath(release, opts.OutputFileTemplate)
@@ -1485,7 +1484,7 @@ func (st *HelmState) WriteReleasesValues(helm helmexec.Interface, additionalValu
 
 		merged := map[string]interface{}{}
 
-		for _, f := range generatedFiles {
+		for _, f := range append(generatedFiles, additionalValues...) {
 			src := map[string]interface{}{}
 
 			srcBytes, err := st.readFile(f)


### PR DESCRIPTION
This fixes the bug by not including provided values files in the array of generated values, which is evaluated in a deferred block.  

Resolves #1904