### PR TITLE
Add more examples for remote env value files

### DIFF
--- a/README.md
+++ b/README.md
@@ -854,16 +854,20 @@ environments:
     values:
       - git::https://git.company.org/helmfiles/global/azure.yaml?ref=master
       - git::https://git.company.org/helmfiles/global/us-west.yaml?ref=master
+      - git::https://gitlab.com/org/repository-name.git@/config/config.test.yaml?ref=main # Public Gilab Repo
   cluster-gcp-europe-west:
     values:
       - git::https://git.company.org/helmfiles/global/gcp.yaml?ref=master
       - git::https://git.company.org/helmfiles/global/europe-west.yaml?ref=master
+      - git::https://ci:{{ env "CI_JOB_TOKEN" }}@gitlab.com/org/repository-name.git@/config.dev.yaml?ref={{ env "APP_COMMIT_SHA" }}  # Private Gitlab Repo
 
 ---
 
 releases:
   - ...
 ```
+
+For more information about the supported protocols see: [go-getter Protocol-Specific Options](https://github.com/hashicorp/go-getter#protocol-specific-options-1).
 
 This is particularly useful when you co-locate helmfiles within your project repo but want to reuse the definitions in a global repo.
 


### PR DESCRIPTION
I had difficulties loading remote value files even after looking at the docs here and go-getter.
The solution was in the test code here: 

https://github.com/roboll/helmfile/blob/ae942c5288895c84c79171e5446773e4cb41c4ce/pkg/remote/remote_test.go#L67

Use an `@` to separate the path from the GIT url... 

To help others I want to update the docs with the solution which worked for me ;-)
