### PR TITLE
Add debian docker image, drop helm2, and upgrade packages.

### DIFF
--- a/.circleci/Makefile
+++ b/.circleci/Makefile
@@ -1,5 +1,4 @@
 HELM_VERSION ?= v3.5.3
-HELM2_VERSION ?= v2.17.0
 KUSTOMIZE_VERSION ?= v3.8.8
 K8S_VERSION ?= v1.13.12
 MINIKUBE_VERSION ?= v0.30.0
@@ -15,7 +14,6 @@ VAULT_TOKEN := toor
 
 tmp := $(shell mktemp -d)
 HELM_FILENAME := helm-${HELM_VERSION}-linux-amd64.tar.gz
-HELM2_FILENAME := helm-${HELM2_VERSION}-linux-amd64.tar.gz
 KUSTOMIZE_FILENAME := kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz
 
 
@@ -27,13 +25,6 @@ helm:
 	chmod +x ${tmp}/linux-amd64/helm
 	sudo mv ${tmp}/linux-amd64/helm /usr/local/bin/
 .PHONY: helm
-
-helm2:
-	curl -sSLo $(tmp)/${HELM2_FILENAME} "https://kubernetes-helm.storage.googleapis.com/${HELM2_FILENAME}"
-	tar zxf $(tmp)/${HELM2_FILENAME} --directory ${tmp} linux-amd64/helm
-	chmod +x ${tmp}/linux-amd64/helm
-	sudo mv ${tmp}/linux-amd64/helm /usr/local/bin/
-.PHONY: helm2
 
 kustomize:
 	curl -sSLo $(tmp)/${KUSTOMIZE_FILENAME} "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/${KUSTOMIZE_FILENAME}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
           go mod vendor
           ORG=roboll BUILD_URL="$CIRCLE_BUILD_URL" make image
 
-  image_helm3:
+  image_debian:
     docker:
     - image: circleci/golang:1.16.3
     working_directory: /home/circleci/workspace/helmfile
@@ -57,7 +57,7 @@ jobs:
         command: |
           make tools
           go mod vendor
-          ORG=roboll BUILD_URL="$CIRCLE_BUILD_URL" make image/helm3
+          ORG=roboll BUILD_URL="$CIRCLE_BUILD_URL" make image/debian
 
   test:
     environment:
@@ -135,7 +135,7 @@ jobs:
           docker login -u="$DOCKER_USER" -p="$DOCKER_PASS" quay.io
           make tools
           go mod vendor
-          ORG=roboll BUILD_URL="$CIRCLE_BUILD_URL" make push push/helm3 release
+          ORG=roboll BUILD_URL="$CIRCLE_BUILD_URL" make push push/debian release
 
 workflows:
   version: 2
@@ -143,14 +143,14 @@ workflows:
     jobs:
       - build
       - image
-      - image_helm3
+      - image_debian
       - test
       - integration_tests:
           requires:
             - build
           matrix:
             parameters:
-              helm-version: ["v2.17.0", "v3.4.2", "v3.5.4"]
+              helm-version: ["v2.17.0", "v3.4.2", "v3.5.4", "v3.6.3"]
       - release:
           filters:
             branches:

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,15 +1,29 @@
-FROM golang:1.16.3-alpine3.13 as builder
+FROM golang:1.16.7 as builder
 
-RUN apk add --no-cache make git
+RUN apt-get update \
+ && apt-get install --no-install-recommends -y \
+    build-essential \
+    git \
+ && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /workspace/helmfile
 COPY . /workspace/helmfile
+
 RUN make static-linux
 
 # -----------------------------------------------------------------------------
 
-FROM alpine:3.11
+FROM debian:stable-slim
 
-RUN apk add --no-cache ca-certificates git bash curl jq
+RUN apt-get update \ 
+ && apt-get install -y --no-install-recommends \
+    ca-certificates  \
+    git \
+    bash \
+    curl \
+    jq \
+    wget \
+ && rm -rf /var/lib/apt/lists/* 
 
 ARG HELM_VERSION="v3.6.3"
 ARG HELM_SHA256="07c100849925623dc1913209cd1a30f0a9b80a5b4d6ff2153c609d11b043e262"
@@ -17,11 +31,11 @@ ARG HELM_LOCATION="https://get.helm.sh"
 ARG HELM_FILENAME="helm-${HELM_VERSION}-linux-amd64.tar.gz"
 
 RUN set -x && \
-    wget ${HELM_LOCATION}/${HELM_FILENAME} && \
-    echo Verifying ${HELM_FILENAME}... && \
-    sha256sum ${HELM_FILENAME} | grep -q "${HELM_SHA256}" && \
-    echo Extracting ${HELM_FILENAME}... && \
-    tar zxvf ${HELM_FILENAME} && mv /linux-amd64/helm /usr/local/bin/ && \
+    wget "${HELM_LOCATION}/${HELM_FILENAME}" && \
+    echo "Verifying ${HELM_FILENAME}..." && \
+    sha256sum "${HELM_FILENAME}" | grep -q "${HELM_SHA256}" && \
+    echo "Extracting ${HELM_FILENAME}..." && \
+    tar zxvf "${HELM_FILENAME}" && mv /linux-amd64/helm /usr/local/bin/ && \
     rm ${HELM_FILENAME} && rm -r /linux-amd64
 
 # using the install documentation found at https://kubernetes.io/docs/tasks/tools/install-kubectl/
@@ -32,7 +46,7 @@ RUN set -x && \
 ENV KUBECTL_VERSION="v1.21.4"
 ENV KUBECTL_SHA256="9410572396fb31e49d088f9816beaebad7420c7686697578691be1651d3bf85a"
 RUN set -x && \
-    curl --retry 5 --retry-connrefused -LO "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
+    wget "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
     sha256sum kubectl | grep ${KUBECTL_SHA256} && \
     chmod +x kubectl && \
     mv kubectl /usr/local/bin/kubectl

--- a/Makefile
+++ b/Makefile
@@ -71,11 +71,11 @@ run: image
 push: image
 	docker push quay.io/${ORG}/helmfile:${TAG}
 
-image/helm3:
-	docker build -f Dockerfile.helm3 -t quay.io/${ORG}/helmfile:helm3-${TAG} .
+image/debian:
+	docker build -f Dockerfile.debian -t quay.io/${ORG}/helmfile:${TAG}-stable-slim .
 
-push/helm3: image/helm3
-	docker push quay.io/${ORG}/helmfile:helm3-${TAG}
+push/debian: image/debian
+	docker push quay.io/${ORG}/helmfile:${TAG}-stable-slim
 
 tools:
 	go get -u github.com/tcnksm/ghr github.com/mitchellh/gox


### PR DESCRIPTION
- Add debian image based on `stable-slim`, desire for this is largely
  around my use case using Azure DevOps which makes it challenging to
  use images which are not glibc based.
- Drop support for helm2 in the docker images. This is a tricky one but
  given that I was having errors during the docker build for helm2 and
  the fact that it has been EoL for a long time now made me think that
  this was the correct move.
- As a "while I'm in here" I've upgraded kubectl and helm. I've popped
  on the most current patch of the last release (v1.20.3) to give a
  slightly broader support for different Kubernetes versions.
- Reworked CI to support pushing a debian and alpine base, and dropped
  support for the helm2 versions.