### PR TITLE
Stop integration test for Helm 2.17.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,12 +93,7 @@ jobs:
             cp ~/build/helmfile ~/project/helmfile
             cp ~/build/diff-yamls ~/project/diff-yamls
             cp ~/build/yamldiff ~/project/yamldiff
-            if [[ "<< parameters.helm-version >>" == v3* ]]
-            then
-              make -C .circleci helm
-            else
-              make -C .circleci helm2
-            fi            
+            make -C .circleci helm
             make -C .circleci vault
             make -C .circleci sops
             make -C .circleci kustomize
@@ -150,7 +145,7 @@ workflows:
             - build
           matrix:
             parameters:
-              helm-version: ["v2.17.0", "v3.4.2", "v3.5.4", "v3.6.3"]
+              helm-version: ["v3.4.2", "v3.5.4", "v3.6.3"]
       - release:
           filters:
             branches:


### PR DESCRIPTION
It turned out the Helm 2.17.0 binary is nowhere now. I considered a bit about checking for a newer Helm 2.x releases as an alternative but I resisted as it is almost a year since EoL of Helm 2. Thanks Helm 2. Long live Helm 3!