### PR TITLE
feat: Option to pass kubeVersion to helm template

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,13 +318,15 @@ bases:
 # Advanced Configuration: API Capabilities
 #
 # 'helmfile template' renders releases locally without querying an actual cluster,
-# and in this case `.Capabilities.APIVersions` cannot be populated.
-# When a chart queries for a specific CRD, this can lead to unexpected results.
+# and in this case `.Capabilities.APIVersions` cannot be populated. Also `Capabilities.KubeVersion` will probably be incorrect.
+# When a chart queries for a specific CRD or the Kubernetes version, this can lead to unexpected results.
 #
 # Configure a fixed list of api versions to pass to 'helm template' via the --api-versions flag:
 apiVersions:
 - example/v1
 
+# Configure a Kubernetes version to  pass to 'helm template' via the --kube-version flag:
+kubeVersion: v1.21
 ```
 
 ## Templating

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -2692,12 +2692,15 @@ releases:
 	}
 }
 
-func TestTemplate_ApiVersions(t *testing.T) {
+func TestTemplate_ApiVersionsAndKubeVersion(t *testing.T) {
 	files := map[string]string{
 		"/path/to/helmfile.yaml": `
 apiVersions:
 - helmfile.test/v1
 - helmfile.test/v2
+
+kubeVersion: v1.21
+
 releases:
 - name: myrelease1
   chart: stable/mychart1
@@ -2706,7 +2709,7 @@ releases:
 
 	var helm = &mockHelmExec{}
 	var wantReleases = []mockTemplates{
-		{name: "myrelease1", chart: "stable/mychart1", flags: []string{"--api-versions", "helmfile.test/v1", "--api-versions", "helmfile.test/v2", "--namespace", "testNamespace", "--output-dir", "output/subdir/helmfile-[a-z0-9]{8}-myrelease1"}},
+		{name: "myrelease1", chart: "stable/mychart1", flags: []string{"--api-versions", "helmfile.test/v1", "--api-versions", "helmfile.test/v2", "--kube-version", "v1.21", "--namespace", "testNamespace", "--output-dir", "output/subdir/helmfile-[a-z0-9]{8}-myrelease1"}},
 	}
 
 	var buffer bytes.Buffer
@@ -2743,7 +2746,7 @@ releases:
 			t.Errorf("chart = [%v], want %v", helm.templated[i].chart, wantReleases[i].chart)
 		}
 		for j := range wantReleases[i].flags {
-			if j == 7 {
+			if j == 9 {
 				matched, _ := regexp.Match(wantReleases[i].flags[j], []byte(helm.templated[i].flags[j]))
 				if !matched {
 					t.Errorf("HelmState.TemplateReleases() = [%v], want %v", helm.templated[i].flags[j], wantReleases[i].flags[j])

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -61,6 +61,7 @@ type ReleaseSetSpec struct {
 	Releases            []ReleaseSpec     `yaml:"releases,omitempty"`
 	Selectors           []string          `yaml:"-"`
 	ApiVersions         []string          `yaml:"apiVersions,omitempty"`
+	KubeVersion         string            `yaml:"kubeVersion,omitempty"`
 
 	// Hooks is a list of extension points paired with operations, that are executed in specific points of the lifecycle of releases defined in helmfile
 	Hooks []event.Hook `yaml:"hooks,omitempty"`
@@ -2455,6 +2456,9 @@ func (st *HelmState) flagsForTemplate(helm helmexec.Interface, release *ReleaseS
 	}
 
 	flags = st.appendApiVersionsFlags(flags)
+	if st.KubeVersion != "" {
+		flags = append(flags, "--kube-version", st.KubeVersion)
+	}
 
 	common, files, err := st.namespaceAndValuesFlags(helm, release, workerIndex)
 	if err != nil {


### PR DESCRIPTION
To be able to use `helmfile template` to render helm charts for cluster with other than the default Kubernetes version in helm you might need to add the --kube-version flag to helm. This adds that functionality.