### PR TITLE
Set postsync and cleanup error

### DIFF
--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -851,11 +851,19 @@ func (st *HelmState) SyncReleases(affectedReleases *AffectedReleases, helm helme
 				}
 
 				if _, err := st.triggerPostsyncEvent(release, relErr, "sync"); err != nil {
-					st.logger.Warnf("warn: %v\n", err)
+					if relErr == nil {
+						relErr = newReleaseFailedError(release, err)
+					} else {
+						st.logger.Warnf("warn: %v\n", err)
+					}
 				}
 
 				if _, err := st.TriggerCleanupEvent(release, "sync"); err != nil {
-					st.logger.Warnf("warn: %v\n", err)
+					if relErr == nil {
+						relErr = newReleaseFailedError(release, err)
+					} else {
+						st.logger.Warnf("warn: %v\n", err)
+					}
 				}
 
 				if relErr == nil {


### PR DESCRIPTION
This fixes https://github.com/roboll/helmfile/issues/1272.

Our use-case for this is: If `postsync` or `cleanup` script fails, this means that a deploy should be marked as failed. Without this fix, this is impossible to detect unless you go and review logs.

Please review and comment on this behaviour change.
