### PR TITLE
feat: supports --set-file on windows

### DIFF
--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -2882,7 +2882,7 @@ func (st *HelmState) setFlags(setValues []SetValue) ([]string, error) {
 			}
 			flags = append(flags, "--set", fmt.Sprintf("%s=%s", escape(set.Name), escape(renderedValue[0])))
 		} else if set.File != "" {
-			flags = append(flags, "--set-file", fmt.Sprintf("%s=%s", escape(set.Name), st.storage().normalizePath(set.File)))
+			flags = append(flags, "--set-file", fmt.Sprintf("%s=%s", escape(set.Name), filepath.ToSlash(st.storage().normalizePath(set.File))))
 		} else if len(set.Values) > 0 {
 			renderedValues, err := renderValsSecrets(st.valsRuntime, set.Values...)
 			if err != nil {

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -1069,6 +1069,31 @@ func TestHelmState_SyncReleases(t *testing.T) {
 			wantReleases: []exectest.Release{{Name: "releaseName", Flags: []string{"--set", "foo=FOO", "--set-file", "bar=path/to/bar", "--set", "baz=BAZ"}}},
 		},
 		{
+			name: "set single value from file where path has backslash",
+			releases: []ReleaseSpec{
+				{
+					Name:  "releaseName",
+					Chart: "foo",
+					SetValues: []SetValue{
+						{
+							Name:  "foo",
+							Value: "FOO",
+						},
+						{
+							Name: "bar",
+							File: "path\\to\\bar",
+						},
+						{
+							Name:  "baz",
+							Value: "BAZ",
+						},
+					},
+				},
+			},
+			helm:         &exectest.Helm{},
+			wantReleases: []exectest.Release{{Name: "releaseName", Flags: []string{"--set", "foo=FOO", "--set-file", "bar=path/to/bar", "--set", "baz=BAZ"}}},
+		},
+		{
 			name: "set single array value in an array",
 			releases: []ReleaseSpec{
 				{


### PR DESCRIPTION
This adds support for --set-file on windows by converting the backslashes to forward slashes. When the arguments are passed to helmfile, the \ aren't escaped, so the path ..\foo\bar is always unreadable.

Haven't created an issue for this yet, wondering if I should add it in.