### PR TITLE
Use os.UserCacheDir()/helmfile to store downloaded artifacts instead of relative .helmfile directory

### DIFF
--- a/examples/remote/helmfile.yaml
+++ b/examples/remote/helmfile.yaml
@@ -1,0 +1,10 @@
+helmfiles:
+- path: git::https://github.com/cloudposse/helmfiles.git@releases/echo-server/helmfile.yaml?ref=master
+  values:
+  - installed: true
+    stage: test
+    environment: test
+
+releases:
+- name: apache
+  chart: git::https://github.com/bitnami/charts.git@bitnami/apache?ref=master

--- a/main.go
+++ b/main.go
@@ -691,6 +691,27 @@ func main() {
 			}),
 		},
 		{
+			Name:      "cache",
+			Usage:     "cache management",
+			ArgsUsage: "[command]",
+			Subcommands: []cli.Command{
+				{
+					Name:  "info",
+					Usage: "cache info",
+					Action: action(func(a *app.App, c configImpl) error {
+						return a.ShowCacheDir(c)
+					}),
+				},
+				{
+					Name:  "cleanup",
+					Usage: "clean up cache directory",
+					Action: action(func(a *app.App, c configImpl) error {
+						return a.CleanCacheDir(c)
+					}),
+				},
+			},
+		},
+		{
 			Name:      "version",
 			Usage:     "Show the version for Helmfile.",
 			ArgsUsage: "[command]",

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -998,12 +998,7 @@ func (a *App) visitStatesWithSelectorsAndRemoteSupport(fileOrDir string, converg
 		opts.Environment.OverrideValues = envvals
 	}
 
-	dir, err := a.getwd()
-	if err != nil {
-		return err
-	}
-
-	a.remote = remote.NewRemote(a.Logger, dir, a.readFile, a.directoryExistsAt, a.fileExistsAt)
+	a.remote = remote.NewRemote(a.Logger, "", a.readFile, a.directoryExistsAt, a.fileExistsAt)
 
 	f := converge
 	if opts.Filter {
@@ -2098,7 +2093,6 @@ func (a *App) ShowCacheDir(c ListConfigProvider) error {
 
 func (a *App) CleanCacheDir(c ListConfigProvider) error {
 	if !directoryExistsAt(remote.CacheDir()) {
-		fmt.Printf("Nothing to remove in cache directory: %s\n", remote.CacheDir())
 		return nil
 	}
 	fmt.Printf("Cleaning up cache directory: %s\n", remote.CacheDir())

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -2078,3 +2078,38 @@ func (c context) wrapErrs(errs ...error) error {
 	}
 	return nil
 }
+
+func (a *App) ShowCacheDir(c ListConfigProvider) error {
+	fmt.Printf("Cache directory: %s\n", remote.CacheDir())
+
+	if !directoryExistsAt(remote.CacheDir()) {
+		return nil
+	}
+	dirs, err := os.ReadDir(remote.CacheDir())
+	if err != nil {
+		return err
+	}
+	for _, e := range dirs {
+		fmt.Printf("- %s\n", e.Name())
+	}
+
+	return nil
+}
+
+func (a *App) CleanCacheDir(c ListConfigProvider) error {
+	if !directoryExistsAt(remote.CacheDir()) {
+		fmt.Printf("Nothing to remove in cache directory: %s\n", remote.CacheDir())
+		return nil
+	}
+	fmt.Printf("Cleaning up cache directory: %s\n", remote.CacheDir())
+	dirs, err := os.ReadDir(remote.CacheDir())
+	if err != nil {
+		return err
+	}
+	for _, e := range dirs {
+		fmt.Printf("- %s\n", e.Name())
+		os.RemoveAll(filepath.Join(remote.CacheDir(), e.Name()))
+	}
+
+	return nil
+}

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -17,7 +17,7 @@ import (
 
 const defaultCacheDir = "helmfile"
 
-func cacheDir() string {
+func CacheDir() string {
 	dir, err := os.UserCacheDir()
 	if err != nil {
 		// fall back to relative path with hidden directory
@@ -204,7 +204,7 @@ func (r *Remote) Fetch(goGetterSrc string, cacheDirOpt ...string) (string, error
 	// e.g. https_github_com_cloudposse_helmfiles_git.ref=0.xx.0
 	getterDst := filepath.Join(cacheBaseDir, cacheKey)
 
-	// e.g. os.cacheDir()/helmfile/https_github_com_cloudposse_helmfiles_git.ref=0.xx.0
+	// e.g. os.CacheDir()/helmfile/https_github_com_cloudposse_helmfiles_git.ref=0.xx.0
 	cacheDirPath := filepath.Join(r.Home, getterDst)
 
 	r.Logger.Debugf("home: %s", r.Home)
@@ -292,7 +292,7 @@ func NewRemote(logger *zap.SugaredLogger, homeDir string, readFile func(string) 
 
 	if remote.Home == "" {
 		// Use for remote charts
-		remote.Home = cacheDir()
+		remote.Home = CacheDir()
 	} else {
 		// Use for remote helmfiles, this case Home is relative to the processing file
 		remote.Home = filepath.Join(remote.Home, relativeCacheDir())

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -15,20 +15,13 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-const defaultCacheDir = "helmfile"
-
 func CacheDir() string {
 	dir, err := os.UserCacheDir()
 	if err != nil {
 		// fall back to relative path with hidden directory
-		return relativeCacheDir()
+		return ".helmfile"
 	}
-	return filepath.Join(dir, defaultCacheDir)
-}
-
-// TODO remove this function when rework on caching of remote helmfiles
-func relativeCacheDir() string {
-	return fmt.Sprintf(".%s", defaultCacheDir)
+	return filepath.Join(dir, "helmfile")
 }
 
 type Remote struct {
@@ -293,9 +286,6 @@ func NewRemote(logger *zap.SugaredLogger, homeDir string, readFile func(string) 
 	if remote.Home == "" {
 		// Use for remote charts
 		remote.Home = CacheDir()
-	} else {
-		// Use for remote helmfiles, this case Home is relative to the processing file
-		remote.Home = filepath.Join(remote.Home, relativeCacheDir())
 	}
 
 	return remote

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -13,10 +13,10 @@ import (
 
 func TestRemote_HttpsGitHub(t *testing.T) {
 	cleanfs := map[string]string{
-		cacheDir(): "",
+		CacheDir(): "",
 	}
 	cachefs := map[string]string{
-		filepath.Join(cacheDir(), "https_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml"): "foo: bar",
+		filepath.Join(CacheDir(), "https_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml"): "foo: bar",
 	}
 
 	type testcase struct {
@@ -38,7 +38,7 @@ func TestRemote_HttpsGitHub(t *testing.T) {
 			hit := true
 
 			get := func(wd, src, dst string) error {
-				if wd != cacheDir() {
+				if wd != CacheDir() {
 					return fmt.Errorf("unexpected wd: %s", wd)
 				}
 				if src != "git::https://github.com/cloudposse/helmfiles.git?ref=0.40.0" {
@@ -55,7 +55,7 @@ func TestRemote_HttpsGitHub(t *testing.T) {
 			}
 			remote := &Remote{
 				Logger:     helmexec.NewLogger(os.Stderr, "debug"),
-				Home:       cacheDir(),
+				Home:       CacheDir(),
 				Getter:     getter,
 				ReadFile:   testfs.ReadFile,
 				FileExists: testfs.FileExistsAt,
@@ -74,7 +74,7 @@ func TestRemote_HttpsGitHub(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			expectedFile := filepath.Join(cacheDir(), "https_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml")
+			expectedFile := filepath.Join(CacheDir(), "https_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml")
 			if file != expectedFile {
 				t.Errorf("unexpected file located: %s vs expected: %s", file, expectedFile)
 			}
@@ -91,10 +91,10 @@ func TestRemote_HttpsGitHub(t *testing.T) {
 
 func TestRemote_SShGitHub(t *testing.T) {
 	cleanfs := map[string]string{
-		cacheDir(): "",
+		CacheDir(): "",
 	}
 	cachefs := map[string]string{
-		filepath.Join(cacheDir(), "ssh_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml"): "foo: bar",
+		filepath.Join(CacheDir(), "ssh_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml"): "foo: bar",
 	}
 
 	type testcase struct {
@@ -116,7 +116,7 @@ func TestRemote_SShGitHub(t *testing.T) {
 			hit := true
 
 			get := func(wd, src, dst string) error {
-				if wd != cacheDir() {
+				if wd != CacheDir() {
 					return fmt.Errorf("unexpected wd: %s", wd)
 				}
 				if src != "git::ssh://git@github.com/cloudposse/helmfiles.git?ref=0.40.0" {
@@ -133,7 +133,7 @@ func TestRemote_SShGitHub(t *testing.T) {
 			}
 			remote := &Remote{
 				Logger:     helmexec.NewLogger(os.Stderr, "debug"),
-				Home:       cacheDir(),
+				Home:       CacheDir(),
 				Getter:     getter,
 				ReadFile:   testfs.ReadFile,
 				FileExists: testfs.FileExistsAt,
@@ -146,7 +146,7 @@ func TestRemote_SShGitHub(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			expectedFile := filepath.Join(cacheDir(), "ssh_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml")
+			expectedFile := filepath.Join(CacheDir(), "ssh_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml")
 			if file != expectedFile {
 				t.Errorf("unexpected file located: %s vs expected: %s", file, expectedFile)
 			}

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -3,6 +3,7 @@ package remote
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -12,10 +13,10 @@ import (
 
 func TestRemote_HttpsGitHub(t *testing.T) {
 	cleanfs := map[string]string{
-		"/path/to/home": "",
+		cacheDir(): "",
 	}
 	cachefs := map[string]string{
-		"/path/to/home/.helmfile/cache/https_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml": "foo: bar",
+		filepath.Join(cacheDir(), "https_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml"): "foo: bar",
 	}
 
 	type testcase struct {
@@ -37,7 +38,7 @@ func TestRemote_HttpsGitHub(t *testing.T) {
 			hit := true
 
 			get := func(wd, src, dst string) error {
-				if wd != "/path/to/home" {
+				if wd != cacheDir() {
 					return fmt.Errorf("unexpected wd: %s", wd)
 				}
 				if src != "git::https://github.com/cloudposse/helmfiles.git?ref=0.40.0" {
@@ -54,7 +55,7 @@ func TestRemote_HttpsGitHub(t *testing.T) {
 			}
 			remote := &Remote{
 				Logger:     helmexec.NewLogger(os.Stderr, "debug"),
-				Home:       "/path/to/home",
+				Home:       cacheDir(),
 				Getter:     getter,
 				ReadFile:   testfs.ReadFile,
 				FileExists: testfs.FileExistsAt,
@@ -73,8 +74,9 @@ func TestRemote_HttpsGitHub(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			if file != "/path/to/home/.helmfile/cache/https_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml" {
-				t.Errorf("unexpected file located: %s", file)
+			expectedFile := filepath.Join(cacheDir(), "https_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml")
+			if file != expectedFile {
+				t.Errorf("unexpected file located: %s vs expected: %s", file, expectedFile)
 			}
 
 			if testcase.expectCacheHit && !hit {
@@ -89,10 +91,10 @@ func TestRemote_HttpsGitHub(t *testing.T) {
 
 func TestRemote_SShGitHub(t *testing.T) {
 	cleanfs := map[string]string{
-		"/path/to/home": "",
+		cacheDir(): "",
 	}
 	cachefs := map[string]string{
-		"/path/to/home/.helmfile/cache/ssh_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml": "foo: bar",
+		filepath.Join(cacheDir(), "ssh_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml"): "foo: bar",
 	}
 
 	type testcase struct {
@@ -114,7 +116,7 @@ func TestRemote_SShGitHub(t *testing.T) {
 			hit := true
 
 			get := func(wd, src, dst string) error {
-				if wd != "/path/to/home" {
+				if wd != cacheDir() {
 					return fmt.Errorf("unexpected wd: %s", wd)
 				}
 				if src != "git::ssh://git@github.com/cloudposse/helmfiles.git?ref=0.40.0" {
@@ -131,7 +133,7 @@ func TestRemote_SShGitHub(t *testing.T) {
 			}
 			remote := &Remote{
 				Logger:     helmexec.NewLogger(os.Stderr, "debug"),
-				Home:       "/path/to/home",
+				Home:       cacheDir(),
 				Getter:     getter,
 				ReadFile:   testfs.ReadFile,
 				FileExists: testfs.FileExistsAt,
@@ -144,8 +146,9 @@ func TestRemote_SShGitHub(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			if file != "/path/to/home/.helmfile/cache/ssh_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml" {
-				t.Errorf("unexpected file located: %s", file)
+			expectedFile := filepath.Join(cacheDir(), "ssh_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml")
+			if file != expectedFile {
+				t.Errorf("unexpected file located: %s vs expected: %s", file, expectedFile)
 			}
 
 			if testcase.expectCacheHit && !hit {

--- a/pkg/state/helmx.go
+++ b/pkg/state/helmx.go
@@ -40,9 +40,7 @@ type Chartify struct {
 }
 
 func (st *HelmState) downloadChartWithGoGetter(r *ReleaseSpec) (string, error) {
-	pathElems := []string{
-		remote.DefaultCacheDir,
-	}
+	var pathElems []string
 
 	if r.Namespace != "" {
 		pathElems = append(pathElems, r.Namespace)
@@ -70,7 +68,7 @@ func (st *HelmState) goGetterChart(chart, dir, cacheDir string, force bool) (str
 			return "", fmt.Errorf("Parsing url from dir failed due to error %q.\nContinuing the process assuming this is a regular Helm chart or a local dir.", err.Error())
 		}
 	} else {
-		r := remote.NewRemote(st.logger, st.basePath, st.readFile, directoryExistsAt, fileExistsAt)
+		r := remote.NewRemote(st.logger, "", st.readFile, directoryExistsAt, fileExistsAt)
 
 		fetchedDir, err := r.Fetch(chart, cacheDir)
 		if err != nil {


### PR DESCRIPTION
Current behavior:
Artifacts (remote helmfile or chart) are downloaded into `.helmfile` relative to working directory

Proposed behavior:
There artifacts are downloaded and cached in user's  `.cache` directory. Since the caching system is moved out of working directory, new commands are proposed `cache info` and `cache cleanup`

Test with `examples/remote`

```
root@e3f962517cc9:/source/examples/remote# /source/helmfile cache info
Cache directory: /root/.cache/helmfile
- apache
- https_github_com_cloudposse_helmfiles_git.ref=master

root@e3f962517cc9:/source/examples/remote# /source/helmfile cache cleanup
Cleaning up cache directory: /root/.cache/helmfile
- apache
- https_github_com_cloudposse_helmfiles_git.ref=master
```