### PR TITLE
Support apple silicon (m1 mac) builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ integration/vagrant:
 .PHONY: integration/vagrant
 
 cross:
-	env CGO_ENABLED=0 gox -os 'windows darwin linux' -arch '386 amd64 arm64' -osarch '!darwin/arm64 !darwin/386' -output "dist/{{.Dir}}_{{.OS}}_{{.Arch}}" -ldflags '-X github.com/roboll/helmfile/pkg/app/version.Version=${TAG}' ${TARGETS}
+	env CGO_ENABLED=0 gox -os 'windows darwin linux' -arch '386 amd64 arm64' -osarch '!darwin/386' -output "dist/{{.Dir}}_{{.OS}}_{{.Arch}}" -ldflags '-X github.com/roboll/helmfile/pkg/app/version.Version=${TAG}' ${TARGETS}
 .PHONY: cross
 
 static-linux:


### PR DESCRIPTION
Adds a `darwin/arm64` release artifact compatible with m1 macs.  

I tested this out via circleci and was able to generate the `darwin/arm64` build just fine:
```
#!/bin/bash -eo pipefail
make tools
go mod vendor
ORG=mhuber BUILD_URL="$CIRCLE_BUILD_URL" make cross

go get -u github.com/tcnksm/ghr github.com/mitchellh/gox
go: downloading github.com/mitchellh/gox v1.0.1
go: downloading github.com/tcnksm/ghr v0.14.0
go: downloading github.com/hashicorp/go-version v1.3.0
go: downloading github.com/mitchellh/iochan v1.0.0
go: downloading github.com/google/go-github v17.0.0+incompatible
go: downloading github.com/tcnksm/go-latest v0.0.0-20170313132115-e3007ae9052e
go: downloading github.com/Songmu/retry v0.1.0
go: downloading github.com/tcnksm/go-gitconfig v0.1.2
go: downloading golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c
go: downloading github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db
go: downloading github.com/mattn/go-colorable v0.1.12
go: downloading golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
go: downloading github.com/mattn/go-isatty v0.0.13
go: downloading github.com/mattn/go-isatty v0.0.14
go: downloading golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1
go: downloading google.golang.org/appengine v1.6.7
go: downloading golang.org/x/net v0.0.0-20210614182718-04defd469f4e
go: downloading github.com/google/go-querystring v1.1.0
go: downloading golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e
go: downloading golang.org/x/net v0.0.0-20211216030914-fe4d6282115f
go: downloading google.golang.org/protobuf v1.27.1
go get: upgraded github.com/hashicorp/go-version v1.2.1 => v1.3.0
go get: upgraded github.com/mattn/go-colorable v0.1.8 => v0.1.12
go get: upgraded github.com/mattn/go-isatty v0.0.12 => v0.0.14
go get: upgraded github.com/mitchellh/gox v0.4.0 => v1.0.1
go get: added github.com/tcnksm/ghr v0.14.0
go get: upgraded golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4 => v0.0.0-20211216030914-fe4d6282115f
go get: upgraded golang.org/x/oauth2 v0.0.0-20210413134643-5e61552d6c78 => v0.0.0-20211104180415-d3ed0bb246c8
go get: upgraded golang.org/x/sys v0.0.0-20210412220455-f1c623a9e750 => v0.0.0-20211216021012-1d35b9e2eb4e
go get: upgraded google.golang.org/protobuf v1.26.0 => v1.27.1
go: downloading gotest.tools v2.2.0+incompatible
go: downloading github.com/inconshreveable/mousetrap v1.0.0
go: downloading golang.org/x/tools v0.1.0
go: downloading golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5
go: downloading github.com/jstemmer/go-junit-report v0.9.1
go: downloading golang.org/x/text v0.3.6
go: downloading gotest.tools/v3 v3.0.3
go: downloading golang.org/x/mod v0.4.1
go: downloading golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
env CGO_ENABLED=0 gox -os 'windows darwin linux' -arch '386 amd64 arm64' -osarch '!darwin/386' -output "dist/{{.Dir}}_{{.OS}}_{{.Arch}}" -ldflags '-X github.com/roboll/helmfile/pkg/app/version.Version=v0.142.0' 
Number of parallel builds: 35

-->    darwin/amd64: github.com/roboll/helmfile
-->    darwin/arm64: github.com/roboll/helmfile
-->       linux/386: github.com/roboll/helmfile
-->     windows/386: github.com/roboll/helmfile
-->   windows/amd64: github.com/roboll/helmfile
-->     linux/amd64: github.com/roboll/helmfile
-->     linux/arm64: github.com/roboll/helmfile

CircleCI received exit code 0
```

```
❯ ls -al dist
total 582328
drwxr-xr-x   9 huberm  staff       288 Dec 23 06:00 .
drwxr-xr-x  30 huberm  staff       960 Dec 23 06:01 ..
-rw-r--r--   1 huberm  staff  43950144 Dec 23 06:00 helmfile_darwin_amd64
-rwxr-xr-x   1 huberm  staff  43334098 Dec 23 06:00 helmfile_darwin_arm64
-rw-r--r--   1 huberm  staff  38445705 Dec 23 06:00 helmfile_linux_386
-rw-r--r--   1 huberm  staff  44329635 Dec 23 06:00 helmfile_linux_amd64
-rw-r--r--   1 huberm  staff  42097219 Dec 23 06:00 helmfile_linux_arm64
-rw-r--r--   1 huberm  staff  39821312 Dec 23 06:00 helmfile_windows_386.exe
-rw-r--r--   1 huberm  staff  45280768 Dec 23 06:00 helmfile_windows_amd64.exe
```

```
❯ uname -a
Darwin Micahs-Air.localdomain 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:27 PDT 2021; root:xnu-7195.141.2~5/RELEASE_ARM64_T8101 arm64

❯ ./dist/helmfile_darwin_arm64
NAME:
   helmfile

USAGE:
   helmfile_darwin_arm64 [global options] command [command options] [arguments...]

VERSION:
   v0.142.0

COMMANDS:
   deps          update charts based on their requirements
   repos         sync repositories from state file (helm repo add && helm repo update)
   charts        DEPRECATED: sync releases from state file (helm upgrade --install)
   diff          diff releases from state file against env (helm diff)
   template      template releases from state file against env (helm template)
   write-values  write values files for releases. Similar to `helmfile template`, write values files instead of manifests.
   lint          lint charts from state file (helm lint)
   fetch         fetch charts from state file
   sync          sync all resources from state file (repos, releases and chart deps)
   apply         apply all resources from state file only when there are changes
   status        retrieve status of releases in state file
   delete        DEPRECATED: delete releases from state file (helm delete)
   destroy       deletes and then purges releases
   test          test releases from state file (helm test)
   build         output compiled helmfile state(s) as YAML
   list          list releases defined in state file
   version       Show the version for Helmfile.
   help, h       Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --helm-binary value, -b value           path to helm binary (default: "helm")
   --file helmfile.yaml, -f helmfile.yaml  load config from file or directory. defaults to helmfile.yaml or `helmfile.d`(means `helmfile.d/*.yaml`) in this preference
   --environment value, -e value           specify the environment name. defaults to "default"
   --state-values-set value                set state values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
   --state-values-file value               specify state values in a YAML file
   --quiet, -q                             Silence output. Equivalent to log-level warn
   --kube-context value                    Set kubectl context. Uses current context by default
   --debug                                 Enable verbose output for Helm and set log-level to debug, this disables --quiet/-q effect
   --no-color                              Output without color
   --log-level value                       Set log level, default info
   --namespace value, -n value             Set namespace. Uses the namespace set in the context by default, and is available in templates as {{ .Namespace }}
   --chart value, -c value                 Set chart. Uses the chart set in release by default, and is available in template as {{ .Chart }}
   --selector value, -l value              Only run using the releases that match labels. Labels can take the form of foo=bar or foo!=bar.
                                           A release must match all labels in a group in order to be used. Multiple groups can be specified at once.
                                           --selector tier=frontend,tier!=proxy --selector tier=backend. Will match all frontend, non-proxy releases AND all backend releases.
                                           The name of a release can be used as a label. --selector name=myrelease
   --allow-no-matching-release             Do not exit with an error code if the provided selector has no matching releases.
   --interactive, -i                       Request confirmation before attempting to modify clusters
   --help, -h                              show help
   --version, -v                           print the version
```