### PR TITLE
Add template function isFile

### DIFF
--- a/pkg/tmpl/context_funcs.go
+++ b/pkg/tmpl/context_funcs.go
@@ -1,6 +1,7 @@
 package tmpl
 
 import (
+	"errors"
 	"fmt"
 	"github.com/ghodss/yaml"
 	"github.com/roboll/helmfile/pkg/helmexec"
@@ -19,6 +20,7 @@ type Values = map[string]interface{}
 func (c *Context) createFuncMap() template.FuncMap {
 	funcMap := template.FuncMap{
 		"exec":             c.Exec,
+		"isFile":           IsFile,
 		"readFile":         c.ReadFile,
 		"readDir":          ReadDir,
 		"toYaml":           ToYaml,
@@ -114,6 +116,17 @@ func (c *Context) Exec(command string, args []interface{}, inputs ...string) (st
 	}
 
 	return string(bytes), nil
+}
+
+func IsFile(filename string) (bool, error) {
+    stat, err := os.Stat(filename)
+    if err == nil {
+        return !stat.IsDir(), nil
+    }
+    if errors.Is(err, os.ErrNotExist) {
+        return false, nil
+    }
+    return false, err
 }
 
 func (c *Context) ReadFile(filename string) (string, error) {

--- a/pkg/tmpl/context_funcs.go
+++ b/pkg/tmpl/context_funcs.go
@@ -20,7 +20,7 @@ type Values = map[string]interface{}
 func (c *Context) createFuncMap() template.FuncMap {
 	funcMap := template.FuncMap{
 		"exec":             c.Exec,
-		"isFile":           IsFile,
+		"isFile":           c.IsFile,
 		"readFile":         c.ReadFile,
 		"readDir":          ReadDir,
 		"toYaml":           ToYaml,
@@ -118,15 +118,22 @@ func (c *Context) Exec(command string, args []interface{}, inputs ...string) (st
 	return string(bytes), nil
 }
 
-func IsFile(filename string) (bool, error) {
-    stat, err := os.Stat(filename)
-    if err == nil {
-        return !stat.IsDir(), nil
-    }
-    if errors.Is(err, os.ErrNotExist) {
-        return false, nil
-    }
-    return false, err
+func (c *Context) IsFile(filename string) (bool, error) {
+	var path string
+	if filepath.IsAbs(filename) {
+		path = filename
+	} else {
+		path = filepath.Join(c.basePath, filename)
+	}
+
+	stat, err := os.Stat(path)
+	if err == nil {
+		return !stat.IsDir(), nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	return false, err
 }
 
 func (c *Context) ReadFile(filename string) (string, error) {


### PR DESCRIPTION
My use case is to check for file existence before using it with `readFile`, or we might implement `must` functions instead.

For now as a workaround, I'm using something like `if eq "ok" (exec test -f <file> && echo "ok" || echo "ko")` to do the job :-)