### PR TITLE
Add `--skip-tests` to helmfile template command

### DIFF
--- a/main.go
+++ b/main.go
@@ -283,7 +283,7 @@ func main() {
 					Usage: "include CRDs in the templated output",
 				},
 				cli.BoolFlag{
-					Name: "skip-tests",
+					Name:  "skip-tests",
 					Usage: "skip tests from templated output",
 				},
 				cli.BoolFlag{

--- a/main.go
+++ b/main.go
@@ -283,6 +283,10 @@ func main() {
 					Usage: "include CRDs in the templated output",
 				},
 				cli.BoolFlag{
+					Name: "skip-tests",
+					Usage: "skip tests from templated output",
+				},
+				cli.BoolFlag{
 					Name:  "include-needs",
 					Usage: `automatically include releases from the target release's "needs" when --selector/-l flag is provided. Does nothing when when --selector/-l flag is not provided`,
 				},
@@ -932,6 +936,10 @@ func (c configImpl) EmbedValues() bool {
 
 func (c configImpl) IncludeCRDs() bool {
 	return c.c.Bool("include-crds")
+}
+
+func (c configImpl) SkipTests() bool {
+	return c.c.Bool("skip-tests")
 }
 
 func (c configImpl) Logger() *zap.SugaredLogger {

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1858,6 +1858,7 @@ func (a *App) template(r *Run, c TemplateConfigProvider) (bool, []error) {
 				IncludeCRDs:       c.IncludeCRDs(),
 				OutputDirTemplate: c.OutputDirTemplate(),
 				SkipCleanup:       c.SkipCleanup(),
+				SkipTests:         c.SkipTests(),
 			}
 			return subst.TemplateReleases(helm, c.OutputDir(), c.Values(), args, c.Concurrency(), c.Validate(), opts)
 		}))

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -2268,6 +2268,7 @@ type configImpl struct {
 	skipCleanup bool
 	skipCRDs    bool
 	skipDeps    bool
+	skipTests   bool
 
 	skipNeeds              bool
 	includeNeeds           bool
@@ -2308,6 +2309,10 @@ func (c configImpl) SkipDeps() bool {
 
 func (c configImpl) SkipNeeds() bool {
 	return c.skipNeeds
+}
+
+func (c configImpl) SkipTests() bool {
+	return c.skipTests
 }
 
 func (c configImpl) IncludeNeeds() bool {

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -177,6 +177,7 @@ type TemplateConfigProvider interface {
 	Validate() bool
 	SkipDeps() bool
 	SkipCleanup() bool
+	SkipTests() bool
 	OutputDir() string
 	IncludeCRDs() bool
 	IncludeNeeds() bool

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1307,6 +1307,7 @@ type TemplateOpts struct {
 	SkipCleanup       bool
 	OutputDirTemplate string
 	IncludeCRDs       bool
+	SkipTests         bool
 }
 
 type TemplateOpt interface{ Apply(*TemplateOpts) }
@@ -1383,6 +1384,10 @@ func (st *HelmState) TemplateReleases(helm helmexec.Interface, outputDir string,
 
 		if opts.IncludeCRDs {
 			flags = append(flags, "--include-crds")
+		}
+
+		if opts.SkipTests {
+			flags = append(flags, "--skip-tests")
 		}
 
 		if len(errs) == 0 {


### PR DESCRIPTION
Adds support for `helm template --skip-tests` in the `helmfile template` command. Improves functionality in GitOps tools like ArgoCD.