### PR TITLE
Fix context of the ReadDir templating function

### DIFF
--- a/pkg/tmpl/context_funcs.go
+++ b/pkg/tmpl/context_funcs.go
@@ -20,7 +20,7 @@ func (c *Context) createFuncMap() template.FuncMap {
 	funcMap := template.FuncMap{
 		"exec":             c.Exec,
 		"readFile":         c.ReadFile,
-		"readDir":          ReadDir,
+		"readDir":          c.ReadDir,
 		"toYaml":           ToYaml,
 		"fromYaml":         FromYaml,
 		"setValueAtPath":   SetValueAtPath,
@@ -131,8 +131,14 @@ func (c *Context) ReadFile(filename string) (string, error) {
 	return string(bytes), nil
 }
 
-func ReadDir(path string) ([]string, error) {
-	entries, err := os.ReadDir(path)
+func (c *Context) ReadDir(path string) ([]string, error) {
+    var context_path string
+	if filepath.IsAbs(path) {
+        context_path = path
+	} else {
+		context_path = filepath.Join(c.basePath, path)
+    }
+	entries, err := os.ReadDir(context_path)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tmpl/context_funcs.go
+++ b/pkg/tmpl/context_funcs.go
@@ -2,9 +2,6 @@ package tmpl
 
 import (
 	"fmt"
-	"github.com/ghodss/yaml"
-	"github.com/roboll/helmfile/pkg/helmexec"
-	"golang.org/x/sync/errgroup"
 	"io"
 	"os"
 	"os/exec"
@@ -12,6 +9,10 @@ import (
 	"reflect"
 	"strings"
 	"text/template"
+
+	"github.com/ghodss/yaml"
+	"github.com/roboll/helmfile/pkg/helmexec"
+	"golang.org/x/sync/errgroup"
 )
 
 type Values = map[string]interface{}
@@ -132,16 +133,15 @@ func (c *Context) ReadFile(filename string) (string, error) {
 }
 
 func (c *Context) ReadDir(path string) ([]string, error) {
-    var context_path string
-	if filepath.IsAbs(path) {
-        context_path = path
-	} else {
-		context_path = filepath.Join(c.basePath, path)
-    }
-	entries, err := os.ReadDir(context_path)
-	if err != nil {
-		return nil, err
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(c.basePath, path)
 	}
+
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return nil, fmt.Errorf("ReadDir %q: %w", path, err)
+	}
+
 	var filenames []string
 	for _, entry := range entries {
 		if entry.IsDir() {
@@ -149,6 +149,7 @@ func (c *Context) ReadDir(path string) ([]string, error) {
 		}
 		filenames = append(filenames, filepath.Join(path, entry.Name()))
 	}
+
 	return filenames, nil
 }
 


### PR DESCRIPTION
This PR fixes an issue brought up by @bhester01 in #1934. I made `ReadDir` a method of `*Context` as suggested by @mumoshu, and that seems to have resolved the issue.