### PR TITLE
Allow more characters in label selectors

### DIFF
--- a/pkg/state/release_filters.go
+++ b/pkg/state/release_filters.go
@@ -54,8 +54,8 @@ func ParseLabels(l string) (LabelFilter, error) {
 	lf.negativeLabels = [][]string{}
 	var err error
 	labels := strings.Split(l, ",")
-	reMissmatch := regexp.MustCompile("^[a-zA-Z0-9_-]+!=[a-zA-Z0-9_-]+$")
-	reMatch := regexp.MustCompile("^[a-zA-Z0-9_-]+=[a-zA-Z0-9_-]+$")
+	reMissmatch := regexp.MustCompile(`^[a-zA-Z0-9_\.\/\+-]+!=[a-zA-Z0-9_\.\/\+-]+$`)
+	reMatch := regexp.MustCompile(`^[a-zA-Z0-9_\.\/\+-]+=[a-zA-Z0-9_\.\/\+-]+$`)
 	for _, label := range labels {
 		if match := reMissmatch.MatchString(label); match { // k!=v case
 			kv := strings.Split(label, "!=")

--- a/pkg/state/selector_test.go
+++ b/pkg/state/selector_test.go
@@ -22,22 +22,22 @@ func TestSelectReleasesWithOverrides(t *testing.T) {
 		{
 			subject:  "multiple OR selectors (non-nillable label first)",
 			selector: []string{"name=foo", "type!=bar"},
-			want:     []string{"nolabel1", "nolabel2", "foo"},
+			want:     []string{"nolabel1", "nolabel2", "foo", "bar", "foobar"},
 		},
 		{
 			subject:  "multiple AND conditions (nillable label first)",
 			selector: []string{"type!=bar,name!=nolabel2"},
-			want:     []string{"nolabel1"},
+			want:     []string{"nolabel1", "bar", "foobar"},
 		},
 		{
 			subject:  "multiple AND conditions (non-nillable label first)",
 			selector: []string{"name!=nolabel2,type!=bar"},
-			want:     []string{"nolabel1"},
+			want:     []string{"nolabel1", "bar", "foobar"},
 		},
 		{
 			subject:  "inequality on nillable label",
 			selector: []string{"type!=bar"},
-			want:     []string{"nolabel1", "nolabel2"},
+			want:     []string{"nolabel1", "nolabel2", "bar", "foobar"},
 		},
 		{
 			subject:  "equality on nillable label",
@@ -47,12 +47,32 @@ func TestSelectReleasesWithOverrides(t *testing.T) {
 		{
 			subject:  "inequality on non-nillable label",
 			selector: []string{"name!=nolabel1"},
-			want:     []string{"nolabel2", "foo"},
+			want:     []string{"nolabel2", "foo", "bar", "foobar"},
 		},
 		{
 			subject:  "equality on non-nillable label",
 			selector: []string{"name=nolabel1"},
 			want:     []string{"nolabel1"},
+		},
+		{
+			subject:  "equality on non-alphabetic character label",
+			selector: []string{"version=1.2/3"},
+			want:     []string{"bar"},
+		},
+		{
+			subject:  "equality on non-alphabetic character label",
+			selector: []string{"version=1.2.3+123"},
+			want:     []string{"foobar"},
+		},
+		{
+			subject:  "inequality on non-alphatetic character label",
+			selector: []string{"version!=1.2/3"},
+			want:     []string{"nolabel1", "nolabel2", "foo", "foobar"},
+		},
+		{
+			subject:  "inequality on non-alphatetic character label",
+			selector: []string{"version!=1.2.3+123"},
+			want:     []string{"nolabel1", "nolabel2", "foo", "bar"},
 		},
 	}
 
@@ -68,6 +88,16 @@ func TestSelectReleasesWithOverrides(t *testing.T) {
   chart: stable/foo
   labels:
     type: bar
+- name: bar
+  namespace: kube-system
+  chart: stable/bar
+  labels:
+    version: 1.2/3
+- name: foobar
+  namespace: kube-system
+  chart: stable/bar
+  labels:
+    version: 1.2.3+123
 `)
 
 	state := stateTestEnv{


### PR DESCRIPTION
label selectors now also allows . and / in filter.

Not sure if we should allow more characters? Maybe everything except whitespace?


Fixes #970