### PR TITLE
Stop panic when deduplicating releases

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1203,13 +1203,11 @@ func (a *App) getSelectedReleases(r *Run, includeTransitiveNeeds bool) ([]state.
 		// releases in the helmfile config.
 		// Otherwise we can't compute the DAG of releases correctly.
 		r, deduped := selectedIds[id]
-		if !deduped {
-			panic(fmt.Errorf("assertion error: release %q has never been selected. This shouldn't happen!", id))
+		if deduped {
+			deduplicated = append(deduplicated, r)
+
+			dedupedBefore[id] = struct{}{}
 		}
-
-		deduplicated = append(deduplicated, r)
-
-		dedupedBefore[id] = struct{}{}
 	}
 
 	if err := checkDuplicates(r.helm, r.state, deduplicated); err != nil {

--- a/pkg/app/testdata/testapply_2/select_non_existant_release_with_--allow-no-matching-release/log
+++ b/pkg/app/testdata/testapply_2/select_non_existant_release_with_--allow-no-matching-release/log
@@ -1,0 +1,43 @@
+processing file "helmfile.yaml" in directory "."
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: incubator/raw
+ 4:   namespace: default
+ 5:   labels:
+ 6:     app: test
+ 7: 
+ 8: - name: bar
+ 9:   chart: incubator/raw
+10:   namespace: default
+11:   labels:
+12:     app: test
+13: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: incubator/raw
+ 4:   namespace: default
+ 5:   labels:
+ 6:     app: test
+ 7: 
+ 8: - name: bar
+ 9:   chart: incubator/raw
+10:   namespace: default
+11:   labels:
+12:     app: test
+13: 
+
+merged environment: &{default map[] map[]}
+0 release(s) matching app=foo found in helmfile.yaml
+

--- a/pkg/app/testdata/testapply_2/select_single_release_from_helmfile_with_two_duplicates/log
+++ b/pkg/app/testdata/testapply_2/select_single_release_from_helmfile_with_two_duplicates/log
@@ -1,0 +1,69 @@
+processing file "helmfile.yaml" in directory "."
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: incubator/raw
+ 4:   namespace: default
+ 5:   labels:
+ 6:     app: test
+ 7: 
+ 8: - name: bar
+ 9:   chart: incubator/raw
+10:   namespace: default
+11:   labels:
+12:     app: build
+13: 
+14: - name: bar
+15:   chart: incubator/raw
+16:   namespace: default
+17:   labels:
+18:     app: test
+19: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: incubator/raw
+ 4:   namespace: default
+ 5:   labels:
+ 6:     app: test
+ 7: 
+ 8: - name: bar
+ 9:   chart: incubator/raw
+10:   namespace: default
+11:   labels:
+12:     app: build
+13: 
+14: - name: bar
+15:   chart: incubator/raw
+16:   namespace: default
+17:   labels:
+18:     app: test
+19: 
+
+merged environment: &{default map[] map[]}
+1 release(s) matching name=foo found in helmfile.yaml
+
+Affected releases are:
+  foo (incubator/raw) UPDATED
+
+processing 1 groups of releases in this order:
+GROUP RELEASES
+1     default/default/foo
+
+processing releases in group 1/1: default/default/foo
+getting deployed release version failed:unexpected list key: {^foo$ --kube-contextdefault--deleting--deployed--failed--pending}
+
+UPDATED RELEASES:
+NAME   CHART           VERSION
+foo    incubator/raw          
+


### PR DESCRIPTION
Stops panic when deduplicating releases, and only add release to deduplicated list if the release is in the selectedIds.

Added two testcases for the two issues that mention this problem.

Fixes #2062 
Fixes #2065 