### PR TITLE
Bump chartify to v0.9.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/tatsushid/go-prettytable v0.0.0-20141013043238-ed2d14c29939
 	github.com/urfave/cli v1.22.5
-	github.com/variantdev/chartify v0.9.3
+	github.com/variantdev/chartify v0.9.4
 	github.com/variantdev/dag v1.1.0
 	github.com/variantdev/vals v0.15.0
 	go.uber.org/multierr v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1238,8 +1238,8 @@ github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtX
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.5 h1:lNq9sAHXK2qfdI8W+GRItjCEkI+2oR4d+MEHy1CKXoU=
 github.com/urfave/cli v1.22.5/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
-github.com/variantdev/chartify v0.9.3 h1:IdFiznqFkpKm3yoEMbqiao+wArQofvQohvk4WQ7z5tI=
-github.com/variantdev/chartify v0.9.3/go.mod h1:A0nQmb+ihiBJrrbgofs1t7QVeit+/llT0vJhvkj7U0Q=
+github.com/variantdev/chartify v0.9.4 h1:7u6C4Hh5Ah6sZgRHF75gbEakAXv64LpJ8alViNs+cbY=
+github.com/variantdev/chartify v0.9.4/go.mod h1:A0nQmb+ihiBJrrbgofs1t7QVeit+/llT0vJhvkj7U0Q=
 github.com/variantdev/dag v1.1.0 h1:xodYlSng33KWGvIGMpKUyLcIZRXKiNUx612mZJqYrDg=
 github.com/variantdev/dag v1.1.0/go.mod h1:pH1TQsNSLj2uxMo9NNl9zdGy01Wtn+/2MT96BrKmVyE=
 github.com/variantdev/vals v0.15.0 h1:ZkY+K4IxqEenfVNbgTayVXW0JKdYdEBqGIarrDs0htI=


### PR DESCRIPTION
This release fixes an issue when you tried to chartify a local chart whose directory name does not match the name of the chart defined in Chart.yaml.

See https://github.com/variantdev/chartify/releases/tag/v0.9.4 for more information.