### PR TITLE
Enhance support for kube-version and api-versions

### DIFF
--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -60,8 +60,12 @@ type ReleaseSetSpec struct {
 	CommonLabels        map[string]string `yaml:"commonLabels,omitempty"`
 	Releases            []ReleaseSpec     `yaml:"releases,omitempty"`
 	Selectors           []string          `yaml:"-"`
-	ApiVersions         []string          `yaml:"apiVersions,omitempty"`
-	KubeVersion         string            `yaml:"kubeVersion,omitempty"`
+
+	// Capabilities.APIVersions
+	ApiVersions []string `yaml:"apiVersions,omitempty"`
+
+	// Capabilities.KubeVersion
+	KubeVersion string `yaml:"kubeVersion,omitempty"`
 
 	// Hooks is a list of extension points paired with operations, that are executed in specific points of the lifecycle of releases defined in helmfile
 	Hooks []event.Hook `yaml:"hooks,omitempty"`
@@ -248,6 +252,12 @@ type ReleaseSpec struct {
 
 	ValuesTemplate    []interface{} `yaml:"valuesTemplate,omitempty"`
 	SetValuesTemplate []SetValue    `yaml:"setTemplate,omitempty"`
+
+	// Capabilities.APIVersions
+	ApiVersions []string `yaml:"apiVersions,omitempty"`
+
+	// Capabilities.KubeVersion
+	KubeVersion string `yaml:"kubeVersion,omitempty"`
 
 	// The 'env' section is not really necessary any longer, as 'set' would now provide the same functionality
 	EnvValues []SetValue `yaml:"env,omitempty"`
@@ -1120,6 +1130,9 @@ func (st *HelmState) PrepareCharts(helm helmexec.Interface, dir string, concurre
 					chartifyOpts.IncludeCRDs = includeCRDs
 
 					chartifyOpts.Validate = opts.Validate
+
+					chartifyOpts.KubeVersion = release.KubeVersion
+					chartifyOpts.ApiVersions = release.ApiVersions
 
 					out, err := c.Chartify(release.Name, chartPath, chartify.WithChartifyOpts(chartifyOpts))
 					if err != nil {
@@ -2471,10 +2484,7 @@ func (st *HelmState) flagsForTemplate(helm helmexec.Interface, release *ReleaseS
 		return nil, nil, err
 	}
 
-	flags = st.appendApiVersionsFlags(flags)
-	if st.KubeVersion != "" {
-		flags = append(flags, "--kube-version", st.KubeVersion)
-	}
+	flags = st.appendApiVersionsFlags(flags, release)
 
 	common, files, err := st.namespaceAndValuesFlags(helm, release, workerIndex)
 	if err != nil {
@@ -2536,10 +2546,15 @@ func (st *HelmState) chartVersionFlags(release *ReleaseSpec) []string {
 	return flags
 }
 
-func (st *HelmState) appendApiVersionsFlags(flags []string) []string {
-	for _, a := range st.ApiVersions {
+func (st *HelmState) appendApiVersionsFlags(flags []string, r *ReleaseSpec) []string {
+	for _, a := range r.ApiVersions {
 		flags = append(flags, "--api-versions", a)
 	}
+
+	if r.KubeVersion != "" {
+		flags = append(flags, "--kube-version", st.KubeVersion)
+	}
+
 	return flags
 }
 

--- a/pkg/state/state_exec_tmpl.go
+++ b/pkg/state/state_exec_tmpl.go
@@ -100,6 +100,13 @@ func (st *HelmState) ExecuteTemplates() (*HelmState, error) {
 		for k, v := range st.CommonLabels {
 			release.Labels[k] = v
 		}
+		if len(release.ApiVersions) == 0 {
+			release.ApiVersions = st.ApiVersions
+		}
+		if release.KubeVersion == "" {
+			release.KubeVersion = st.KubeVersion
+		}
+
 		successFlag := false
 		for it, prev := 0, &release; it < 6; it++ {
 			tmplData := st.createReleaseTemplateData(prev, vals)

--- a/pkg/state/temp_test.go
+++ b/pkg/state/temp_test.go
@@ -38,39 +38,39 @@ func TestGenerateID(t *testing.T) {
 	run(testcase{
 		subject: "baseline",
 		release: ReleaseSpec{Name: "foo", Chart: "incubator/raw"},
-		want:    "foo-values-779795898b",
+		want:    "foo-values-6d97d4c7ff",
 	})
 
 	run(testcase{
 		subject: "different bytes content",
 		release: ReleaseSpec{Name: "foo", Chart: "incubator/raw"},
 		data:    []byte(`{"k":"v"}`),
-		want:    "foo-values-6b7ffbccc",
+		want:    "foo-values-74fcbfbd68",
 	})
 
 	run(testcase{
 		subject: "different map content",
 		release: ReleaseSpec{Name: "foo", Chart: "incubator/raw"},
 		data:    map[string]interface{}{"k": "v"},
-		want:    "foo-values-6d57bbfccf",
+		want:    "foo-values-7b954b6b6b",
 	})
 
 	run(testcase{
 		subject: "different chart",
 		release: ReleaseSpec{Name: "foo", Chart: "stable/envoy"},
-		want:    "foo-values-5c45b58947",
+		want:    "foo-values-5c54676568",
 	})
 
 	run(testcase{
 		subject: "different name",
 		release: ReleaseSpec{Name: "bar", Chart: "incubator/raw"},
-		want:    "bar-values-99d5fdbcc",
+		want:    "bar-values-5fff459546",
 	})
 
 	run(testcase{
 		subject: "specific ns",
 		release: ReleaseSpec{Name: "foo", Chart: "incubator/raw", Namespace: "myns"},
-		want:    "myns-foo-values-544cb97d7f",
+		want:    "myns-foo-values-cfd9959dd",
 	})
 
 	for id, n := range ids {


### PR DESCRIPTION
This adds support for `kube-version` and `api-versions` to be available to `chartify` so that it works even if your release requires `chartify` due to that you use features like `forceNamespace`, `jsonPatches`, `strategicMergePatches`, and so on.

This also enhances `ReleaseSpec` which corresponds to each item of `releases[]` in your `helmfile.yaml` to also accept `kubeVersion` and `apiVersions`, in addition to the top-level `kubeVersion` and `apiVersions` we have today.

The top-level ones works as the default values for release-specific ones. If you have been using the top-level ones, keep using it. It is backward-compatible. If you want to specify it per release, because, for example, your releases are deployed across clusters(in case you differentiate `kubeContext` fields), try the new fields added to the release spec.

Resolves #1864