### PR TITLE
chore(state): Append KubeVersion flag to helm-diff

### DIFF
--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -2515,6 +2515,10 @@ func (st *HelmState) flagsForDiff(helm helmexec.Interface, release *ReleaseSpec,
 		flags = append(flags, "--disable-validation")
 	}
 
+	if st.KubeVersion != "" {
+		flags = append(flags, "--kube-version", st.KubeVersion)
+	}
+
 	flags = st.appendConnectionFlags(flags, helm, release)
 
 	var err error


### PR DESCRIPTION
Support for this flag on Helm Diff was added in this PR: https://github.com/databus23/helm-diff/pull/386.

Helm diff will append this flag to `helm template`.

