### PR TITLE
feat: retrieve repository's username/password from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ repositories:
   url: http://roboll.io/charts
   certFile: optional_client_cert
   keyFile: optional_client_key
+  # username is retrieve from the environment with the format <registryNameUpperCase>_USERNAME for CI usage, here ROBOLL_USERNAME
   username: optional_username
+  # username is retrieve from the environment with the format <registryNameUpperCase>_PASSWORD for CI usage, here ROBOLL_PASSWORD
   password: optional_password
   oci: true
   passCredentials: true

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -416,14 +416,12 @@ func (st *HelmState) SyncRepos(helm RepoUpdater, shouldSkip map[string]bool) ([]
 		if shouldSkip[repo.Name] {
 			continue
 		}
+		username, password := gatherUsernamePassword(repo.Name, repo.Username, repo.Password)
 		var err error
-		if repo.OCI {
-			username, password := gatherOCIUsernamePassword(repo.Name, repo.Username, repo.Password)
-			if username != "" && password != "" {
-				err = helm.RegistryLogin(repo.URL, username, password)
-			}
+		if repo.OCI &&  username != "" && password != "" {
+			err = helm.RegistryLogin(repo.URL, username, password)
 		} else {
-			err = helm.AddRepo(repo.Name, repo.URL, repo.CaFile, repo.CertFile, repo.KeyFile, repo.Username, repo.Password, repo.Managed, repo.PassCredentials, repo.SkipTLSVerify)
+			err = helm.AddRepo(repo.Name, repo.URL, repo.CaFile, repo.CertFile, repo.KeyFile, username, password, repo.Managed, repo.PassCredentials, repo.SkipTLSVerify)
 		}
 
 		if err != nil {
@@ -436,7 +434,7 @@ func (st *HelmState) SyncRepos(helm RepoUpdater, shouldSkip map[string]bool) ([]
 	return updated, nil
 }
 
-func gatherOCIUsernamePassword(repoName string, username string, password string) (string, string) {
+func gatherUsernamePassword(repoName string, username string, password string) (string, string) {
 	var user, pass string
 
 	if username != "" {


### PR DESCRIPTION
Make possible to retrieve username/password from the environment for Helm repositories, like it is done for OCI registries.

Related to https://github.com/roboll/helmfile/pull/1629